### PR TITLE
Parser: implement __builtin_choose_expr

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -219,6 +219,7 @@ pub const Tag = enum {
     arr_init_too_long,
     invalid_typeof,
     division_by_zero,
+    builtin_choose_cond,
 };
 
 const Options = struct {
@@ -551,6 +552,7 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
             .arr_init_too_long => m.print("cannot initialize type ({s})", .{msg.extra.str}),
             .invalid_typeof => m.print("'{s} typeof' is invalid", .{msg.extra.str}),
             .division_by_zero => m.print("{s} by zero is undefined", .{msg.extra.str}),
+            .builtin_choose_cond => m.write("'__builtin_choose_expr' requires a constant expression"),
         }
         m.end(lcs);
 
@@ -729,6 +731,7 @@ fn tagKind(diag: *Diagnostics, tag: Tag) Kind {
         .empty_scalar_init,
         .arr_init_too_long,
         .invalid_typeof,
+        .builtin_choose_cond,
         => .@"error",
         .to_match_paren,
         .to_match_brace,

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -189,6 +189,9 @@ pub const Token = struct {
         keyword_alignof2,
         keyword_typeof,
 
+        // gcc builtins
+        builtin_choose_expr,
+
         /// Return true if token is identifier or keyword.
         pub fn isMacroIdentifier(id: Id) bool {
             switch (id) {
@@ -260,6 +263,7 @@ pub const Token = struct {
                 .keyword_restrict2,
                 .keyword_alignof1,
                 .keyword_alignof2,
+                .builtin_choose_expr,
                 => return true,
                 else => return false,
             }
@@ -438,6 +442,7 @@ pub const Token = struct {
                 .keyword_alignof2 => "__alignof__",
                 .keyword_typeof1 => "__typeof",
                 .keyword_typeof2 => "__typeof__",
+                .builtin_choose_expr => "__builtin_choose_expr",
             };
         }
 
@@ -563,6 +568,9 @@ pub const Token = struct {
         .{ "__alignof", .keyword_alignof1 },
         .{ "__alignof__", .keyword_alignof2 },
         .{ "typeof", .keyword_typeof },
+
+        // gcc builtins
+        .{ "__builtin_choose_expr", .builtin_choose_expr },
     });
 };
 

--- a/test/cases/builtin choose expr.c
+++ b/test/cases/builtin choose expr.c
@@ -1,0 +1,10 @@
+void foo(void) {
+    int x, y;
+    __builtin_choose_expr(1, x, 0/0) = 10;
+    __builtin_choose_expr(0, x/0, y) = 32;
+    __builtin_choose_expr(x, 1, 2);
+    int z = __builtin_choose_expr(1>0, 1, (char *)5);
+    float f = __builtin_choose_expr(0!=0, (char *)10, 1.0f);
+}
+
+#define EXPECTED_ERRORS "builtin choose expr.c:5:27: error: '__builtin_choose_expr' requires a constant expression"


### PR DESCRIPTION
Similar to conditional operator, except:
1. First argument must be an integer constant
2. return type matches that of chosen expression and does not undergo promotion
3. unchosen expression is not evaluated
4. can return an lvalue if the chosen expression is an lvalue