### PR TITLE
Parser: add typeof support

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -217,6 +217,7 @@ pub const Tag = enum {
     excess_str_init,
     str_init_too_long,
     arr_init_too_long,
+    invalid_typeof,
 };
 
 const Options = struct {
@@ -546,6 +547,7 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
             .excess_str_init => m.write("excess elements in string initializer"),
             .str_init_too_long => m.write("initializer-string for char array is too long"),
             .arr_init_too_long => m.print("cannot initialize type ({s})", .{msg.extra.str}),
+            .invalid_typeof => m.print("'{s} typeof' is invalid", .{msg.extra.str}),
         }
         m.end(lcs);
 
@@ -723,6 +725,7 @@ fn tagKind(diag: *Diagnostics, tag: Tag) Kind {
         .incompatible_init,
         .empty_scalar_init,
         .arr_init_too_long,
+        .invalid_typeof,
         => .@"error",
         .to_match_paren,
         .to_match_brace,

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -138,6 +138,8 @@ pub const Token = struct {
         keyword_struct,
         keyword_switch,
         keyword_typedef,
+        keyword_typeof1,
+        keyword_typeof2,
         keyword_union,
         keyword_unsigned,
         keyword_void,
@@ -183,6 +185,7 @@ pub const Token = struct {
         keyword_restrict2,
         keyword_alignof1,
         keyword_alignof2,
+        keyword_typeof,
 
         /// Return true if token is identifier or keyword.
         pub fn isMacroIdentifier(id: Id) bool {
@@ -244,6 +247,9 @@ pub const Token = struct {
                 .keyword_static_assert,
                 .keyword_thread_local,
                 .identifier,
+                .keyword_typeof,
+                .keyword_typeof1,
+                .keyword_typeof2,
                 => return true,
                 else => return false,
             }
@@ -382,6 +388,7 @@ pub const Token = struct {
                 .keyword_struct => "struct",
                 .keyword_switch => "switch",
                 .keyword_typedef => "typedef",
+                .keyword_typeof => "typeof",
                 .keyword_union => "union",
                 .keyword_unsigned => "unsigned",
                 .keyword_void => "void",
@@ -419,6 +426,8 @@ pub const Token = struct {
                 .keyword_restrict2 => "__restrict__",
                 .keyword_alignof1 => "__alignof",
                 .keyword_alignof2 => "__alignof__",
+                .keyword_typeof1 => "__typeof",
+                .keyword_typeof2 => "__typeof__",
             };
         }
 
@@ -486,6 +495,8 @@ pub const Token = struct {
         .{ "void", .keyword_void },
         .{ "volatile", .keyword_volatile },
         .{ "while", .keyword_while },
+        .{ "__typeof__", .keyword_typeof2 },
+        .{ "__typeof", .keyword_typeof1 },
 
         // ISO C99
         .{ "_Bool", .keyword_bool },
@@ -526,6 +537,7 @@ pub const Token = struct {
         .{ "__restrict__", .keyword_restrict2 },
         .{ "__alignof", .keyword_alignof1 },
         .{ "__alignof__", .keyword_alignof2 },
+        .{ "typeof", .keyword_typeof },
     });
 };
 
@@ -902,6 +914,8 @@ pub fn next(self: *Tokenizer) Token {
                 'a'...'z', 'A'...'Z', '_', '0'...'9', '$' => {},
                 else => {
                     id = Token.keywords.get(self.buf[start..self.index]) orelse .identifier;
+                    // TODO: if id == .keyword_typeof and GNU extensions are not enabled,
+                    // turn id back into .identifier
                     break;
                 },
             },

--- a/test/cases/incorrect typeof usage.c
+++ b/test/cases/incorrect typeof usage.c
@@ -1,0 +1,12 @@
+void foo(void) {
+    unsigned typeof(int) x;
+    typeof(int) typeof(int) y;
+    typeof() z;
+    typeof(int) unsigned w;
+}
+
+#define EXPECTED_ERRORS "incorrect typeof usage.c:2:5: error: 'unsigned typeof' is invalid" \
+    "incorrect typeof usage.c:3:5: error: cannot combine with previous 'typeof' specifier" \
+    "incorrect typeof usage.c:4:12: error: expected expression" \
+    "incorrect typeof usage.c:5:17: error: 'unsigned typeof' is invalid" \
+

--- a/test/cases/typeof.c
+++ b/test/cases/typeof.c
@@ -1,0 +1,38 @@
+int foo(void) {
+    return 42.0;
+}
+
+typeof(int) g_i = 42;
+typeof(foo()) f_i = 42.0;
+
+struct S {
+    typeof(int) x;
+    typeof(foo()) y;
+};
+
+int bar(typeof(int *restrict) a, int y) {
+    return 42;
+}
+
+void baz(void) {
+    const typeof(int) a;
+    const typeof(foo()) b;
+    typeof(foo()) i = 4;
+    typeof(float) f = 4.5;
+    typeof(i)* p_i = &i;
+    p_i = &f;
+    p_i = (typeof(i)*)&f;
+    p_i = (typeof(p_i))&f;
+    typeof(const int)x;
+    x = 5;
+    const typeof(*p_i)y;
+    y = 5;
+    // typeof(0/0) divzero = 0;
+}
+
+#define EXPECTED_ERRORS "typeof.c:23:9: warning: incompatible pointer types assigning to 'int *' from incompatible type 'float *'" \
+    "typeof.c:27:7: error: expression is not assignable" \
+    "typeof.c:29:7: error: expression is not assignable"
+
+
+#define TESTS_SKIPPED 1


### PR DESCRIPTION
Two questions:

1) bare `typeof` is a GNU extension, so if GNU extensions are turned off it should be an identifier. But it doesn't seem like the Tokenizer has any concept of language options - is that something we should add?

2) I'm not storing the typeof nodes in the AST. I think that would be fine for `translate-c` but other things may want them. However I think it might be a more invasive change since it means we'd need a way to link types to nodes.