### PR TITLE
Fix recursive macro func substitution

### DIFF
--- a/test/cases/nested macro call.c
+++ b/test/cases/nested macro call.c
@@ -1,0 +1,7 @@
+#define EXPECTED_TOKENS x x
+
+#define A(x) x
+#define B(x) A(x)
+
+B(B(x))
+A(B(x))

--- a/test/cases/recursive func macro.c
+++ b/test/cases/recursive func macro.c
@@ -1,0 +1,6 @@
+#define EXPECTED_TOKENS F(1)
+
+#define F(x) G(x)
+#define G(x) F(x)
+
+F(1)


### PR DESCRIPTION
The current approach of having a map of the previously expanded macros
comes close, but isn't quite correct as it is too conservative.
The `expansion_log` was changed to a simple `expansion_stack`, which
is searched linearly to check for already expanded macros.

I have not written much zig yet, so suggestions for style or logic are welcome.