### PR TITLE
Do not evaluate typeof/sizeof/alignof arguments

### DIFF
--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -44,20 +44,16 @@ const Standard = enum {
     pub fn atLeast(self: Standard, other: Standard) bool {
         return @enumToInt(self) >= @enumToInt(other);
     }
+
+    pub fn isGNU(standard: Standard) bool {
+        return switch (standard) {
+            .gnu89, .gnu99, .gnu11, .gnu17, .gnu2x => true,
+            else => false,
+        };
+    }
 };
 
 standard: Standard = .gnu17,
-
-pub fn hasGNUKeywords(langopts: LangOpts) bool {
-    return switch (langopts.standard) {
-        .gnu89, .gnu99, .gnu11, .gnu17, .gnu2x => true,
-        else => false,
-    };
-}
-
-pub fn hasC99Keywords(langopts: LangOpts) bool {
-    return langopts.standard.atLeast(.c99);
-}
 
 pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!void {
     self.standard = Standard.NameMap.get(name) orelse return error.InvalidStandard;
@@ -66,6 +62,7 @@ pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!voi
 pub fn suppress(langopts: LangOpts, tag: DiagnosticTag) bool {
     return switch (tag) {
         .static_assert_missing_message => langopts.standard.atLeast(.c2x),
+        .alignof_expr => langopts.standard.isGNU(),
         else => false,
     };
 }

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -470,10 +470,11 @@ pub const Token = struct {
     /// TODO: add `.keyword_asm` here as GNU extension once that is supported.
     pub fn getTokenId(comp: *const Compilation, str: []const u8) Token.Id {
         const kw = all_kws.get(str) orelse return .identifier;
+        const standard = comp.langopts.standard;
         return switch (kw) {
-            .keyword_inline => if (comp.langopts.hasGNUKeywords() or comp.langopts.hasC99Keywords()) kw else .identifier,
-            .keyword_restrict => if (comp.langopts.hasC99Keywords()) kw else .identifier,
-            .keyword_typeof => if (comp.langopts.hasGNUKeywords()) kw else .identifier,
+            .keyword_inline => if (standard.isGNU() or standard.atLeast(.c99)) kw else .identifier,
+            .keyword_restrict => if (standard.atLeast(.c99)) kw else .identifier,
+            .keyword_typeof => if (standard.isGNU()) kw else .identifier,
             else => kw,
         };
     }

--- a/test/cases/gnu alignof.c
+++ b/test/cases/gnu alignof.c
@@ -1,0 +1,5 @@
+//std=gnu17
+void foo(void) {
+	(void) _Alignof 2;
+	(void) _Alignof(2);
+}

--- a/test/cases/sizeof alignof.c
+++ b/test/cases/sizeof alignof.c
@@ -20,4 +20,6 @@ int quuux(void) {
 }
 
 #define EXPECTED_ERRORS "sizeof alignof.c:10:19: error: expected parentheses around type name" \
-    "sizeof alignof.c:10:37: error: expected parentheses around type name"
+    "sizeof alignof.c:10:37: error: expected parentheses around type name" \
+    "sizeof alignof.c:14:32: warning: '_Alignof' applied to an expression is a GNU extension" \
+    "sizeof alignof.c:19:20: warning: '_Alignof' applied to an expression is a GNU extension"

--- a/test/cases/sizeof alignof.c
+++ b/test/cases/sizeof alignof.c
@@ -20,6 +20,4 @@ int quuux(void) {
 }
 
 #define EXPECTED_ERRORS "sizeof alignof.c:10:19: error: expected parentheses around type name" \
-    "sizeof alignof.c:10:37: error: expected parentheses around type name" \
-    "sizeof alignof.c:14:32: warning: '_Alignof' applied to an expression is a GNU extension" \
-    "sizeof alignof.c:19:20: warning: '_Alignof' applied to an expression is a GNU extension"
+    "sizeof alignof.c:10:37: error: expected parentheses around type name"

--- a/test/cases/sizeof alignof.c
+++ b/test/cases/sizeof alignof.c
@@ -14,6 +14,12 @@ int quux(void) {
     return sizeof 2 + _Alignof 2;
 }
 
+int quuux(void) {
+    (void)sizeof(0/0);
+    return _Alignof(0/0);
+}
+
 #define EXPECTED_ERRORS "sizeof alignof.c:10:19: error: expected parentheses around type name" \
     "sizeof alignof.c:10:37: error: expected parentheses around type name" \
-    "sizeof alignof.c:14:32: warning: '_Alignof' applied to an expression is a GNU extension"
+    "sizeof alignof.c:14:32: warning: '_Alignof' applied to an expression is a GNU extension" \
+    "sizeof alignof.c:19:20: warning: '_Alignof' applied to an expression is a GNU extension"

--- a/test/cases/typeof.c
+++ b/test/cases/typeof.c
@@ -27,12 +27,9 @@ void baz(void) {
     x = 5;
     const typeof(*p_i)y;
     y = 5;
-    // typeof(0/0) divzero = 0;
+    typeof(0/0) divzero = 0;
 }
 
 #define EXPECTED_ERRORS "typeof.c:23:9: warning: incompatible pointer types assigning to 'int *' from incompatible type 'float *'" \
     "typeof.c:27:7: error: expression is not assignable" \
     "typeof.c:29:7: error: expression is not assignable"
-
-
-#define TESTS_SKIPPED 1

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -78,7 +78,7 @@ pub fn main() !void {
     var skip_count: u32 = 0;
     for (cases.items) |range| {
         const path = path_buf.items[range.start..range.end];
-        try comp.langopts.setStandard("gnu17");
+        comp.langopts.standard = .default;
         const file = comp.addSource(path) catch |err| {
             fail_count += 1;
             progress.log("could not add source '{s}': {s}\n", .{ path, @errorName(err) });


### PR DESCRIPTION
Note: `sizeof` and `_Alignof` previously used `unExpr` to parse their expression but it seems like it should be `assignExpr` for them (like `genericSelection` uses). If they actually should be `unExpr` I can change them back.

