### PR TITLE
Parser: Issue warning on missing parameter name being a C2x feature

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -261,6 +261,7 @@ pub const Tag = enum {
     pragma_poison_macro,
     newline_eof,
     empty_translation_unit,
+    omitting_parameter_name,
 };
 
 const Options = struct {
@@ -652,6 +653,7 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
             .pragma_poison_macro => m.write("poisoning existing macro"),
             .newline_eof => m.write("no newline at end of file"),
             .empty_translation_unit => m.write("ISO C requires a translation unit to contain at least one declaration"),
+            .omitting_parameter_name => m.write("omitting the parameter name in a function definition is a C2x extension"),
         }
         m.end(lcs);
 
@@ -901,7 +903,9 @@ fn tagKind(diag: *Diagnostics, tag: Tag) Kind {
         .array_before => diag.options.@"array-bounds",
         .implicit_int_to_ptr => diag.options.@"int-conversion",
         .pointer_mismatch => diag.options.@"pointer-type-mismatch",
-        .static_assert_missing_message => diag.options.@"c2x-extension",
+        .omitting_parameter_name,
+        .static_assert_missing_message,
+        => diag.options.@"c2x-extension",
         .incompatible_ptr_init,
         .incompatible_ptr_assign,
         => diag.options.@"incompatible-pointer-types",

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -77,7 +77,9 @@ pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!voi
 
 pub fn suppress(langopts: LangOpts, tag: DiagnosticTag) bool {
     return switch (tag) {
-        .static_assert_missing_message => langopts.standard.atLeast(.c2x),
+        .omitting_parameter_name,
+        .static_assert_missing_message,
+        => langopts.standard.atLeast(.c2x),
         .alignof_expr => langopts.standard.isExplicitGNU(),
         else => false,
     };

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -654,6 +654,12 @@ fn decl(p: *Parser) Error!bool {
         } else {
             for (init_d.d.ty.data.func.params) |param| {
                 if (param.ty.hasUnboundVLA()) try p.errTok(.unbound_vla, param.name_tok);
+
+                if (param.name.len == 0) {
+                    try p.errTok(.omitting_parameter_name, param.name_tok);
+                    continue;
+                }
+
                 try p.scopes.append(.{
                     .param = .{
                         .name = param.name,

--- a/test/cases/nameless param.c
+++ b/test/cases/nameless param.c
@@ -1,0 +1,13 @@
+int xyz(float);
+
+void foo(int) {
+    return;
+}
+
+void bar(float, char) {
+    return;
+}
+
+#define EXPECTED_ERRORS "nameless param.c:3:13: warning: omitting the parameter name in a function definition is a C2x extension" \
+    "nameless param.c:7:15: warning: omitting the parameter name in a function definition is a C2x extension" \
+    "nameless param.c:7:21: warning: omitting the parameter name in a function definition is a C2x extension"


### PR DESCRIPTION
Missing parameter name (but type is present) is a C2x feature which works on C17- but as extension. This PR emits warnings for them.

```c
void foo(test) {
    return;
}
```

```sh-session
nameless param.c:3:13: warning: omitting the parameter name in a function definition is a C2x extension
```

Test case included.
Does not affect function declarations.
