### PR TITLE
Source: require source files to be utf-8 encoded

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -391,11 +391,12 @@ pub fn addSource(comp: *Compilation, path: []const u8) !Source {
     const contents = try file.reader().readAllAlloc(comp.gpa, std.math.maxInt(u32));
     errdefer comp.gpa.free(contents);
 
-    const source = Source{
+    var source = Source{
         .id = @intToEnum(Source.Id, comp.sources.count() + 2),
         .path = duped_path,
         .buf = contents,
     };
+    source.checkUtf8();
 
     try comp.sources.put(duped_path, source);
 

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -267,6 +267,7 @@ pub const Tag = enum {
     negative_bitwidth,
     zero_width_named_field,
     bitfield_too_big,
+    invalid_utf8,
 };
 
 pub const Options = struct {
@@ -664,6 +665,7 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
             .negative_bitwidth => m.print("bit-field has negative width ({d})", .{msg.extra.signed}),
             .zero_width_named_field => m.write("named bit-field has zero width"),
             .bitfield_too_big => m.write("width of bit-field exceeds width of its type"),
+            .invalid_utf8 => m.write("source file is not valid UTF-8"),
         }
 
         if (comp.diag.tagOption(msg.tag)) |opt| {
@@ -936,6 +938,7 @@ fn tagKind(diag: *Diagnostics, tag: Tag) Kind {
         .zero_width_named_field,
         .bitfield_too_big,
         .division_by_zero_macro,
+        .invalid_utf8,
         => .@"error",
         .to_match_paren,
         .to_match_brace,

--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -135,6 +135,14 @@ pub fn deinit(pp: *Preprocessor) void {
 
 /// Preprocess a source file.
 pub fn preprocess(pp: *Preprocessor, source: Source) Error!void {
+    if (source.invalid_utf8_loc) |loc| {
+        try pp.comp.addDiagnostic(.{
+            .tag = .invalid_utf8,
+            .loc = loc,
+        });
+        return error.FatalError;
+    }
+
     pp.preprocess_count += 1;
     var tokenizer = Tokenizer{
         .buf = source.buf,

--- a/src/Source.zig
+++ b/src/Source.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const Source = @This();
 
 pub const Id = enum(u32) {
@@ -15,6 +16,7 @@ pub const Location = struct {
 path: []const u8,
 buf: []const u8,
 id: Id,
+invalid_utf8_loc: ?Location = null,
 
 pub const LCS = struct { line: u32, col: u32, str: []const u8 };
 
@@ -35,4 +37,25 @@ pub fn lineColString(source: Source, byte_offset: u32) LCS {
         if (source.buf[i] == '\n') break;
     }
     return .{ .line = line, .col = col, .str = source.buf[start..i] };
+}
+
+/// Returns the first offset, if any, in buf where an invalid utf8 sequence
+/// is found. Code adapted from std.unicode.utf8ValidateSlice
+fn offsetOfInvalidUtf8(buf: []const u8) ?u32 {
+    std.debug.assert(buf.len <= std.math.maxInt(u32));
+    var i: u32 = 0;
+    while (i < buf.len) {
+        if (std.unicode.utf8ByteSequenceLength(buf[i])) |cp_len| {
+            if (i + cp_len > buf.len) return i;
+            if (std.meta.isError(std.unicode.utf8Decode(buf[i .. i + cp_len]))) return i;
+            i += cp_len;
+        } else |_| return i;
+    }
+    return null;
+}
+
+pub fn checkUtf8(source: *Source) void {
+    if (offsetOfInvalidUtf8(source.buf)) |offset| {
+        source.invalid_utf8_loc = Location{ .id = source.id, .byte_offset = offset };
+    }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -222,7 +222,9 @@ fn handleArgs(comp: *Compilation, args: [][]const u8) !void {
     for (source_files.items) |source| {
         processSource(comp, source, builtin, user_macros) catch |e| switch (e) {
             error.OutOfMemory => return error.OutOfMemory,
-            error.FatalError => {},
+            error.FatalError => {
+                comp.renderErrors();
+            },
         };
     }
 }

--- a/test/cases/latin1.c
+++ b/test/cases/latin1.c
@@ -1,0 +1,4 @@
+int main(void) {
+    char *ö = "ABC";
+    return 0;
+}


### PR DESCRIPTION
Currently this just scans the whole file up-front to ensure that it is
utf-8 encoded. The scan is performed in preprocessor even though addSource
seems like a more natural fit because returning an error from that function
invalidates the source and path buffers which are needed for error messages.

Subsequent tokenizer enhancements will be needed for consuming unicode
codepoints instead of bytes (e.g. for identifiers); at that time the extra
scan can be removed and tokenizer.next() can either return an error or a special
token to indicate invalid utf8