### PR TITLE
Preprocessor: detect ## at the beginning of a func macro

### DIFF
--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -1242,6 +1242,12 @@ fn defineFn(pp: *Preprocessor, tokenizer: *Tokenizer, macro_name: RawToken, l_pa
                 tok = param;
             },
             .hash_hash => {
+                // if ## appears at the beginning, the token buf is still empty
+                // in this case, error out
+                if (pp.token_buf.items.len == 0) {
+                    try pp.err(tok, .hash_hash_at_start);
+                    continue;
+                }
                 const start = tokenizer.index;
                 const next = tokenizer.next();
                 if (next.id == .nl or next.id == .eof) {

--- a/test/cases/hash_hash at func macro start.c
+++ b/test/cases/hash_hash at func macro start.c
@@ -1,0 +1,5 @@
+#define EXPECTED_ERRORS \
+	"'##' cannot appear at the start of a macro expansion"
+
+#define foo(X) ## x
+


### PR DESCRIPTION
fixes #77