### PR TITLE
Expose parser in lib.zig

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2,3 +2,4 @@ pub const Compilation = @import("Compilation.zig");
 pub const Source = @import("Source.zig");
 pub const Preprocessor = @import("Preprocessor.zig");
 pub const Tokenizer = @import("Tokenizer.zig");
+pub const Parser = @import("Parser.zig");


### PR DESCRIPTION
This is quite a simple PR - but just makes the parser part of the public-facing API.