### PR TITLE
Parser: Prevent call expression with incomplete-size argument

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4876,6 +4876,7 @@ fn callExpr(p: *Parser, lhs: Result) Error!Result {
             var arg = try p.assignExpr();
             try arg.expect(p);
             try arg.lvalConversion(p);
+            if (arg.ty.hasIncompleteSize() and !arg.ty.is(.void)) return error.ParsingFailed;
 
             if (arg_count < params.len) {
                 const p_ty = params[arg_count].ty;

--- a/test/cases/call.c
+++ b/test/cases/call.c
@@ -29,6 +29,11 @@ void foo(void) {
     var(1, 1.f, (char)1, a);
 }
 
+enum E;
+void bar(enum E e) {
+    baz(e);
+}
+
 #define EXPECTED_ERRORS "call.c:16:7: error: passing 'void' to parameter of incompatible type" \
     "call.c:5:21: note: passing argument to parameter here" \
     "call.c:19:7: warning: implicit pointer to integer conversion from 'int *' to 'int'" \
@@ -40,4 +45,6 @@ void foo(void) {
     "call.c:25:8: error: passing 'float' to parameter of incompatible type" \
     "call.c:8:20: note: passing argument to parameter here" \
     "call.c:28:7: error: passing 'int' to parameter of incompatible type" \
-    "call.c:9:25: note: passing argument to parameter here"
+    "call.c:9:25: note: passing argument to parameter here" \
+    "call.c:33:17: error: parameter has incomplete type 'enum E'" \
+    "call.c:34:5: warning: implicit declaration of function 'baz' is invalid in C99" \


### PR DESCRIPTION
void arguments handled separately

Fixes #130