### PR TITLE
Parser: improve typeof support

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1825,7 +1825,7 @@ fn paramDecls(p: *Parser) Error!?[]Type.Func.Param {
             if (p.param_buf.items.len == param_buf_top) {
                 if (p.tok_ids[p.tok_i] != .r_paren) {
                     try p.err(.void_only_param);
-                    if (param_ty.qual.any()) try p.err(.void_param_qualified);
+                    if (param_ty.anyQual()) try p.err(.void_param_qualified);
                     return error.ParsingFailed;
                 }
                 return &[0]Type.Func.Param{};
@@ -3943,7 +3943,7 @@ fn castExpr(p: *Parser) Error!Result {
             } else {
                 try p.errStr(.invalid_cast_type, l_paren, try p.typeStr(operand.ty));
             }
-            if (ty.qual.any()) try p.errStr(.qual_cast, l_paren, try p.typeStr(ty));
+            if (ty.anyQual()) try p.errStr(.qual_cast, l_paren, try p.typeStr(ty));
             operand.ty = ty;
             operand.ty.qual = .{};
             try operand.un(p, .cast_expr);
@@ -4920,7 +4920,7 @@ fn genericSelection(p: *Parser) Error!Result {
     while (true) {
         const start = p.tok_i;
         if (try p.typeName()) |ty| {
-            if (ty.qual.any()) {
+            if (ty.anyQual()) {
                 try p.errTok(.generic_qual_type, start);
             }
             _ = try p.expectToken(.colon);

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -856,7 +856,7 @@ fn typeof(p: *Parser) Error!?Type {
         const typeof_ty = try p.arena.create(Type);
         typeof_ty.* = .{
             .data = ty.data,
-            .qual = ty.qual, // todo: exclude register qualifier
+            .qual = ty.qual.inheritFromTypeof(),
             .specifier = ty.specifier,
         };
 
@@ -874,7 +874,7 @@ fn typeof(p: *Parser) Error!?Type {
         .node = typeof_expr.node,
         .ty = .{
             .data = typeof_expr.ty.data,
-            .qual = typeof_expr.ty.qual, // todo: exclude register qualifier
+            .qual = typeof_expr.ty.qual.inheritFromTypeof(),
             .specifier = typeof_expr.ty.specifier,
         },
     };

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -2101,14 +2101,14 @@ fn coerceArrayInit(p: *Parser, item: *Result, tok: TokenIndex, target: Type) !bo
         return true; // do not do further coercion
     }
 
-    if (target.is(.array)) {
+    if (target.get(.array)) |arr_ty| {
         assert(item.ty.specifier == .array);
         var len = item.ty.data.array.len;
         if (p.nodeIs(item.node, .string_literal_expr)) {
             // the null byte of a string can be dropped
-            if (len - 1 > target.arrayLen())
+            if (len - 1 > arr_ty.arrayLen())
                 try p.errTok(.str_init_too_long, tok);
-        } else if (len > target.arrayLen()) {
+        } else if (len > arr_ty.arrayLen()) {
             try p.errStr(
                 .arr_init_too_long,
                 tok,

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -869,10 +869,10 @@ fn typeof(p: *Parser) Error!?Type {
     try typeof_expr.expect(p);
     try p.expectClosing(l_paren, .r_paren);
 
-    const inner = try p.arena.create(Type.VLA);
+    const inner = try p.arena.create(Type.Expr);
     inner.* = .{
-        .expr = typeof_expr.node,
-        .elem = .{
+        .node = typeof_expr.node,
+        .ty = .{
             .data = typeof_expr.ty.data,
             .qual = typeof_expr.ty.qual, // todo: exclude register qualifier
             .specifier = typeof_expr.ty.specifier,
@@ -880,7 +880,7 @@ fn typeof(p: *Parser) Error!?Type {
     };
 
     return Type{
-        .data = .{ .vla = inner },
+        .data = .{ .expr = inner },
         .specifier = .typeof_expr,
     };
 }
@@ -1633,9 +1633,9 @@ fn directDeclarator(p: *Parser, base_type: Type, d: *Declarator, kind: Declarato
         switch (size.val) {
             .unavailable => if (size.node != .none) {
                 if (p.return_type == null and kind != .param) try p.errTok(.variable_len_array_file_scope, l_bracket);
-                const vla_ty = try p.arena.create(Type.VLA);
-                vla_ty.expr = size.node;
-                res_ty.data = .{ .vla = vla_ty };
+                const expr_ty = try p.arena.create(Type.Expr);
+                expr_ty.node = size.node;
+                res_ty.data = .{ .expr = expr_ty };
                 res_ty.specifier = .variable_len_array;
 
                 if (static) |some| try p.errTok(.useless_static, some);

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -399,26 +399,20 @@ pub fn anyQual(ty: Type) bool {
 }
 
 pub fn eitherLongDouble(a: Type, b: Type) ?Type {
-    const unwrapped_a = a.unwrapTypeof();
-    if (unwrapped_a.specifier == .long_double or unwrapped_a.specifier == .complex_long_double) return a;
-    const unwrapped_b = b.unwrapTypeof();
-    if (unwrapped_b.specifier == .long_double or unwrapped_b.specifier == .complex_long_double) return b;
+    if (a.is(.long_double) or a.is(.complex_long_double)) return a;
+    if (b.is(.long_double) or b.is(.complex_long_double)) return b;
     return null;
 }
 
 pub fn eitherDouble(a: Type, b: Type) ?Type {
-    const unwrapped_a = a.unwrapTypeof();
-    if (unwrapped_a.specifier == .double or unwrapped_a.specifier == .complex_double) return a;
-    const unwrapped_b = b.unwrapTypeof();
-    if (unwrapped_b.specifier == .double or unwrapped_b.specifier == .complex_double) return b;
+    if (a.is(.double) or a.is(.complex_double)) return a;
+    if (b.is(.double) or b.is(.complex_double)) return b;
     return null;
 }
 
 pub fn eitherFloat(a: Type, b: Type) ?Type {
-    const unwrapped_a = a.unwrapTypeof();
-    if (unwrapped_a.specifier == .float or unwrapped_a.specifier == .complex_float) return a;
-    const unwrapped_b = b.unwrapTypeof();
-    if (unwrapped_b.specifier == .float or unwrapped_b.specifier == .complex_float) return b;
+    if (a.is(.float) or a.is(.complex_float)) return a;
+    if (b.is(.float) or b.is(.complex_float)) return b;
     return null;
 }
 

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -227,6 +227,17 @@ alignment: u29 = 0,
 specifier: Specifier,
 qual: Qualifiers = .{},
 
+/// Determine if type matches the given specifier, recursing into typeof
+/// types if necessary.
+pub fn is(ty: Type, specifier: Specifier) bool {
+    std.debug.assert(specifier != .typeof_type and specifier != .typeof_expr);
+    return switch (ty.specifier) {
+        .typeof_type => ty.data.sub_type.is(specifier),
+        .typeof_expr => ty.data.vla.elem.is(specifier),
+        else => ty.specifier == specifier,
+    };
+}
+
 pub fn isCallable(ty: Type) ?Type {
     return switch (ty.specifier) {
         .func, .var_args_func, .old_style_func => ty,

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -48,6 +48,14 @@ pub const Qualifiers = packed struct {
         };
     }
 
+    /// register is a storage class and not actually a qualifier
+    /// so it is not preserved by typeof()
+    pub fn inheritFromTypeof(quals: Qualifiers) Qualifiers {
+        var res = quals;
+        res.register = false;
+        return res;
+    }
+
     pub const Builder = struct {
         @"const": ?TokenIndex = null,
         atomic: ?TokenIndex = null,

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -637,6 +637,15 @@ pub fn unwrapTypeof(ty: Type) Type {
     };
 }
 
+pub fn get(ty: *const Type, specifier: Specifier) ?*const Type {
+    std.debug.assert(specifier != .typeof_type and specifier != .typeof_expr);
+    return switch (ty.specifier) {
+        .typeof_type => ty.data.sub_type.get(specifier),
+        .typeof_expr => ty.data.expr.ty.get(specifier),
+        else => if (ty.specifier == specifier) ty else null,
+    };
+}
+
 pub fn eql(a_param: Type, b_param: Type, check_qualifiers: bool) bool {
     const a = a_param.unwrapTypeof();
     const b = b_param.unwrapTypeof();

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -239,11 +239,7 @@ qual: Qualifiers = .{},
 /// types if necessary.
 pub fn is(ty: Type, specifier: Specifier) bool {
     std.debug.assert(specifier != .typeof_type and specifier != .typeof_expr);
-    return switch (ty.specifier) {
-        .typeof_type => ty.data.sub_type.is(specifier),
-        .typeof_expr => ty.data.expr.ty.is(specifier),
-        else => ty.specifier == specifier,
-    };
+    return ty.get(specifier) != null;
 }
 
 pub fn isCallable(ty: Type) ?Type {

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -374,6 +374,15 @@ pub fn elemType(ty: Type) Type {
     };
 }
 
+pub fn arrayLen(ty: Type) usize {
+    return switch (ty.specifier) {
+        .array => ty.data.array.len,
+        .typeof_type => ty.data.sub_type.arrayLen(),
+        .typeof_expr => ty.data.expr.ty.arrayLen(),
+        else => std.math.maxInt(usize),
+    };
+}
+
 pub fn eitherLongDouble(a: Type, b: Type) ?Type {
     const unwrapped_a = a.unwrapTypeof();
     if (unwrapped_a.specifier == .long_double or unwrapped_a.specifier == .complex_long_double) return a;

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -370,12 +370,12 @@ pub fn elemType(ty: Type) Type {
     };
 }
 
-pub fn arrayLen(ty: Type) usize {
+pub fn arrayLen(ty: Type) ?usize {
     return switch (ty.specifier) {
-        .array => ty.data.array.len,
-        .typeof_type => ty.data.sub_type.arrayLen(),
-        .typeof_expr => ty.data.expr.ty.arrayLen(),
-        else => std.math.maxInt(usize),
+        .array, .static_array, .decayed_array, .decayed_static_array => ty.data.array.len,
+        .typeof_type, .decayed_typeof_type => ty.data.sub_type.arrayLen(),
+        .typeof_expr, .decayed_typeof_expr => ty.data.expr.ty.arrayLen(),
+        else => null,
     };
 }
 

--- a/test/cases/parser using typeof types.c
+++ b/test/cases/parser using typeof types.c
@@ -28,6 +28,21 @@ void array_index_warning(void) {
     (void)static_arr2[5];
 }
 
+void extra_record_inits(void) {
+    struct S {int x; };
+    typeof(struct S) s = { 1, 2 };
+    typeof(s) s2 = { 1, 2 };
+
+    union U { int x; };
+    typeof(union U) u = { 1, 2 };
+    typeof(u) u2 = { 1 , 2 };
+}
+
+
 #define EXPECTED_ERRORS "parser using typeof types.c:26:14: warning: array index 5 is past the end of the array" \
     "parser using typeof types.c:27:15: warning: array index 5 is past the end of the array" \
-    "parser using typeof types.c:28:22: warning: array index 5 is past the end of the array"
+    "parser using typeof types.c:28:22: warning: array index 5 is past the end of the array" \
+    "parser using typeof types.c:33:31: warning: excess elements in struct initializer" \
+    "parser using typeof types.c:34:25: warning: excess elements in struct initializer" \
+    "parser using typeof types.c:37:30: warning: excess elements in struct initializer" \
+    "parser using typeof types.c:38:26: warning: excess elements in struct initializer"

--- a/test/cases/parser using typeof types.c
+++ b/test/cases/parser using typeof types.c
@@ -1,0 +1,33 @@
+// Test for situations where the parser behavior depends on the type, to ensure
+// that typeof() is handled correctly.
+
+void typeof_array_initializer_list(void) {
+    typeof(char[3]) arr = {1,2,3};
+    typeof(arr) arr2 = {1,2,3};
+
+    static char static_arr[3] = {1,2,3};
+    typeof(static_arr) static_arr2 = {1,2,3};
+}
+
+void typeof_array_string_init(void) {
+    typeof(char[6]) arr = "Hello";
+    typeof(arr) arr2 = "Hello";
+
+    static char static_arr[6] = "Hello";
+    typeof(static_arr) static_arr2 = "Hello";
+}
+
+void array_index_warning(void) {
+    typeof(int[5]) arr;
+    typeof(arr) arr2;
+    static int static_arr[5];
+    typeof(static_arr) static_arr2;
+
+    (void)arr[5];
+    (void)arr2[5];
+    (void)static_arr2[5];
+}
+
+#define EXPECTED_ERRORS "parser using typeof types.c:26:14: warning: array index 5 is past the end of the array" \
+    "parser using typeof types.c:27:15: warning: array index 5 is past the end of the array" \
+    "parser using typeof types.c:28:22: warning: array index 5 is past the end of the array"

--- a/test/cases/parser using typeof types.c
+++ b/test/cases/parser using typeof types.c
@@ -45,6 +45,28 @@ void incomplete_array(void) {
 
 void voidparams(typeof(const void), ...);
 
+void string_initializer(void) {
+     typeof(char[2]) arr = "hello";
+     typeof(arr) arr2 = "hello";
+}
+
+void old_style(x, y)
+    typeof(void) x;
+    typeof(x) y;
+{
+}
+
+void do_not_coerce_extra_initializers(void) {
+    typeof(int[2]) arr = {1,2,"hello"};
+    typeof(arr) arr2 = {1,2,"hello"};
+}
+
+void bool_init(void) {
+    struct S {int x;};
+    struct S s = {1};
+    typeof(_Bool) b = s;
+    typeof(b) b2 = s;
+}
 
 #define EXPECTED_ERRORS "parser using typeof types.c:26:14: warning: array index 5 is past the end of the array" \
     "parser using typeof types.c:27:15: warning: array index 5 is past the end of the array" \
@@ -54,4 +76,12 @@ void voidparams(typeof(const void), ...);
     "parser using typeof types.c:37:30: warning: excess elements in struct initializer" \
     "parser using typeof types.c:38:26: warning: excess elements in struct initializer" \
     "parser using typeof types.c:46:35: error: 'void' must be the only parameter if specified" \
-    "parser using typeof types.c:46:35: error: 'void' parameter cannot be qualified"
+    "parser using typeof types.c:46:35: error: 'void' parameter cannot be qualified" \
+    "parser using typeof types.c:49:28: warning: initializer-string for char array is too long" \
+    "parser using typeof types.c:50:25: warning: initializer-string for char array is too long" \
+    "parser using typeof types.c:54:18: error: parameter cannot have void type" \
+    "parser using typeof types.c:55:15: error: parameter cannot have void type" \
+    "parser using typeof types.c:60:31: warning: excess elements in array initializer" \
+    "parser using typeof types.c:61:29: warning: excess elements in array initializer" \
+    "parser using typeof types.c:67:23: error: initializing '_Bool' from incompatible type 'struct S'" \
+    "parser using typeof types.c:68:20: error: initializing '_Bool' from incompatible type 'struct S'"

--- a/test/cases/parser using typeof types.c
+++ b/test/cases/parser using typeof types.c
@@ -38,6 +38,10 @@ void extra_record_inits(void) {
     typeof(u) u2 = { 1 , 2 };
 }
 
+void incomplete_array(void) {
+    typeof(int[]) arr = {1, 2, 3};
+    typeof(arr) arr2 = {1, 2, 3};
+}
 
 #define EXPECTED_ERRORS "parser using typeof types.c:26:14: warning: array index 5 is past the end of the array" \
     "parser using typeof types.c:27:15: warning: array index 5 is past the end of the array" \

--- a/test/cases/parser using typeof types.c
+++ b/test/cases/parser using typeof types.c
@@ -43,10 +43,15 @@ void incomplete_array(void) {
     typeof(arr) arr2 = {1, 2, 3};
 }
 
+void voidparams(typeof(const void), ...);
+
+
 #define EXPECTED_ERRORS "parser using typeof types.c:26:14: warning: array index 5 is past the end of the array" \
     "parser using typeof types.c:27:15: warning: array index 5 is past the end of the array" \
     "parser using typeof types.c:28:22: warning: array index 5 is past the end of the array" \
     "parser using typeof types.c:33:31: warning: excess elements in struct initializer" \
     "parser using typeof types.c:34:25: warning: excess elements in struct initializer" \
     "parser using typeof types.c:37:30: warning: excess elements in struct initializer" \
-    "parser using typeof types.c:38:26: warning: excess elements in struct initializer"
+    "parser using typeof types.c:38:26: warning: excess elements in struct initializer" \
+    "parser using typeof types.c:46:35: error: 'void' must be the only parameter if specified" \
+    "parser using typeof types.c:46:35: error: 'void' parameter cannot be qualified"

--- a/test/cases/typeof quals.c
+++ b/test/cases/typeof quals.c
@@ -1,0 +1,18 @@
+void test_typeof_quals(void) {
+    const int a;
+    typeof(a) b;
+    volatile int c;
+    typeof(c) d;
+    register int e;
+    typeof(e) f;
+    _Atomic int g;
+    typeof(g) h;
+    int *restrict i = 0;
+    typeof(i) j;
+}
+
+#define EXPECTED_TYPES "const int" "typeof(<expr>: const int)" \
+    "volatile int" "typeof(<expr>: volatile int)" \
+    "register int" "typeof(<expr>: int)" \
+    "_Atomic int" "typeof(<expr>: _Atomic int)" \
+    "restrict *int" "typeof(<expr>: restrict *int)"

--- a/test/cases/typeof.c
+++ b/test/cases/typeof.c
@@ -54,8 +54,70 @@ void qux(int x) {
     b = (typeof(b2))10;
 }
 
+void const_arrays(void) {
+    const typeof(int[]) arr1 = {1,2};
+    arr1[0] = 1;
+    const typeof(int[2]) arr2 = {1,2};
+    arr2[0] = 1;
+
+    typeof(const int[]) arr3 = {1,2};
+    arr3[0] = 1;
+    typeof(const int[2]) arr4 = {1,2};
+    arr4[0] = 1;
+
+    const typeof(int) arr5[] = {1,2};
+    arr5[0] = 1;
+    typeof(const int) arr6[] = {1,2};
+    arr6[0] = 1;
+
+    const int arr7[] = {1,2};
+    arr7[0] = 1;
+
+    typeof(const typeof(typeof(int[2]))) arr8 = {1,2};
+    arr8[0] = 1;
+
+    const typeof(int[2]) arr9 = {1,2};
+    const int *p = arr9;
+    const typeof(int[]) arr10 = {1,2};
+    p = arr10;
+    typeof(const int[]) arr11 = {1,2};
+    p = arr11;
+    typeof(const int[2]) arr12 = {1,2};
+    p = arr12;
+    typeof(const int) arr13[2] = {1,2};
+    p = arr13;
+    typeof(const int) arr14[] = {1,2};
+    p = arr14;
+}
+
+void pointers(void) {
+    const int arr[2] = {1,2};
+    typeof(const int) *p1 = arr;
+    const typeof(int) *p2 = arr;
+    typeof(const int *)p3 = arr;
+    typeof(int *)const p4 = arr;
+}
+
+float my_func(int x) {
+    return 2.0f;
+}
+typeof(my_func) my_other_func;
+void test_my_other_func(void) {
+    float f = my_func(42);
+    f = my_other_func(42);
+}
+
 #define EXPECTED_ERRORS "typeof.c:24:9: warning: incompatible pointer types assigning to 'int *' from incompatible type 'float *'" \
     "typeof.c:28:7: error: expression is not assignable" \
     "typeof.c:30:7: error: expression is not assignable" \
     "typeof.c:34:30: error: initializing 'int *' from incompatible type 'float'" \
     "typeof.c:35:8: error: expected expression" \
+    "typeof.c:59:13: error: expression is not assignable" \
+    "typeof.c:61:13: error: expression is not assignable" \
+    "typeof.c:64:13: error: expression is not assignable" \
+    "typeof.c:66:13: error: expression is not assignable" \
+    "typeof.c:69:13: error: expression is not assignable" \
+    "typeof.c:71:13: error: expression is not assignable" \
+    "typeof.c:74:13: error: expression is not assignable" \
+    "typeof.c:77:13: error: expression is not assignable" \
+    "typeof.c:98:29: warning: initializing 'int *' from incompatible type 'const int *' discards qualifiers"

--- a/test/cases/typeof.c
+++ b/test/cases/typeof.c
@@ -34,6 +34,20 @@ void baz(void) {
 typeof((void)1, (int*)2) a = 2.f;
 typeof();
 
+void qux(int x) {
+    char vla[x];
+    char arr[10];
+    typeof(arr) arr2;
+    typeof(char[10]) arr3;
+
+    typeof(vla) vla2;
+    typeof(char[x]) vla3;
+    char *p = arr2;
+    p = arr3;
+    p = vla2;
+    p = vla3;
+}
+
 #define EXPECTED_ERRORS "typeof.c:24:9: warning: incompatible pointer types assigning to 'int *' from incompatible type 'float *'" \
     "typeof.c:28:7: error: expression is not assignable" \
     "typeof.c:30:7: error: expression is not assignable" \

--- a/test/cases/typeof.c
+++ b/test/cases/typeof.c
@@ -46,6 +46,12 @@ void qux(int x) {
     p = arr3;
     p = vla2;
     p = vla3;
+
+    typeof(_Bool) b = 10;
+    b = 5;
+    typeof(b) b2 = 5;
+    b2 = 10;
+    b = (typeof(b2))10;
 }
 
 #define EXPECTED_ERRORS "typeof.c:24:9: warning: incompatible pointer types assigning to 'int *' from incompatible type 'float *'" \


### PR DESCRIPTION
Add two new type specifiers: `typeof_type` and `typeof_expr`, which
are the types returned by `typeof` (depending on whether it's called
with a type or an expression)

This allows us to track the underlying type or expression that was
used.