### PR TITLE
Tets runner: set language version using a pragma

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2,6 +2,7 @@ pub const Codegen = @import("Codegen.zig");
 pub const Compilation = @import("Compilation.zig");
 pub const Diagnostics = @import("Diagnostics.zig");
 pub const Parser = @import("Parser.zig");
+pub const Pragma = @import("Pragma.zig");
 pub const Object = @import("Object.zig");
 pub const Preprocessor = @import("Preprocessor.zig");
 pub const Source = @import("Source.zig");

--- a/test/README.MD
+++ b/test/README.MD
@@ -22,8 +22,8 @@ CALL(CAT)
 ```
 ---
 ## Setting the C standard
-The C standard to use for a test can be set with the following comment as the first line
-of the file: `//std=<standard>`. See LangOpts.zig for a list of standards.
+The C standard to use for a test can be set using the `Aro_test` pragma by adding
+`#pragma Aro_test version <standard>` in the file. See LangOpts.zig for a list of standards.
 
 ## Testing for errors
 Expected compile errors can be tested by defining a `EXPECTED_ERRORS` macro.

--- a/test/cases/__is_identifier.c
+++ b/test/cases/__is_identifier.c
@@ -1,4 +1,5 @@
-//std=c17
+#pragma Aro_test version c17
+
 #if !__is_identifier(typeof)
 #error typeof should be an identifier in c17
 #endif

--- a/test/cases/c89 standard.c
+++ b/test/cases/c89 standard.c
@@ -1,4 +1,5 @@
-//std=c89
+#pragma Aro_test version c89
+
 void foo(void) {
 	int inline = 5;
 	int restrict = 10;

--- a/test/cases/c99 standard.c
+++ b/test/cases/c99 standard.c
@@ -1,4 +1,5 @@
-//std=c99
+#pragma Aro_test version c99
+
 void foo(void) {
 	int typeof = 5;
 }

--- a/test/cases/extended identifiers c11.c
+++ b/test/cases/extended identifiers c11.c
@@ -1,4 +1,4 @@
-//std=c11
+#pragma Aro_test version c11
 
 #pragma GCC diagnostic warning "-Wc99-compat"
 

--- a/test/cases/extended identifiers c99.c
+++ b/test/cases/extended identifiers c99.c
@@ -1,4 +1,4 @@
-//std=c99
+#pragma Aro_test version c99
 
 #define Ǻ 42
 int fǿǿ(void) {

--- a/test/cases/gnu alignof.c
+++ b/test/cases/gnu alignof.c
@@ -1,4 +1,5 @@
-//std=gnu17
+#pragma Aro_test version gnu17
+
 void foo(void) {
 	(void) _Alignof 2;
 	(void) _Alignof(2);

--- a/test/cases/gnu89 standard.c
+++ b/test/cases/gnu89 standard.c
@@ -1,4 +1,4 @@
-//std=gnu89
+#pragma Aro_test version gnu89
 
 void foo() {
 	typeof(int) x = 5;

--- a/test/cases/predefined macros.c
+++ b/test/cases/predefined macros.c
@@ -1,4 +1,5 @@
-//std=c99
+#pragma Aro_test version c99
+
 void foo(void) {
     _Static_assert(__STDC_VERSION__ == 199901, "__STDC_VERSION__ is incorrect");
     (void)__DATE__;

--- a/test/cases/static assert c2x.c
+++ b/test/cases/static assert c2x.c
@@ -1,4 +1,5 @@
-//std=c2x
+#pragma Aro_test version c2x
+
 void foo(void) {
     _Static_assert(1);
 }

--- a/test/cases/typeof.c
+++ b/test/cases/typeof.c
@@ -1,4 +1,5 @@
-//std=gnu17
+#pragma Aro_test version gnu17
+
 int foo(void) {
     return 42.0;
 }


### PR DESCRIPTION
Now that we have a nice pragma system we can use it instead of some hacky comment, especially since c++ style comments aren't even valid pre c99.

@ehaas there seems to be some bug in the way tokens are handled that appears depending on whether there is whitespace after the pragma or not, mind taking a look?