### PR TITLE
Preprocessor: start_idx can exceed end_idx in nextBufToken

### DIFF
--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -780,7 +780,7 @@ fn shouldExpand(tok: Token, macro: *Macro) bool {
 
 fn nextBufToken(pp: *Preprocessor, tokenizer: *Tokenizer, buf: *ExpandBuf, start_idx: *usize, end_idx: *usize, extend_buf: bool) Error!Token {
     start_idx.* += 1;
-    if (start_idx.* == buf.items.len and start_idx.* == end_idx.*) {
+    if (start_idx.* == buf.items.len and start_idx.* >= end_idx.*) {
         if (extend_buf) {
             const raw_tok = tokenizer.next();
             if (raw_tok.id.isMacroIdentifier() and pp.poisoned_identifiers.get(pp.tokSliceSafe(raw_tok)) != null) {

--- a/test/cases/macro unbalanced parens call.c
+++ b/test/cases/macro unbalanced parens call.c
@@ -1,0 +1,6 @@
+#define EXPECTED_TOKENS FIRST 42
+
+#define FIRST(x) x
+#define SECOND FIRST
+#define THIRD SECOND( FIRST
+THIRD 42)


### PR DESCRIPTION
Nested expansions with unbalanced parentheses at the callsite could cause
start_idx to exceed end_idx; check for this and expand the buffer if
necessary.

Fixes #95