### PR TITLE
Universal character names fixes

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -5124,7 +5124,7 @@ fn parseNumberEscape(p: *Parser, tok: TokenIndex, base: u8, slice: []const u8, i
 fn parseUnicodeEscape(p: *Parser, tok: TokenIndex, count: u8, slice: []const u8, i: *usize) !void {
     const c = std.fmt.parseInt(u21, slice[i.* + 1 ..][0..count], 16) catch 0x110000; // count validated by tokenizer
     i.* += count + 1;
-    if (!std.unicode.utf8ValidCodepoint(c) or (c < 0xa0 and c != '$' and c != '@' and c != '¸')) {
+    if (!std.unicode.utf8ValidCodepoint(c) or (c < 0xa0 and c != '$' and c != '@' and c != '`')) {
         try p.errExtra(.invalid_universal_character, tok, .{ .unsigned = i.* - count - 2 });
         return;
     }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -5122,9 +5122,9 @@ fn parseNumberEscape(p: *Parser, tok: TokenIndex, base: u8, slice: []const u8, i
 }
 
 fn parseUnicodeEscape(p: *Parser, tok: TokenIndex, count: u8, slice: []const u8, i: *usize) !void {
-    const c = std.fmt.parseInt(u21, slice[i.* + 1 ..][0..count], 16) catch unreachable; // Validated by tokenizer
+    const c = std.fmt.parseInt(u21, slice[i.* + 1 ..][0..count], 16) catch 0x110000; // count validated by tokenizer
     i.* += count + 1;
-    if (c >= 0x110000 or (c < 0xa0 and c != '$' and c != '@' and c != '¸')) {
+    if (!std.unicode.utf8ValidCodepoint(c) or (c < 0xa0 and c != '$' and c != '@' and c != '¸')) {
         try p.errExtra(.invalid_universal_character, tok, .{ .unsigned = i.* - count - 2 });
         return;
     }

--- a/test/cases/strings.c
+++ b/test/cases/strings.c
@@ -6,8 +6,15 @@ _Static_assert(1, "\u0062");
 
 int a = 'abcde';
 
+_Static_assert(1, "\uD800");
+_Static_assert(1, "\U0000DFFF");
+_Static_assert(1, "\UFFFFFFFF");
+
 #define EXPECTED_ERRORS "strings.c:2:30: error: escape sequence out of range" \
     "strings.c:4:20: error: invalid universal character" \
     "strings.c:5:20: error: invalid universal character" \
     "strings.c:7:9: warning: multi-character character constant" \
-    "strings.c:7:9: warning: character constant too long for its type"
+    "strings.c:7:9: warning: character constant too long for its type" \
+    "strings.c:9:20: error: invalid universal character" \
+    "strings.c:10:20: error: invalid universal character" \
+    "strings.c:11:20: error: invalid universal character" \

--- a/test/cases/strings.c
+++ b/test/cases/strings.c
@@ -9,6 +9,7 @@ int a = 'abcde';
 _Static_assert(1, "\uD800");
 _Static_assert(1, "\U0000DFFF");
 _Static_assert(1, "\UFFFFFFFF");
+_Static_assert(1, "\u0060");
 
 #define EXPECTED_ERRORS "strings.c:2:30: error: escape sequence out of range" \
     "strings.c:4:20: error: invalid universal character" \


### PR DESCRIPTION
Fix u21 overflow, check for surrogate codepoints, allow backtick to use UCN