### PR TITLE
Compilation: check for embedded null in include paths

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -382,6 +382,10 @@ pub fn getSource(comp: *Compilation, id: Source.Id) Source {
 pub fn addSource(comp: *Compilation, path: []const u8) !Source {
     if (comp.sources.get(path)) |some| return some;
 
+    if (mem.indexOfScalar(u8, path, 0) != null) {
+        return error.FileNotFound;
+    }
+
     const file = try std.fs.cwd().openFile(path, .{});
     defer file.close();
 


### PR DESCRIPTION
They are not legal on any system I know of, and trying to open such a path
can trigger an assert in the Zig stdlib

Fixes #106