### PR TITLE
Update predefined macros

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const mem = std.mem;
 const Allocator = mem.Allocator;
+const EpochSeconds = std.time.epoch.EpochSeconds;
 const Diagnostics = @import("Diagnostics.zig");
 const LangOpts = @import("LangOpts.zig");
 const Preprocessor = @import("Preprocessor.zig");
@@ -52,6 +53,31 @@ pub fn deinit(comp: *Compilation) void {
     if (comp.builtin_header_path) |some| comp.gpa.free(some);
 }
 
+fn generateDateAndTime(w: anytype) !void {
+    const timestamp = std.math.clamp(std.time.timestamp(), 0, std.math.maxInt(i64));
+    const epoch_seconds = EpochSeconds{ .secs = @intCast(u64, timestamp) };
+    const epoch_day = epoch_seconds.getEpochDay();
+    const day_seconds = epoch_seconds.getDaySeconds();
+    const year_day = epoch_day.calculateYearDay();
+
+    const month_day = year_day.calculateMonthDay();
+
+    const MonthNames = [_][]const u8{ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+    std.debug.assert(std.time.epoch.Month.jan.numeric() == 1);
+
+    const monthName = MonthNames[month_day.month.numeric() - 1];
+    try w.print("#define __DATE__ \"{s} {d: >2} {d}\"\n", .{
+        monthName,
+        month_day.day_index + 1,
+        year_day.year,
+    });
+    try w.print("#define __TIME__ \"{d:0>2}:{d:0>2}:{d:0>2}\"\n", .{
+        day_seconds.getHoursIntoDay(),
+        day_seconds.getMinutesIntoHour(),
+        day_seconds.getSecondsIntoMinute(),
+    });
+}
+
 /// Generate builtin macros that will be available to each source file.
 pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     var buf = std.ArrayList(u8).init(comp.gpa);
@@ -68,6 +94,7 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
         \\#define __STDC_NO_VLA__ 1
         \\
     );
+    try generateDateAndTime(buf.writer());
 
     if (comp.langopts.standard.StdCVersionMacro()) |stdc_version| {
         try buf.writer().print("#define __STDC_VERSION__ {s}\n", .{stdc_version});

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -62,13 +62,16 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     ++ @import("lib.zig").version_str ++ "\"\n" ++
         \\#define __STDC__ 1
         \\#define __STDC_HOSTED__ 1
-        \\#define __STDC_VERSION__ 201710L
         \\#define __STDC_NO_ATOMICS__ 1
         \\#define __STDC_NO_COMPLEX__ 1
         \\#define __STDC_NO_THREADS__ 1
         \\#define __STDC_NO_VLA__ 1
         \\
     );
+
+    if (comp.langopts.standard.StdCVersionMacro()) |stdc_version| {
+        try buf.writer().print("#define __STDC_VERSION__ {s}\n", .{stdc_version});
+    }
 
     switch (comp.target.os.tag) {
         .linux => try buf.appendSlice(

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -54,6 +54,19 @@ const Standard = enum {
     pub fn isExplicitGNU(standard: Standard) bool {
         return standard.isGNU() and standard != .default;
     }
+
+    /// Value reported by __STDC_VERSION__ macro
+    pub fn StdCVersionMacro(standard: Standard) ?[]const u8 {
+        return switch (standard) {
+            .c89, .gnu89 => null,
+            .iso9899 => "199409L",
+            .c99, .gnu99 => "199901L",
+            .c11, .gnu11 => "201112L",
+            .default, .c17, .gnu17 => "201710L",
+            // todo: update once finalized; this currently matches clang
+            .c2x, .gnu2x => "201710L",
+        };
+    }
 };
 
 standard: Standard = .default,

--- a/test/cases/predefined macros.c
+++ b/test/cases/predefined macros.c
@@ -1,0 +1,6 @@
+//std=c99
+void foo(void) {
+    _Static_assert(__STDC_VERSION__ == 199901, "__STDC_VERSION__ is incorrect");
+    (void)__DATE__;
+    (void)__TIME__;
+}

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -58,7 +58,6 @@ pub fn main() !void {
 
     try comp.defineSystemIncludes();
 
-    const builtin_macros = try comp.generateBuiltinMacros();
     const test_runner_macros = blk: {
         const duped_path = try gpa.dupe(u8, "<test_runner>");
         errdefer comp.gpa.free(duped_path);
@@ -106,6 +105,13 @@ pub fn main() !void {
             if (it.next()) |standard| {
                 try comp.langopts.setStandard(standard);
             }
+        }
+
+        const builtin_macros = try comp.generateBuiltinMacros();
+        defer {
+            _ = comp.sources.swapRemove(builtin_macros.path);
+            gpa.free(builtin_macros.path);
+            gpa.free(builtin_macros.buf);
         }
 
         const case = std.mem.sliceTo(std.fs.path.basename(path), '.');


### PR DESCRIPTION
Use correct value of `__STDC_VERSION__`
Add placeholder values for `__DATE__` and `__TIME__`
Update test runner to create a new compilation for each test since the predefined macros can change based on the test.