### PR TITLE
Parser: Check for function redefinition for same signature

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -573,12 +573,18 @@ fn decl(p: *Parser) Error!bool {
         }
         if (p.return_type != null) try p.err(.func_not_in_root);
 
-        // TODO check redefinition
-        try p.scopes.append(.{ .def = .{
-            .name = p.tokSlice(init_d.d.name),
-            .ty = init_d.d.ty,
-            .name_tok = init_d.d.name,
-        } });
+        if (p.findSymbol(init_d.d.name, .definition)) |sym| {
+            if (sym == .def) {
+                try p.errStr(.redefinition, init_d.d.name, p.tokSlice(init_d.d.name));
+                try p.errTok(.previous_definition, sym.def.name_tok);
+            }
+        } else {
+            try p.scopes.append(.{ .def = .{
+                .name = p.tokSlice(init_d.d.name),
+                .ty = init_d.d.ty,
+                .name_tok = init_d.d.name,
+            } });
+        }
 
         const return_type = p.return_type;
         const func_name = p.func_name;

--- a/test/cases/redefinitions.c
+++ b/test/cases/redefinitions.c
@@ -27,6 +27,12 @@ int func5(int a) {
     return a;
 }
 
+int func5(int a) {
+    return 10;
+}
+
+int func5(int a);
+
 #define TESTS_SKIPPED 1
 // int f(int (*)(), double (*)[3]);
 // int f(int (*)(char *), double (*)[]);
@@ -51,4 +57,6 @@ int func5(int a) {
     "redefinitions.c:23:5: error: redefinition of 'func4' with a different type" \
     "redefinitions.c:22:5: note: previous definition is here" \
     "redefinitions.c:26:9: error: redefinition of 'a'" \
-    "redefinitions.c:25:15: note: previous definition is here"
+    "redefinitions.c:25:15: note: previous definition is here" \
+    "redefinitions.c:30:5: error: redefinition of 'func5'" \
+    "redefinitions.c:25:5: note: previous definition is here"


### PR DESCRIPTION
Check for function redefinitions having exactly same signature, i,e redefinition of exact same function, which were previously missing from the parser. Test case included.

```c
int foo(int a) { 
    return 10; 
}

int foo(int a) { 
    return a; 
}
```