### PR TITLE
condexpr type resolution + null ptr cast + some tests

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -200,6 +200,7 @@ pub const Tag = enum {
     align_ignored,
     zero_align_ignored,
     non_pow2_align,
+    pointer_mismatch,
 };
 
 const Options = struct {
@@ -224,6 +225,7 @@ const Options = struct {
     @"cast-qualifiers": Kind = .warning,
     @"array-bounds": Kind = .warning,
     @"int-conversion": Kind = .warning,
+    @"pointer-type-mismatch": Kind = .warning,
 };
 
 list: std.ArrayList(Message),
@@ -508,6 +510,7 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
             .align_ignored => m.write("'_Alignas' attribute is ignored here"),
             .zero_align_ignored => m.write("specified alignment of zero is ignored"),
             .non_pow2_align => m.write("requested alignment is not a power of 2"),
+            .pointer_mismatch => m.print("pointer type mismatch ({s})", .{msg.extra.str}),
         }
         m.end(lcs);
 
@@ -717,6 +720,7 @@ fn tagKind(diag: *Diagnostics, tag: Tag) Kind {
         .array_after => diag.options.@"array-bounds",
         .array_before => diag.options.@"array-bounds",
         .implicit_int_to_ptr => diag.options.@"int-conversion",
+        .pointer_mismatch => diag.options.@"pointer-type-mismatch",
     };
     if (kind == .@"error" and diag.fatal_errors) kind = .@"fatal error";
     return kind;

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -386,8 +386,15 @@ pub const Tag = enum(u8) {
     int_cast,
     /// Convert one floating type to another
     float_cast,
+    /// Convert pointer to one with same child type but more CV-quals,
+    /// OR to appropriately-qualified void *
+    /// only appears on the branches of a conditional expr
+    qual_cast,
     /// Convert type to void; only appears on the branches of a conditional expr
     to_void,
+
+    /// Convert a literal 0 to a null pointer
+    null_to_pointer,
 
     /// Inserted at the end of a function body if no return stmt is found.
     /// ty is the functions return type
@@ -412,6 +419,8 @@ pub const Tag = enum(u8) {
             .float_cast,
             .to_void,
             .implicit_return,
+            .qual_cast,
+            .null_to_pointer,
             => true,
             else => false,
         };
@@ -916,6 +925,8 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         .int_cast,
         .float_cast,
         .to_void,
+        .qual_cast,
+        .null_to_pointer,
         => {
             try tree.dumpNode(data.un, level + delta, w);
         },

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -28,6 +28,15 @@ pub const Qualifiers = packed struct {
         if (quals.register) try w.writeAll("register ");
     }
 
+    /// Merge the const/volatile/_Atomic qualifiers
+    pub fn mergeCVA(a: Qualifiers, b: Qualifiers) Qualifiers {
+        return .{
+            .@"const" = a.@"const" or b.@"const",
+            .@"volatile" = a.@"volatile" or b.@"volatile",
+            .atomic = a.atomic or b.atomic,
+        };
+    }
+
     pub const Builder = struct {
         @"const": ?TokenIndex = null,
         atomic: ?TokenIndex = null,
@@ -244,6 +253,13 @@ pub fn isReal(ty: Type) bool {
     return switch (ty.specifier) {
         .complex_float, .complex_double, .complex_long_double => false,
         else => true,
+    };
+}
+
+pub fn isVoidStar(ty: Type) bool {
+    return switch (ty.specifier) {
+        .pointer => ty.data.sub_type.specifier == .void,
+        else => false,
     };
 }
 

--- a/test/README.MD
+++ b/test/README.MD
@@ -24,7 +24,7 @@ CALL(CAT)
 ## Testing for errors
 Expected compile errors can be tested by defining a `EXPECTED_ERRORS` macro.
 
-**exmpale:**
+**example:**
 ```c
 #define EXPECTED_ERRORS \
     "invalid types.c:8:6: error: cannot combine with previous 'long' specifier" \
@@ -32,6 +32,22 @@ Expected compile errors can be tested by defining a `EXPECTED_ERRORS` macro.
 
 long float a;
 enum Foo {};
+```
+---
+## Testing type resolution
+Type resolution can be tested by defining a `EXPECTED_TYPES` macro, and a function.
+The nth token in the `EXPECTED_TYPES` macro is the expected type of the nth statement
+in the function
+
+**example:**
+```c
+void my_test(void) {
+    int x = 5;
+    1L;
+    (void)1L;
+}
+#define EXPECTED_TYPES \
+    "int" "long" "void"
 ```
 ---
 ## Marking a test as skipped

--- a/test/cases/assignment.c
+++ b/test/cases/assignment.c
@@ -25,6 +25,9 @@ void foo(void) {
     f *= g;
     int arr[4];
     arr = 4;
+    int *x;
+    x = 0;
+    x = (0);
 }
 
 #define EXPECTED_ERRORS "assignment.c:2:7: error: expression is not assignable" \

--- a/test/cases/binary expressions.c
+++ b/test/cases/binary expressions.c
@@ -20,8 +20,12 @@ void foo(void) {
     1 ? (void)2 : 3;
     1 ? (int*)2 : 3;
     1 ? 2 : (int*)3;
-    // (void)(1 ? (int*)2 : (int*)3);
-    // (void)(1 ? (int*)2 : (float*)3);
+    (void)(1 ? (int*)2 : (int*)3);
+    (void)(1 ? (int*)2 : (float*)3);
+    (void)(1 ? (int*)2 : (const void*)3);
+    (void)(1 ? (volatile int*)2 : (const void*)3);
+    (void)(1 ? (const int *)1 : 0);
+    (void)(1 ? 0 : (const int *)1);
     // struct Foo { int a; } b, c;
     // (void)(1 ? b : c);
     // (void)(1 ? b : 1);
@@ -32,7 +36,7 @@ int bar(void) {
     return 1U < 2U;
 }
 
-#define TESTS_SKIPPED 5
+#define TESTS_SKIPPED 3
 
 #define EXPECTED_ERRORS "binary expressions.c:3:7: error: invalid operands to binary expression ('long' and 'float')" \
     "binary expressions.c:6:13: error: invalid operands to binary expression ('char' and 'int *')" \
@@ -46,4 +50,5 @@ int bar(void) {
     "binary expressions.c:19:13: error: incompatible pointer types ('int *' and 'float *')" \
     "binary expressions.c:21:17: warning: implicit integer to pointer conversion from 'int' to 'int *'" \
     "binary expressions.c:22:11: warning: implicit integer to pointer conversion from 'int' to 'int *'" \
-    "binary expressions.c:28:5: error: expected statement"
+    "binary expressions.c:24:24: warning: pointer type mismatch ('int *' and 'float *')" \
+    "binary expressions.c:32:5: error: expected statement"

--- a/test/cases/type_resolution.c
+++ b/test/cases/type_resolution.c
@@ -1,0 +1,51 @@
+void test_type_resolution(void) {
+    1 - 1;
+    1L;
+    1UL;
+    1LL;
+    1ULL;
+    int x = 1;
+    // The next 12 examples are from the C17 standard § 6.5.16 (once with each order for branch types)
+    (x ? (const void *)1 : (const int *)2);
+    (x ? (const int *)1 : (const void *)2);
+    (x ? (volatile int *)1 : 0);
+    (x ? 0 : (volatile int *)1);
+    (x ? (const int *)1 : (volatile int *)2);
+    (x ? (volatile int *)1 : (const int *)2);
+    (x ? (void *)1 : (const char *)2);
+    (x ? (const char *)1 : (void *)2);
+    (x ? (int *)1 : (const int *)2);
+    (x ? (const int *)1 : (int *)2);
+    (x ? (void *)1 : (int *)2);
+    (x ? (int *)1 : (void *)2);
+
+    (x ? (int *)1 : (float *)2);
+}
+
+#define EXPECTED_TYPES "int" "long" "unsigned long" "long long" "unsigned long long" "int" \
+    "*const void" "*const void" \
+    "*volatile int" "*volatile int" \
+    "*const volatile int" "*const volatile int" \
+    "*const void" "*const void" \
+    "*const int" "*const int" \
+    "*void" "*void" \
+    "*void"
+
+#define EXPECTED_ERRORS "type_resolution.c:2:5: warning: expression result unused" \
+    "type_resolution.c:3:5: warning: expression result unused" \
+    "type_resolution.c:4:5: warning: expression result unused" \
+    "type_resolution.c:5:5: warning: expression result unused" \
+    "type_resolution.c:6:5: warning: expression result unused" \
+    "type_resolution.c:9:5: warning: expression result unused" \
+    "type_resolution.c:10:5: warning: expression result unused" \
+    "type_resolution.c:11:5: warning: expression result unused" \
+    "type_resolution.c:12:5: warning: expression result unused" \
+    "type_resolution.c:13:5: warning: expression result unused" \
+    "type_resolution.c:14:5: warning: expression result unused" \
+    "type_resolution.c:15:5: warning: expression result unused" \
+    "type_resolution.c:17:5: warning: expression result unused" \
+    "type_resolution.c:16:5: warning: expression result unused" \
+    "type_resolution.c:17:5: warning: expression result unused" \
+    "type_resolution.c:18:5: warning: expression result unused" \
+    "type_resolution.c:19:5: warning: expression result unused" \
+    "type_resolution.c:22:19: warning: pointer type mismatch ('int *' and 'float *')"


### PR DESCRIPTION
Adds a new implicit cast type `qual_cast` for implicit casts due to mismatching pointers on conditional expressions

Adds a new implicit cast type `null_to_pointer` to convert `0` to a pointer of appropriate type

Adds a way to test expression types.