### PR TITLE
Preprocessor: don't restore compilation options after preprocessing

### DIFF
--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -133,9 +133,6 @@ pub fn deinit(pp: *Preprocessor) void {
 
 /// Preprocess a source file.
 pub fn preprocess(pp: *Preprocessor, source: Source) Error!void {
-    const initial_options = pp.comp.diag.options;
-    defer pp.comp.diag.options = initial_options;
-
     var tokenizer = Tokenizer{
         .buf = source.buf,
         .comp = pp.comp,

--- a/test/cases/pragma changes warning to error in parser.c
+++ b/test/cases/pragma changes warning to error in parser.c
@@ -1,0 +1,6 @@
+#pragma GCC diagnostic error "-Wint-conversion"
+void foo(void) {
+	int *x = 5;
+}
+
+#define EXPECTED_ERRORS "pragma changes warning to error in parser.c:3:11: error: implicit integer to pointer conversion from 'int' to 'int *'"

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -87,8 +87,10 @@ pub fn main() !void {
     var ok_count: u32 = 0;
     var fail_count: u32 = 0;
     var skip_count: u32 = 0;
+    const initial_options = comp.diag.options;
     for (cases.items) |path| {
         comp.langopts.standard = .default;
+        comp.diag.options = initial_options;
         const file = comp.addSource(path) catch |err| {
             fail_count += 1;
             progress.log("could not add source '{s}': {s}\n", .{ path, @errorName(err) });


### PR DESCRIPTION
Doing so prevents the correct options from being used during parsing.