### PR TITLE
Parser: add support for address-of-label extension

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -244,6 +244,7 @@ pub const Tag = enum {
     builtin_macro_redefined,
     missing_token,
     feature_check_requires_identifier,
+    gnu_label_as_value,
 };
 
 const Options = struct {
@@ -278,6 +279,7 @@ const Options = struct {
     @"unknown-attributes": Kind = .warning,
     @"ignored-attributes": Kind = .warning,
     @"builtin-macro-redefined": Kind = .warning,
+    @"gnu-label-as-value": Kind = .off,
 };
 
 list: std.ArrayList(Message),
@@ -609,6 +611,7 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
                 msg.extra.tok_id.expected.symbol(),
                 msg.extra.tok_id.actual.symbol(),
             }),
+            .gnu_label_as_value => m.write("use of GNU address-of-label extension"),
         }
         m.end(lcs);
 
@@ -865,6 +868,7 @@ fn tagKind(diag: *Diagnostics, tag: Tag) Kind {
         .unknown_attribute => diag.options.@"unknown-attributes",
         .ignored_attribute => diag.options.@"ignored-attributes",
         .builtin_macro_redefined => diag.options.@"builtin-macro-redefined",
+        .gnu_label_as_value => diag.options.@"gnu-label-as-value",
     };
     if (kind == .@"error" and diag.fatal_errors) kind = .@"fatal error";
     return kind;

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -289,6 +289,8 @@ pub const Tag = enum(u8) {
     cast_expr,
     /// &un
     addr_of_expr,
+    /// &&decl_ref
+    addr_of_label,
     /// *un
     deref_expr,
     /// +un
@@ -792,7 +794,7 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
                 try tree.dumpNode(for_stmt.body, level + delta, w);
             }
         },
-        .goto_stmt => {
+        .goto_stmt, .addr_of_label => {
             try w.writeByteNTimes(' ', level + half);
             try w.print("label: " ++ LITERAL ++ "{s}\n" ++ RESET, .{tree.tokSlice(data.decl_ref)});
         },

--- a/test/cases/address of label.c
+++ b/test/cases/address of label.c
@@ -1,0 +1,12 @@
+void foo(void) {
+    int x = 5;
+    void *y = &&baz;
+    bar:
+    y = &&bar;
+    baz:
+    x = 0;
+    // Todo: computed goto support
+    // goto *y;
+}
+
+#define TESTS_SKIPPED 1


### PR DESCRIPTION
See https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html