### PR TITLE
Make diagnostics declarative

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -452,11 +452,6 @@ pub fn fatal(comp: *Compilation, tok: Token, comptime fmt: []const u8, args: any
     return comp.diag.fatal(source.path, lcs, fmt, args);
 }
 
-pub fn addDiagnostic(comp: *Compilation, msg: Diagnostics.Message) Error!void {
-    if (comp.langopts.suppress(msg.tag)) return;
-    return comp.diag.add(msg);
-}
-
 pub fn addPragmaHandler(comp: *Compilation, name: []const u8, handler: *Pragma) Allocator.Error!void {
     try comp.pragma_handlers.putNoClobber(name, handler);
 }

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -9,9 +9,9 @@ const Diagnostics = @This();
 
 pub const Message = struct {
     tag: Tag,
+    kind: Kind = undefined,
     loc: Source.Location = .{},
     extra: Extra = .{ .none = {} },
-    kind: Kind = undefined,
 
     pub const Extra = union {
         str: []const u8,
@@ -19,6 +19,7 @@ pub const Message = struct {
             expected: Tree.Token.Id,
             actual: Tree.Token.Id,
         },
+        tok_id_expected: Tree.Token.Id,
         arguments: struct {
             expected: u32,
             actual: u32,
@@ -27,306 +28,1234 @@ pub const Message = struct {
             actual: u21,
             resembles: u21,
         },
+        actual_codepoint: u21,
         unsigned: u64,
         signed: i64,
         none: void,
     };
 };
 
-pub const Tag = enum {
-    // Maybe someday this will no longer be needed.
-    todo,
-    error_directive,
-    elif_without_if,
-    elif_after_else,
-    else_without_if,
-    else_after_else,
-    endif_without_if,
-    unsupported_pragma,
-    line_simple_digit,
-    line_invalid_filename,
-    unterminated_conditional_directive,
-    invalid_preprocessing_directive,
-    macro_name_missing,
-    extra_tokens_directive_end,
-    expected_value_in_expr,
-    closing_paren,
-    to_match_paren,
-    to_match_brace,
-    to_match_bracket,
-    header_str_closing,
-    header_str_match,
-    string_literal_in_pp_expr,
-    float_literal_in_pp_expr,
-    defined_as_macro_name,
-    macro_name_must_be_identifier,
-    whitespace_after_macro_name,
-    hash_hash_at_start,
-    hash_hash_at_end,
-    pasting_formed_invalid,
-    missing_paren_param_list,
-    unterminated_macro_param_list,
-    invalid_token_param_list,
-    hash_not_followed_param,
-    expected_filename,
-    empty_filename,
-    expected_invalid,
-    expected_token,
-    expected_expr,
-    expected_integer_constant_expr,
-    missing_type_specifier,
-    multiple_storage_class,
-    static_assert_failure,
-    static_assert_failure_message,
-    expected_type,
-    cannot_combine_spec,
-    duplicate_decl_spec,
-    restrict_non_pointer,
-    expected_external_decl,
-    expected_ident_or_l_paren,
-    missing_declaration,
-    func_not_in_root,
-    illegal_initializer,
-    extern_initializer,
-    spec_from_typedef,
-    type_is_invalid,
-    param_before_var_args,
-    void_only_param,
-    void_param_qualified,
-    void_must_be_first_param,
-    invalid_storage_on_param,
-    threadlocal_non_var,
-    func_spec_non_func,
-    illegal_storage_on_func,
-    illegal_storage_on_global,
-    expected_stmt,
-    func_cannot_return_func,
-    func_cannot_return_array,
-    undeclared_identifier,
-    not_callable,
-    unsupported_str_cat,
-    static_func_not_global,
-    implicit_func_decl,
-    expected_param_decl,
-    invalid_old_style_params,
-    expected_fn_body,
-    invalid_void_param,
-    unused_value,
-    continue_not_in_loop,
-    break_not_in_loop_or_switch,
-    unreachable_code,
-    duplicate_label,
-    previous_label,
-    undeclared_label,
-    case_not_in_switch,
-    duplicate_switch_case_signed,
-    duplicate_switch_case_unsigned,
-    multiple_default,
-    previous_case,
-    expected_arguments,
-    expected_arguments_old,
-    expected_at_least_arguments,
-    invalid_static_star,
-    static_non_param,
-    array_qualifiers,
-    star_non_param,
-    variable_len_array_file_scope,
-    useless_static,
-    negative_array_size,
-    array_incomplete_elem,
-    array_func_elem,
-    static_non_outermost_array,
-    qualifier_non_outermost_array,
-    unterminated_macro_arg_list,
-    unknown_warning,
-    overflow_unsigned,
-    overflow_signed,
-    int_literal_too_big,
-    indirection_ptr,
-    addr_of_rvalue,
-    not_assignable,
-    ident_or_l_brace,
-    empty_enum,
-    redefinition,
-    previous_definition,
-    expected_identifier,
-    expected_str_literal,
-    expected_str_literal_in,
-    parameter_missing,
-    empty_record,
-    wrong_tag,
-    expected_parens_around_typename,
-    alignof_expr,
-    invalid_sizeof,
-    macro_redefined,
-    generic_qual_type,
-    generic_duplicate,
-    generic_duplicate_default,
-    generic_no_match,
-    escape_sequence_overflow,
-    invalid_universal_character,
-    multichar_literal,
-    char_lit_too_wide,
-    must_use_struct,
-    must_use_union,
-    must_use_enum,
-    redefinition_different_sym,
-    redefinition_incompatible,
-    redefinition_of_parameter,
-    invalid_bin_types,
-    comparison_ptr_int,
-    comparison_distinct_ptr,
-    incompatible_pointers,
-    invalid_argument_un,
-    incompatible_assign,
-    implicit_ptr_to_int,
-    invalid_cast_to_float,
-    invalid_cast_to_pointer,
-    invalid_cast_type,
-    qual_cast,
-    invalid_index,
-    invalid_subscript,
-    array_after,
-    array_before,
-    statement_int,
-    statement_scalar,
-    func_should_return,
-    incompatible_return,
-    implicit_int_to_ptr,
-    func_does_not_return,
-    incompatible_param,
-    parameter_here,
-    atomic_array,
-    atomic_func,
-    atomic_incomplete,
-    addr_of_register,
-    variable_incomplete_ty,
-    parameter_incomplete_ty,
-    alignas_on_func,
-    alignas_on_param,
-    minimum_alignment,
-    maximum_alignment,
-    negative_alignment,
-    align_ignored,
-    zero_align_ignored,
-    non_pow2_align,
-    pointer_mismatch,
-    static_assert_not_constant,
-    static_assert_missing_message,
-    unbound_vla,
-    array_too_large,
-    incompatible_ptr_init,
-    incompatible_ptr_assign,
-    vla_init,
-    func_init,
-    incompatible_init,
-    empty_scalar_init,
-    excess_scalar_init,
-    excess_str_init,
-    excess_struct_init,
-    excess_array_init,
-    str_init_too_long,
-    arr_init_too_long,
-    invalid_typeof,
-    division_by_zero,
-    division_by_zero_macro,
-    builtin_choose_cond,
-    alignas_unavailable,
-    case_val_unavailable,
-    enum_val_unavailable,
-    incompatible_array_init,
-    initializer_overrides,
-    previous_initializer,
-    invalid_array_designator,
-    negative_array_designator,
-    oob_array_designator,
-    invalid_field_designator,
-    no_such_field_designator,
-    empty_aggregate_init_braces,
-    ptr_init_discards_quals,
-    ptr_assign_discards_quals,
-    unknown_attribute,
-    ignored_attribute,
-    invalid_fallthrough,
-    cannot_apply_attribute_to_statement,
-    builtin_macro_redefined,
-    missing_tok_builtin,
-    feature_check_requires_identifier,
-    gnu_label_as_value,
-    expected_record_ty,
-    member_expr_not_ptr,
-    member_expr_ptr,
-    no_such_member,
-    malformed_warning_check,
-    invalid_computed_goto,
-    pragma_warning_message,
-    pragma_error_message,
-    pragma_requires_string_literal,
-    poisoned_identifier,
-    pragma_poison_identifier,
-    pragma_poison_macro,
-    newline_eof,
-    empty_translation_unit,
-    omitting_parameter_name,
-    non_int_bitfield,
-    negative_bitwidth,
-    zero_width_named_field,
-    bitfield_too_big,
-    invalid_utf8,
-    implicitly_unsigned_literal,
-    deref_incomplete_ty_ptr,
-    invalid_preproc_operator,
-    invalid_preproc_expr_start,
-    c99_compat,
-    unicode_zero_width,
-    unicode_homoglyph,
-    pragma_inside_macro,
-    meaningless_asm_qual,
-    duplicate_asm_qual,
-    invalid_asm_str,
+pub const Tag = blk: {
+    const decls = @typeInfo(messages).Struct.decls;
+    var enum_fields: [decls.len]std.builtin.TypeInfo.EnumField = undefined;
+    inline for (decls) |decl, i| {
+        enum_fields[i] = .{
+            .name = decl.name,
+            .value = i,
+        };
+    }
+    break :blk @Type(.{
+        .Enum = .{
+            .layout = .Auto,
+            .tag_type = std.math.IntFittingRange(0, decls.len - 1),
+            .fields = &enum_fields,
+            .decls = &.{},
+            .is_exhaustive = true,
+        },
+    });
 };
 
+pub const Kind = enum { @"fatal error", @"error", note, warning, off };
+
 pub const Options = struct {
-    @"unsupported-pragma": Kind = .warning,
-    @"c99-extensions": Kind = .warning,
-    @"implicit-int": Kind = .warning,
-    @"duplicate-decl-specifier": Kind = .warning,
-    @"missing-declaration": Kind = .warning,
-    @"extern-initializer": Kind = .warning,
-    @"implicit-function-declaration": Kind = .warning,
-    @"unused-value": Kind = .warning,
-    @"unreachable-code": Kind = .warning,
-    @"unknown-warning-option": Kind = .warning,
-    @"empty-struct": Kind = .off,
-    @"gnu-alignof-expression": Kind = .warning,
-    @"macro-redefined": Kind = .warning,
-    @"generic-qual-type": Kind = .warning,
-    multichar: Kind = .warning,
-    @"pointer-integer-compare": Kind = .warning,
-    @"compare-distinct-pointer-types": Kind = .warning,
-    @"literal-conversion": Kind = .warning,
-    @"cast-qualifiers": Kind = .warning,
-    @"array-bounds": Kind = .warning,
-    @"int-conversion": Kind = .warning,
-    @"pointer-type-mismatch": Kind = .warning,
-    @"c2x-extension": Kind = .warning,
-    @"incompatible-pointer-types": Kind = .warning,
-    @"excess-initializers": Kind = .warning,
-    @"division-by-zero": Kind = .warning,
-    @"initializer-overrides": Kind = .warning,
-    @"incompatible-pointer-types-discards-qualifiers": Kind = .warning,
-    @"unknown-attributes": Kind = .warning,
-    @"ignored-attributes": Kind = .warning,
-    @"builtin-macro-redefined": Kind = .warning,
-    @"gnu-label-as-value": Kind = .off,
-    @"malformed-warning-check": Kind = .warning,
-    @"#pragma-messages": Kind = .warning,
-    @"newline-eof": Kind = .off,
-    @"empty-translation-unit": Kind = .off,
-    @"implicitly-unsigned-literal": Kind = .warning,
-    @"c99-compat": Kind = .off,
-    @"unicode-zero-width": Kind = .warning,
-    @"unicode-homoglyph": Kind = .warning,
+    @"unsupported-pragma": ?Kind = null,
+    @"c99-extensions": ?Kind = null,
+    @"implicit-int": ?Kind = null,
+    @"duplicate-decl-specifier": ?Kind = null,
+    @"missing-declaration": ?Kind = null,
+    @"extern-initializer": ?Kind = null,
+    @"implicit-function-declaration": ?Kind = null,
+    @"unused-value": ?Kind = null,
+    @"unreachable-code": ?Kind = null,
+    @"unknown-warning-option": ?Kind = null,
+    @"empty-struct": ?Kind = null,
+    @"gnu-alignof-expression": ?Kind = null,
+    @"macro-redefined": ?Kind = null,
+    @"generic-qual-type": ?Kind = null,
+    multichar: ?Kind = null,
+    @"pointer-integer-compare": ?Kind = null,
+    @"compare-distinct-pointer-types": ?Kind = null,
+    @"literal-conversion": ?Kind = null,
+    @"cast-qualifiers": ?Kind = null,
+    @"array-bounds": ?Kind = null,
+    @"int-conversion": ?Kind = null,
+    @"pointer-type-mismatch": ?Kind = null,
+    @"c2x-extensions": ?Kind = null,
+    @"incompatible-pointer-types": ?Kind = null,
+    @"excess-initializers": ?Kind = null,
+    @"division-by-zero": ?Kind = null,
+    @"initializer-overrides": ?Kind = null,
+    @"incompatible-pointer-types-discards-qualifiers": ?Kind = null,
+    @"unknown-attributes": ?Kind = null,
+    @"ignored-attributes": ?Kind = null,
+    @"builtin-macro-redefined": ?Kind = null,
+    @"gnu-label-as-value": ?Kind = null,
+    @"malformed-warning-check": ?Kind = null,
+    @"#pragma-messages": ?Kind = null,
+    @"newline-eof": ?Kind = null,
+    @"empty-translation-unit": ?Kind = null,
+    @"implicitly-unsigned-literal": ?Kind = null,
+    @"c99-compat": ?Kind = null,
+    @"unicode-zero-width": ?Kind = null,
+    @"unicode-homoglyph": ?Kind = null,
+};
+
+const messages = struct {
+    const todo = struct { // Maybe someday this will no longer be needed.
+        const msg = "TODO: {s}";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const error_directive = struct {
+        const msg = "{s}";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const elif_without_if = struct {
+        const msg = "#elif without #if";
+        const kind = .@"error";
+    };
+    const elif_after_else = struct {
+        const msg = "#elif after #else";
+        const kind = .@"error";
+    };
+    const else_without_if = struct {
+        const msg = "#else without #if";
+        const kind = .@"error";
+    };
+    const else_after_else = struct {
+        const msg = "#else after #else";
+        const kind = .@"error";
+    };
+    const endif_without_if = struct {
+        const msg = "#endif without #if";
+        const kind = .@"error";
+    };
+    const unsupported_pragma = struct {
+        const msg = "unsupported #pragma directive '{s}'";
+        const extra = .str;
+        const opt = "unsupported-pragma";
+        const kind = .warning;
+    };
+    const line_simple_digit = struct {
+        const msg = "#line directive requires a simple digit sequence";
+        const kind = .@"error";
+    };
+    const line_invalid_filename = struct {
+        const msg = "invalid filename for #line directive";
+        const kind = .@"error";
+    };
+    const unterminated_conditional_directive = struct {
+        const msg = "unterminated conditional directive";
+        const kind = .@"error";
+    };
+    const invalid_preprocessing_directive = struct {
+        const msg = "invalid preprocessing directive";
+        const kind = .@"error";
+    };
+    const macro_name_missing = struct {
+        const msg = "macro name missing";
+        const kind = .@"error";
+    };
+    const extra_tokens_directive_end = struct {
+        const msg = "extra tokens at end of macro directive";
+        const kind = .@"error";
+    };
+    const expected_value_in_expr = struct {
+        const msg = "expected value in expression";
+        const kind = .@"error";
+    };
+    const closing_paren = struct {
+        const msg = "expected closing ')'";
+        const kind = .@"error";
+    };
+    const to_match_paren = struct {
+        const msg = "to match this '('";
+        const kind = .note;
+    };
+    const to_match_brace = struct {
+        const msg = "to match this '{'";
+        const kind = .note;
+    };
+    const to_match_bracket = struct {
+        const msg = "to match this '['";
+        const kind = .note;
+    };
+    const header_str_closing = struct {
+        const msg = "expected closing '>'";
+        const kind = .@"error";
+    };
+    const header_str_match = struct {
+        const msg = "to match this '<'";
+        const kind = .note;
+    };
+    const string_literal_in_pp_expr = struct {
+        const msg = "string literal in preprocessor expression";
+        const kind = .@"error";
+    };
+    const float_literal_in_pp_expr = struct {
+        const msg = "floating point literal in preprocessor expression";
+        const kind = .@"error";
+    };
+    const defined_as_macro_name = struct {
+        const msg = "'defined' cannot be used as a macro name";
+        const kind = .@"error";
+    };
+    const macro_name_must_be_identifier = struct {
+        const msg = "macro name must be an identifier";
+        const kind = .@"error";
+    };
+    const whitespace_after_macro_name = struct {
+        const msg = "ISO C99 requires whitespace after the macro name";
+        const opt = "c99-extensions";
+        const kind = .warning;
+    };
+    const hash_hash_at_start = struct {
+        const msg = "'##' cannot appear at the start of a macro expansion";
+        const kind = .@"error";
+    };
+    const hash_hash_at_end = struct {
+        const msg = "'##' cannot appear at the end of a macro expansion";
+        const kind = .@"error";
+    };
+    const pasting_formed_invalid = struct {
+        const msg = "pasting formed '{s}', an invalid preprocessing token";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const missing_paren_param_list = struct {
+        const msg = "missing ')' in macro parameter list";
+        const kind = .@"error";
+    };
+    const unterminated_macro_param_list = struct {
+        const msg = "unterminated macro param list";
+        const kind = .@"error";
+    };
+    const invalid_token_param_list = struct {
+        const msg = "invalid token in macro parameter list";
+        const kind = .@"error";
+    };
+    const hash_not_followed_param = struct {
+        const msg = "'#' is not followed by a macro parameter";
+        const kind = .@"error";
+    };
+    const expected_filename = struct {
+        const msg = "expected \"FILENAME\" or <FILENAME>";
+        const kind = .@"error";
+    };
+    const empty_filename = struct {
+        const msg = "empty filename";
+        const kind = .@"error";
+    };
+    const expected_invalid = struct {
+        const msg = "expected '{s}', found invalid bytes";
+        const extra = .tok_id_expected;
+        const kind = .@"error";
+    };
+    const expected_token = struct {
+        const msg = "expected '{s}', found '{s}'";
+        const extra = .tok_id;
+        const kind = .@"error";
+    };
+    const expected_expr = struct {
+        const msg = "expected expression";
+        const kind = .@"error";
+    };
+    const expected_integer_constant_expr = struct {
+        const msg = "expression is not an integer constant expression";
+        const kind = .@"error";
+    };
+    const missing_type_specifier = struct {
+        const msg = "type specifier missing, defaults to 'int'";
+        const opt = "implicit-int";
+        const kind = .warning;
+    };
+    const multiple_storage_class = struct {
+        const msg = "cannot combine with previous '{s}' declaration specifier";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const static_assert_failure = struct {
+        const msg = "static assertion failed";
+        const kind = .@"error";
+    };
+    const static_assert_failure_message = struct {
+        const msg = "static assertion failed {s}";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const expected_type = struct {
+        const msg = "expected a type";
+        const kind = .@"error";
+    };
+    const cannot_combine_spec = struct {
+        const msg = "cannot combine with previous '{s}' specifier";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const duplicate_decl_spec = struct {
+        const msg = "duplicate '{s}' declaration specifier";
+        const extra = .str;
+        const opt = "duplicate-decl-specifier";
+        const kind = .warning;
+    };
+    const restrict_non_pointer = struct {
+        const msg = "restrict requires a pointer or reference ('{s}' is invalid)";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const expected_external_decl = struct {
+        const msg = "expected external declaration";
+        const kind = .@"error";
+    };
+    const expected_ident_or_l_paren = struct {
+        const msg = "expected identifier or '('";
+        const kind = .@"error";
+    };
+    const missing_declaration = struct {
+        const msg = "declaration does not declare anything";
+        const opt = "missing-declaration";
+        const kind = .warning;
+    };
+    const func_not_in_root = struct {
+        const msg = "function definition is not allowed here";
+        const kind = .@"error";
+    };
+    const illegal_initializer = struct {
+        const msg = "illegal initializer (only variables can be initialized)";
+        const kind = .@"error";
+    };
+    const extern_initializer = struct {
+        const msg = "extern variable has initializer";
+        const opt = "extern-initializer";
+        const kind = .warning;
+    };
+    const spec_from_typedef = struct {
+        const msg = "'{s}' came from typedef";
+        const extra = .str;
+        const kind = .note;
+    };
+    const type_is_invalid = struct {
+        const msg = "'{s}' is invalid";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const param_before_var_args = struct {
+        const msg = "ISO C requires a named parameter before '...'";
+        const kind = .@"error";
+    };
+    const void_only_param = struct {
+        const msg = "'void' must be the only parameter if specified";
+        const kind = .@"error";
+    };
+    const void_param_qualified = struct {
+        const msg = "'void' parameter cannot be qualified";
+        const kind = .@"error";
+    };
+    const void_must_be_first_param = struct {
+        const msg = "'void' must be the first parameter if specified";
+        const kind = .@"error";
+    };
+    const invalid_storage_on_param = struct {
+        const msg = "invalid storage class on function parameter";
+        const kind = .@"error";
+    };
+    const threadlocal_non_var = struct {
+        const msg = "_Thread_local only allowed on variables";
+        const kind = .@"error";
+    };
+    const func_spec_non_func = struct {
+        const msg = "'{s}' can only appear on functions";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const illegal_storage_on_func = struct {
+        const msg = "illegal storage class on function";
+        const kind = .@"error";
+    };
+    const illegal_storage_on_global = struct {
+        const msg = "illegal storage class on global variable";
+        const kind = .@"error";
+    };
+    const expected_stmt = struct {
+        const msg = "expected statement";
+        const kind = .@"error";
+    };
+    const func_cannot_return_func = struct {
+        const msg = "function cannot return a function";
+        const kind = .@"error";
+    };
+    const func_cannot_return_array = struct {
+        const msg = "function cannot return an array";
+        const kind = .@"error";
+    };
+    const undeclared_identifier = struct {
+        const msg = "use of undeclared identifier '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const not_callable = struct {
+        const msg = "cannot call non function type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const unsupported_str_cat = struct {
+        const msg = "unsupported string literal concatenation";
+        const kind = .@"error";
+    };
+    const static_func_not_global = struct {
+        const msg = "static functions must be global";
+        const kind = .@"error";
+    };
+    const implicit_func_decl = struct {
+        const msg = "implicit declaration of function '{s}' is invalid in C99";
+        const extra = .str;
+        const opt = "implicit-function-declaration";
+        const kind = .warning;
+    };
+    const expected_param_decl = struct {
+        const msg = "expected parameter declaration";
+        const kind = .@"error";
+    };
+    const invalid_old_style_params = struct {
+        const msg = "identifier parameter lists are only allowed in function definitions";
+        const kind = .warning;
+    };
+    const expected_fn_body = struct {
+        const msg = "expected function body after function declaration";
+        const kind = .@"error";
+    };
+    const invalid_void_param = struct {
+        const msg = "parameter cannot have void type";
+        const kind = .@"error";
+    };
+    const unused_value = struct {
+        const msg = "expression result unused";
+        const opt = "unused-value";
+        const kind = .warning;
+    };
+    const continue_not_in_loop = struct {
+        const msg = "'continue' statement not in a loop";
+        const kind = .@"error";
+    };
+    const break_not_in_loop_or_switch = struct {
+        const msg = "'break' statement not in a loop or a switch";
+        const kind = .@"error";
+    };
+    const unreachable_code = struct {
+        const msg = "unreachable code";
+        const opt = "unreachable-code";
+        const kind = .warning;
+    };
+    const duplicate_label = struct {
+        const msg = "duplicate label '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const previous_label = struct {
+        const msg = "previous definition of label '{s}' was here";
+        const extra = .str;
+        const kind = .note;
+    };
+    const undeclared_label = struct {
+        const msg = "use of undeclared label '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const case_not_in_switch = struct {
+        const msg = "'{s}' statement not in a switch statement";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const duplicate_switch_case_signed = struct {
+        const msg = "duplicate case value '{d}'";
+        const extra = .signed;
+        const kind = .@"error";
+    };
+    const duplicate_switch_case_unsigned = struct {
+        const msg = "duplicate case value '{d}'";
+        const extra = .unsigned;
+        const kind = .@"error";
+    };
+    const multiple_default = struct {
+        const msg = "multiple default cases in the same switch";
+        const kind = .@"error";
+    };
+    const previous_case = struct {
+        const msg = "previous case defined here";
+        const kind = .note;
+    };
+    const expected_arguments = struct {
+        const msg = "expected {d} argument(s) got {d}";
+        const extra = .arguments;
+        const kind = .@"error";
+    };
+    const expected_arguments_old = struct {
+        const msg = expected_arguments.msg;
+        const extra = .arguments;
+        const kind = .warning;
+    };
+    const expected_at_least_arguments = struct {
+        const msg = "expected at least {d} argument(s) got {d}";
+        const extra = .arguments;
+        const kind = .warning;
+    };
+    const invalid_static_star = struct {
+        const msg = "'static' may not be used with an unspecified variable length array size";
+        const kind = .@"error";
+    };
+    const static_non_param = struct {
+        const msg = "'static' used outside of function parameters";
+        const kind = .@"error";
+    };
+    const array_qualifiers = struct {
+        const msg = "type qualifier in non parameter array type";
+        const kind = .@"error";
+    };
+    const star_non_param = struct {
+        const msg = "star modifier used outside of function parameters";
+        const kind = .@"error";
+    };
+    const variable_len_array_file_scope = struct {
+        const msg = "variable length arrays not allowed at file scope";
+        const kind = .@"error";
+    };
+    const useless_static = struct {
+        const msg = "'static' useless without a constant size";
+        const kind = .warning;
+    };
+    const negative_array_size = struct {
+        const msg = "array size must be 0 or greater";
+        const kind = .@"error";
+    };
+    const array_incomplete_elem = struct {
+        const msg = "array has incomplete element type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const array_func_elem = struct {
+        const msg = "arrays cannot have functions as their element type";
+        const kind = .@"error";
+    };
+    const static_non_outermost_array = struct {
+        const msg = "'static' used in non-outermost array type";
+        const kind = .@"error";
+    };
+    const qualifier_non_outermost_array = struct {
+        const msg = "type qualifier used in non-outermost array type";
+        const kind = .@"error";
+    };
+    const unterminated_macro_arg_list = struct {
+        const msg = "unterminated function macro argument list";
+        const kind = .@"error";
+    };
+    const unknown_warning = struct {
+        const msg = "unknown warning '{s}'";
+        const extra = .str;
+        const opt = "unknown-warning-option";
+        const kind = .warning;
+    };
+    const overflow_signed = struct {
+        const msg = "overflow in expression; result is '{d}'";
+        const extra = .signed;
+        const kind = .@"error";
+    };
+    const overflow_unsigned = struct {
+        const msg = overflow_signed.msg;
+        const extra = .unsigned;
+        const kind = .warning;
+    };
+    const int_literal_too_big = struct {
+        const msg = "integer literal is too large to be represented in any integer type";
+        const kind = .@"error";
+    };
+    const indirection_ptr = struct {
+        const msg = "indirection requires pointer operand";
+        const kind = .@"error";
+    };
+    const addr_of_rvalue = struct {
+        const msg = "cannot take the address of an rvalue";
+        const kind = .@"error";
+    };
+    const not_assignable = struct {
+        const msg = "expression is not assignable";
+        const kind = .@"error";
+    };
+    const ident_or_l_brace = struct {
+        const msg = "expected identifier or '{'";
+        const kind = .@"error";
+    };
+    const empty_enum = struct {
+        const msg = "empty enum is invalid";
+        const kind = .@"error";
+    };
+    const redefinition = struct {
+        const msg = "redefinition of '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const previous_definition = struct {
+        const msg = "previous definition is here";
+        const kind = .note;
+    };
+    const expected_identifier = struct {
+        const msg = "expected identifier";
+        const kind = .@"error";
+    };
+    const expected_str_literal = struct {
+        const msg = "expected string literal for diagnostic message in static_assert";
+        const kind = .@"error";
+    };
+    const expected_str_literal_in = struct {
+        const msg = "expected string literal in '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const parameter_missing = struct {
+        const msg = "parameter named '{s}' is missing";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const empty_record = struct {
+        const msg = "empty {s} is a GNU extension";
+        const extra = .str;
+        const opt = "empty-struct";
+        const kind = .off;
+    };
+    const wrong_tag = struct {
+        const msg = "use of '{s}' with tag type that does not match previous definition";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const expected_parens_around_typename = struct {
+        const msg = "expected parentheses around type name";
+        const kind = .@"error";
+    };
+    const alignof_expr = struct {
+        const msg = "'_Alignof' applied to an expression is a GNU extension";
+        const opt = "gnu-alignof-expression";
+        const kind = .warning;
+        const suppress_gnu = true;
+    };
+    const invalid_sizeof = struct {
+        const msg = "invalid application of 'sizeof' to an incomplete type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const macro_redefined = struct {
+        const msg = "'{s}' macro redefined";
+        const extra = .str;
+        const opt = "macro-redefined";
+        const kind = .warning;
+    };
+    const generic_qual_type = struct {
+        const msg = "generic association with qualifiers cannot be matched with";
+        const opt = "generic-qual-type";
+        const kind = .warning;
+    };
+    const generic_duplicate = struct {
+        const msg = "type '{s}' in generic association compatible with previously specified type";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const generic_duplicate_default = struct {
+        const msg = "duplicate default generic association";
+        const kind = .@"error";
+    };
+    const generic_no_match = struct {
+        const msg = "controlling expression type '{s}' not compatible with any generic association type";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const escape_sequence_overflow = struct {
+        const msg = "escape sequence out of range";
+        const kind = .@"error";
+    };
+    const invalid_universal_character = struct {
+        const msg = "invalid universal character";
+        const kind = .@"error";
+    };
+    const multichar_literal = struct {
+        const msg = "multi-character character constant";
+        const opt = "multichar";
+        const kind = .warning;
+    };
+    const char_lit_too_wide = struct {
+        const msg = "character constant too long for its type";
+        const kind = .warning;
+    };
+    const must_use_struct = struct {
+        const msg = "must use 'struct' tag to refer to type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const must_use_union = struct {
+        const msg = "must use 'union' tag to refer to type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const must_use_enum = struct {
+        const msg = "must use 'enum' tag to refer to type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const redefinition_different_sym = struct {
+        const msg = "redefinition of '{s}' as different kind of symbol";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const redefinition_incompatible = struct {
+        const msg = "redefinition of '{s}' with a different type";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const redefinition_of_parameter = struct {
+        const msg = "redefinition of parameter '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const invalid_bin_types = struct {
+        const msg = "invalid operands to binary expression ({s})";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const comparison_ptr_int = struct {
+        const msg = "comparison between pointer and integer ({s})";
+        const extra = .str;
+        const opt = "pointer-integer-compare";
+        const kind = .warning;
+    };
+    const comparison_distinct_ptr = struct {
+        const msg = "comparison of distinct pointer types ({s})";
+        const extra = .str;
+        const opt = "compare-distinct-pointer-types";
+        const kind = .warning;
+    };
+    const incompatible_pointers = struct {
+        const msg = "incompatible pointer types ({s})";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const invalid_argument_un = struct {
+        const msg = "invalid argument type '{s}' to unary expression";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const incompatible_assign = struct {
+        const msg = "assignment to {s}";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const implicit_ptr_to_int = struct {
+        const msg = "implicit pointer to integer conversion from {s}";
+        const extra = .str;
+        const opt = "literal-conversion";
+        const kind = .warning;
+    };
+    const invalid_cast_to_float = struct {
+        const msg = "pointer cannot be cast to type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const invalid_cast_to_pointer = struct {
+        const msg = "operand of type '{s}' cannot be cast to a pointer type";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const invalid_cast_type = struct {
+        const msg = "cannot cast to non arithmetic or pointer type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const qual_cast = struct {
+        const msg = "cast to type '{s}' will not preserve qualifiers";
+        const extra = .str;
+        const opt = "cast-qualifiers";
+        const kind = .warning;
+    };
+    const invalid_index = struct {
+        const msg = "array subscript is not an integer";
+        const kind = .@"error";
+    };
+    const invalid_subscript = struct {
+        const msg = "subscripted value is not an array or pointer";
+        const kind = .@"error";
+    };
+    const array_after = struct {
+        const msg = "array index {d} is past the end of the array";
+        const extra = .unsigned;
+        const opt = "array-bounds";
+        const kind = .warning;
+    };
+    const array_before = struct {
+        const msg = "array index {d} is before the beginning of the array";
+        const extra = .signed;
+        const opt = "array-bounds";
+        const kind = .warning;
+    };
+    const statement_int = struct {
+        const msg = "statement requires expression with integer type ('{s}' invalid)";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const statement_scalar = struct {
+        const msg = "statement requires expression with scalar type ('{s}' invalid)";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const func_should_return = struct {
+        const msg = "non-void function '{s}' should return a value";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const incompatible_return = struct {
+        const msg = "returning '{s}' from a function with incompatible result type";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const implicit_int_to_ptr = struct {
+        const msg = "implicit integer to pointer conversion from {s}";
+        const extra = .str;
+        const opt = "int-conversion";
+        const kind = .warning;
+    };
+    const func_does_not_return = struct {
+        const msg = "non-void function '{s}' does not return a value";
+        const extra = .str;
+        const kind = .warning;
+    };
+    const incompatible_param = struct {
+        const msg = "passing '{s}' to parameter of incompatible type";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const parameter_here = struct {
+        const msg = "passing argument to parameter here";
+        const kind = .note;
+    };
+    const atomic_array = struct {
+        const msg = "atomic cannot be applied to array type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const atomic_func = struct {
+        const msg = "atomic cannot be applied to function type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const atomic_incomplete = struct {
+        const msg = "atomic cannot be applied to incomplete type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const addr_of_register = struct {
+        const msg = "address of register variable requested";
+        const kind = .@"error";
+    };
+    const variable_incomplete_ty = struct {
+        const msg = "variable has incomplete type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const parameter_incomplete_ty = struct {
+        const msg = "parameter has incomplete type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const deref_incomplete_ty_ptr = struct {
+        const msg = "dereferencing pointer to incomplete type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const alignas_on_func = struct {
+        const msg = "'_Alignas' attribute only applies to variables and fields";
+        const kind = .@"error";
+    };
+    const alignas_on_param = struct {
+        const msg = "'_Alignas' attribute cannot be applied to a function parameter";
+        const kind = .@"error";
+    };
+    const minimum_alignment = struct {
+        const msg = "requested alignment is less than minimum alignment of {d}";
+        const extra = .unsigned;
+        const kind = .@"error";
+    };
+    const maximum_alignment = struct {
+        const msg = "requested alignment of {d} is too large";
+        const extra = .unsigned;
+        const kind = .@"error";
+    };
+    const negative_alignment = struct {
+        const msg = "requested negative alignment of {d} is invalid";
+        const extra = .signed;
+        const kind = .@"error";
+    };
+    const align_ignored = struct {
+        const msg = "'_Alignas' attribute is ignored here";
+        const kind = .warning;
+    };
+    const zero_align_ignored = struct {
+        const msg = "requested alignment of zero is ignored";
+        const kind = .warning;
+    };
+    const non_pow2_align = struct {
+        const msg = "requested alignment is not a power of 2";
+        const kind = .@"error";
+    };
+    const pointer_mismatch = struct {
+        const msg = "pointer type mismatch ({s})";
+        const extra = .str;
+        const opt = "pointer-type-mismatch";
+        const kind = .warning;
+    };
+    const static_assert_not_constant = struct {
+        const msg = "static_assert expression is not an integral constant expression";
+        const kind = .@"error";
+    };
+    const static_assert_missing_message = struct {
+        const msg = "static_assert with no message is a C2X extension";
+        const opt = "c2x-extensions";
+        const kind = .warning;
+        const suppress_version = .c2x;
+    };
+    const unbound_vla = struct {
+        const msg = "variable length array must be bound in function definition";
+        const kind = .@"error";
+    };
+    const array_too_large = struct {
+        const msg = "array is too large";
+        const kind = .@"error";
+    };
+    const incompatible_ptr_init = struct {
+        const msg = "incompatible pointer types initializing {s}";
+        const extra = .str;
+        const opt = "incompatible-pointer-types";
+        const kind = .warning;
+    };
+    const incompatible_ptr_assign = struct {
+        const msg = "incompatible pointer types assigning to {s}";
+        const extra = .str;
+        const opt = "incompatible-pointer-types";
+        const kind = .warning;
+    };
+    const vla_init = struct {
+        const msg = "variable-sized object may not be initialized";
+        const kind = .@"error";
+    };
+    const func_init = struct {
+        const msg = "illegal initializer type";
+        const kind = .@"error";
+    };
+    const incompatible_init = struct {
+        const msg = "initializing {s}";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const empty_scalar_init = struct {
+        const msg = "scalar initializer cannot be empty";
+        const kind = .@"error";
+    };
+    const excess_scalar_init = struct {
+        const msg = "excess elements in scalar initializer";
+        const opt = "excess-initializers";
+        const kind = .warning;
+    };
+    const excess_str_init = struct {
+        const msg = "excess elements in string initializer";
+        const opt = "excess-initializers";
+        const kind = .warning;
+    };
+    const excess_struct_init = struct {
+        const msg = "excess elements in struct initializer";
+        const opt = "excess-initializers";
+        const kind = .warning;
+    };
+    const excess_array_init = struct {
+        const msg = "excess elements in array initializer";
+        const opt = "excess-initializers";
+        const kind = .warning;
+    };
+    const str_init_too_long = struct {
+        const msg = "initializer-string for char array is too long";
+        const opt = "excess-initializers";
+        const kind = .warning;
+    };
+    const arr_init_too_long = struct {
+        const msg = "cannot initialize type ({s})";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const invalid_typeof = struct {
+        const msg = "'{s} typeof' is invalid";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const division_by_zero = struct {
+        const msg = "{s} by zero is undefined";
+        const extra = .str;
+        const opt = "division-by-zero";
+        const kind = .warning;
+    };
+    const division_by_zero_macro = struct {
+        const msg = "{s} by zero in preprocessor expression";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const builtin_choose_cond = struct {
+        const msg = "'__builtin_choose_expr' requires a constant expression";
+        const kind = .@"error";
+    };
+    const alignas_unavailable = struct {
+        const msg = "'_Alignas' attribute requires integer constant expression";
+        const kind = .@"error";
+    };
+    const case_val_unavailable = struct {
+        const msg = "case value must be an integer constant expression";
+        const kind = .@"error";
+    };
+    const enum_val_unavailable = struct {
+        const msg = "enum value must be an integer constant expression";
+        const kind = .@"error";
+    };
+    const incompatible_array_init = struct {
+        const msg = "cannot initialize array of type {s}";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const initializer_overrides = struct {
+        const msg = "initializer overrides previous initialization";
+        const opt = "initializer-overrides";
+        const kind = .warning;
+    };
+    const previous_initializer = struct {
+        const msg = "previous initialization";
+        const kind = .note;
+    };
+    const invalid_array_designator = struct {
+        const msg = "array designator used for non-array type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const negative_array_designator = struct {
+        const msg = "array designator value {d} is negative";
+        const extra = .signed;
+        const kind = .@"error";
+    };
+    const oob_array_designator = struct {
+        const msg = "array designator index {d} exceeds array bounds";
+        const extra = .unsigned;
+        const kind = .@"error";
+    };
+    const invalid_field_designator = struct {
+        const msg = "field designator used for non-record type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const no_such_field_designator = struct {
+        const msg = "record type has no field named '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const empty_aggregate_init_braces = struct {
+        const msg = "initializer for aggregate with no elements requires explicit braces";
+        const kind = .@"error";
+    };
+    const ptr_init_discards_quals = struct {
+        const msg = "initializing {s} discards qualifiers";
+        const extra = .str;
+        const opt = "incompatible-pointer-types-discards-qualifiers";
+        const kind = .warning;
+    };
+    const ptr_assign_discards_quals = struct {
+        const msg = "assigning to {s} discards qualifiers";
+        const extra = .str;
+        const opt = "incompatible-pointer-types-discards-qualifiers";
+        const kind = .warning;
+    };
+    const unknown_attribute = struct {
+        const msg = "unknown attribute '{s}' ignored";
+        const extra = .str;
+        const opt = "unknown-attributes";
+        const kind = .warning;
+    };
+    const ignored_attribute = struct {
+        const msg = "{s}";
+        const extra = .str;
+        const opt = "ignored-attributes";
+        const kind = .warning;
+    };
+    const invalid_fallthrough = struct {
+        const msg = "fallthrough annotation does not directly precede switch label";
+        const kind = .@"error";
+    };
+    const cannot_apply_attribute_to_statement = struct {
+        const msg = "attribute cannot be applied to a statement";
+        const kind = .@"error";
+    };
+    const builtin_macro_redefined = struct {
+        const msg = "redefining builtin macro";
+        const opt = "builtin-macro-redefined";
+        const kind = .warning;
+    };
+    const feature_check_requires_identifier = struct {
+        const msg = "builtin feature check macro requires a parenthesized identifier";
+        const kind = .@"error";
+    };
+    const missing_tok_builtin = struct {
+        const msg = "missing '{s}', after builtin feature-check macro";
+        const extra = .tok_id_expected;
+        const kind = .@"error";
+    };
+    const gnu_label_as_value = struct {
+        const msg = "use of GNU address-of-label extension";
+        const opt = "gnu-label-as-value";
+        const kind = .off;
+    };
+    const expected_record_ty = struct {
+        const msg = "member reference base type '{s}' is not a structure or union";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const member_expr_not_ptr = struct {
+        const msg = "member reference type '{s}' is not a pointer; did you mean to use '.'?";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const member_expr_ptr = struct {
+        const msg = "member reference type '{s}' is a pointer; did you mean to use '->'?";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const no_such_member = struct {
+        const msg = "no member named {s}";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const malformed_warning_check = struct {
+        const msg = "{s} expected option name (e.g. \"-Wundef\")";
+        const extra = .str;
+        const opt = "malformed-warning-check";
+        const kind = .warning;
+    };
+    const invalid_computed_goto = struct {
+        const msg = "computed goto in function with no address-of-label expressions";
+        const kind = .@"error";
+    };
+    const pragma_warning_message = struct {
+        const msg = "{s}";
+        const extra = .str;
+        const opt = "#pragma-messages";
+        const kind = .warning;
+    };
+    const pragma_error_message = struct {
+        const msg = "{s}";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const pragma_requires_string_literal = struct {
+        const msg = "pragma {s} requires string literal";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const poisoned_identifier = struct {
+        const msg = "attempt to use a poisoned identifier";
+        const kind = .@"error";
+    };
+    const pragma_poison_identifier = struct {
+        const msg = "can only poison identifier tokens";
+        const kind = .@"error";
+    };
+    const pragma_poison_macro = struct {
+        const msg = "poisoning existing macro";
+        const kind = .warning;
+    };
+    const newline_eof = struct {
+        const msg = "no newline at end of file";
+        const opt = "newline-eof";
+        const kind = .off;
+    };
+    const empty_translation_unit = struct {
+        const msg = "ISO C requires a translation unit to contain at least one declaration";
+        const opt = "empty-translation-unit";
+        const kind = .off;
+    };
+    const omitting_parameter_name = struct {
+        const msg = "omitting the parameter name in a function definition is a C2x extension";
+        const opt = "c2x-extensions";
+        const kind = .warning;
+        const suppress_version = .c2x;
+    };
+    const non_int_bitfield = struct {
+        const msg = "bit-field has non-integer type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const negative_bitwidth = struct {
+        const msg = "bit-field has negative width ({d})";
+        const extra = .signed;
+        const kind = .@"error";
+    };
+    const zero_width_named_field = struct {
+        const msg = "named bit-field has zero width";
+        const kind = .@"error";
+    };
+    const bitfield_too_big = struct {
+        const msg = "width of bit-field exceeds width of its type";
+        const kind = .@"error";
+    };
+    const invalid_utf8 = struct {
+        const msg = "source file is not valid UTF-8";
+        const kind = .@"error";
+    };
+    const implicitly_unsigned_literal = struct {
+        const msg = "integer literal is too large to be represented in a signed integer type, interpreting as unsigned";
+        const opt = "implicitly-unsigned-literal";
+        const kind = .warning;
+    };
+    const invalid_preproc_operator = struct {
+        const msg = "token is not a valid binary operator in a preprocessor subexpression";
+        const kind = .@"error";
+    };
+    const invalid_preproc_expr_start = struct {
+        const msg = "invalid token at start of a preprocessor expression";
+        const kind = .@"error";
+    };
+    const c99_compat = struct {
+        const msg = "using this character in an identifier is incompatible with C99";
+        const opt = "c99-compat";
+        const kind = .warning;
+    };
+    const unicode_zero_width = struct {
+        const msg = "identifier contains Unicode character <U+{X:0>4}> that is invisible in some environments";
+        const opt = "unicode-homoglyph";
+        const extra = .actual_codepoint;
+        const kind = .warning;
+    };
+    const unicode_homoglyph = struct {
+        const msg = "treating Unicode character <U+{X:0>4}> as identifier character rather than as '{u}' symbol";
+        const extra = .codepoints;
+        const opt = "unicode-homoglyph";
+        const kind = .warning;
+    };
+    const pragma_inside_macro = struct {
+        const msg = "#pragma directive in macro expansion";
+        const kind = .@"error";
+    };
+    const meaningless_asm_qual = struct {
+        const msg = "meaningless '{s}' on assembly outside function";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const duplicate_asm_qual = struct {
+        const msg = "duplicate asm qualifier '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
+    const invalid_asm_str = struct {
+        const msg = "cannot use {s} string literal in assembly";
+        const extra = .str;
+        const kind = .@"error";
+    };
 };
 
 list: std.ArrayList(Message),
@@ -356,7 +1285,6 @@ pub fn set(diag: *Diagnostics, name: []const u8, to: Kind) !void {
     try diag.add(.{
         .tag = .unknown_warning,
         .extra = .{ .str = name },
-        .kind = .warning,
     });
 }
 
@@ -380,9 +1308,7 @@ pub fn deinit(diag: *Diagnostics) void {
 pub fn add(diag: *Diagnostics, msg: Message) Compilation.Error!void {
     const kind = diag.tagKind(msg.tag);
     if (kind == .off) return;
-    var copy = msg;
-    copy.kind = kind;
-    try diag.list.append(copy);
+    try diag.list.append(.{ .tag = msg.tag, .kind = kind, .loc = msg.loc, .extra = msg.extra });
     if (kind == .@"fatal error" or (kind == .@"error" and diag.fatal_errors))
         return error.FatalError;
 }
@@ -447,269 +1373,38 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
         }
 
         m.start(msg.kind);
-        switch (msg.tag) {
-            .todo => m.print("TODO: {s}", .{msg.extra.str}),
-            .error_directive => m.print("{s}", .{msg.extra.str}),
-            .elif_without_if => m.write("#elif without #if"),
-            .elif_after_else => m.write("#elif after #else"),
-            .else_without_if => m.write("#else without #if"),
-            .else_after_else => m.write("#else after #else"),
-            .endif_without_if => m.write("#endif without #if"),
-            .unsupported_pragma => m.print("unsupported #pragma directive '{s}'", .{msg.extra.str}),
-            .line_simple_digit => m.write("#line directive requires a simple digit sequence"),
-            .line_invalid_filename => m.write("invalid filename for #line directive"),
-            .unterminated_conditional_directive => m.write("unterminated conditional directive"),
-            .invalid_preprocessing_directive => m.write("invalid preprocessing directive"),
-            .macro_name_missing => m.write("macro name missing"),
-            .extra_tokens_directive_end => m.write("extra tokens at end of macro directive"),
-            .expected_value_in_expr => m.write("expected value in expression"),
-            .closing_paren => m.write("expected closing ')'"),
-            .to_match_paren => m.write("to match this '('"),
-            .to_match_brace => m.write("to match this '{'"),
-            .to_match_bracket => m.write("to match this '['"),
-            .header_str_closing => m.write("expected closing '>'"),
-            .header_str_match => m.write("to match this '<'"),
-            .string_literal_in_pp_expr => m.write("string literal in preprocessor expression"),
-            .float_literal_in_pp_expr => m.write("floating point literal in preprocessor expression"),
-            .defined_as_macro_name => m.write("'defined' cannot be used as a macro name"),
-            .macro_name_must_be_identifier => m.write("macro name must be an identifier"),
-            .whitespace_after_macro_name => m.write("ISO C99 requires whitespace after the macro name"),
-            .hash_hash_at_start => m.write("'##' cannot appear at the start of a macro expansion"),
-            .hash_hash_at_end => m.write("'##' cannot appear at the end of a macro expansion"),
-            .pasting_formed_invalid => m.print("pasting formed '{s}', an invalid preprocessing token", .{msg.extra.str}),
-            .missing_paren_param_list => m.write("missing ')' in macro parameter list"),
-            .unterminated_macro_param_list => m.write("unterminated macro param list"),
-            .invalid_token_param_list => m.write("invalid token in macro parameter list"),
-            .hash_not_followed_param => m.write("'#' is not followed by a macro parameter"),
-            .expected_filename => m.write("expected \"FILENAME\" or <FILENAME>"),
-            .empty_filename => m.write("empty filename"),
-            .expected_invalid => m.print("expected '{s}', found invalid bytes", .{msg.extra.tok_id.expected.symbol()}),
-            .expected_token => m.print("expected '{s}', found '{s}'", .{
-                msg.extra.tok_id.expected.symbol(),
-                msg.extra.tok_id.actual.symbol(),
-            }),
-            .expected_expr => m.write("expected expression"),
-            .expected_integer_constant_expr => m.write("expression is not an integer constant expression"),
-            .missing_type_specifier => m.write("type specifier missing, defaults to 'int'"),
-            .multiple_storage_class => m.print("cannot combine with previous '{s}' declaration specifier", .{msg.extra.str}),
-            .static_assert_failure => m.write("static assertion failed"),
-            .static_assert_failure_message => m.print("static assertion failed {s}", .{msg.extra.str}),
-            .expected_type => m.write("expected a type"),
-            .cannot_combine_spec => m.print("cannot combine with previous '{s}' specifier", .{msg.extra.str}),
-            .duplicate_decl_spec => m.print("duplicate '{s}' declaration specifier", .{msg.extra.str}),
-            .restrict_non_pointer => m.print("restrict requires a pointer or reference ('{s}' is invalid)", .{msg.extra.str}),
-            .expected_external_decl => m.write("expected external declaration"),
-            .expected_ident_or_l_paren => m.write("expected identifier or '('"),
-            .missing_declaration => m.write("declaration does not declare anything"),
-            .func_not_in_root => m.write("function definition is not allowed here"),
-            .illegal_initializer => m.write("illegal initializer (only variables can be initialized)"),
-            .extern_initializer => m.write("extern variable has initializer"),
-            .spec_from_typedef => m.print("'{s}' came from typedef", .{msg.extra.str}),
-            .type_is_invalid => m.print("'{s}' is invalid", .{msg.extra.str}),
-            .param_before_var_args => m.write("ISO C requires a named parameter before '...'"),
-            .void_only_param => m.write("'void' must be the only parameter if specified"),
-            .void_param_qualified => m.write("'void' parameter cannot be qualified"),
-            .void_must_be_first_param => m.write("'void' must be the first parameter if specified"),
-            .invalid_storage_on_param => m.write("invalid storage class on function parameter"),
-            .threadlocal_non_var => m.write("_Thread_local only allowed on variables"),
-            .func_spec_non_func => m.print("'{s}' can only appear on functions", .{msg.extra.str}),
-            .illegal_storage_on_func => m.write("illegal storage class on function"),
-            .illegal_storage_on_global => m.write("illegal storage class on global variable"),
-            .expected_stmt => m.write("expected statement"),
-            .func_cannot_return_func => m.write("function cannot return a function"),
-            .func_cannot_return_array => m.write("function cannot return an array"),
-            .undeclared_identifier => m.print("use of undeclared identifier '{s}'", .{msg.extra.str}),
-            .not_callable => m.print("cannot call non function type '{s}'", .{msg.extra.str}),
-            .unsupported_str_cat => m.write("unsupported string literal concatenation"),
-            .static_func_not_global => m.write("static functions must be global"),
-            .implicit_func_decl => m.print("implicit declaration of function '{s}' is invalid in C99", .{msg.extra.str}),
-            .expected_param_decl => m.write("expected parameter declaration"),
-            .invalid_old_style_params => m.write("identifier parameter lists are only allowed in function definitions"),
-            .expected_fn_body => m.write("expected function body after function declaration"),
-            .invalid_void_param => m.write("parameter cannot have void type"),
-            .unused_value => m.write("expression result unused"),
-            .continue_not_in_loop => m.write("'continue' statement not in a loop"),
-            .break_not_in_loop_or_switch => m.write("'break' statement not in a loop or a switch"),
-            .unreachable_code => m.write("unreachable code"),
-            .duplicate_label => m.print("duplicate label '{s}'", .{msg.extra.str}),
-            .previous_label => m.print("previous definition of label '{s}' was here", .{msg.extra.str}),
-            .undeclared_label => m.print("use of undeclared label '{s}'", .{msg.extra.str}),
-            .case_not_in_switch => m.print("'{s}' statement not in a switch statement", .{msg.extra.str}),
-            .duplicate_switch_case_signed => m.print("duplicate case value '{d}'", .{msg.extra.signed}),
-            .duplicate_switch_case_unsigned => m.print("duplicate case value '{d}'", .{msg.extra.unsigned}),
-            .multiple_default => m.write("multiple default cases in the same switch"),
-            .previous_case => m.write("previous case defined here"),
-            .expected_arguments, .expected_arguments_old => m.print("expected {d} argument(s) got {d}", .{ msg.extra.arguments.expected, msg.extra.arguments.actual }),
-            .expected_at_least_arguments => m.print("expected at least {d} argument(s) got {d}", .{ msg.extra.arguments.expected, msg.extra.arguments.actual }),
-            .invalid_static_star => m.write("'static' may not be used with an unspecified variable length array size"),
-            .static_non_param => m.write("'static' used outside of function parameters"),
-            .array_qualifiers => m.write("type qualifier in non parameter array type"),
-            .star_non_param => m.write("star modifier used outside of function parameters"),
-            .variable_len_array_file_scope => m.write("variable length arrays not allowed at file scope"),
-            .useless_static => m.write("'static' useless without a constant size"),
-            .negative_array_size => m.write("array size must be 0 or greater"),
-            .array_incomplete_elem => m.print("array has incomplete element type '{s}'", .{msg.extra.str}),
-            .array_func_elem => m.write("arrays cannot have functions as their element type"),
-            .static_non_outermost_array => m.write("'static' used in non-outermost array type"),
-            .qualifier_non_outermost_array => m.write("type qualifier used in non-outermost array type"),
-            .unterminated_macro_arg_list => m.write("unterminated function macro argument list"),
-            .unknown_warning => m.print("unknown warning '{s}'", .{msg.extra.str}),
-            .overflow_signed => m.print("overflow in expression; result is'{d}'", .{msg.extra.signed}),
-            .overflow_unsigned => m.print("overflow in expression; result is '{d}'", .{msg.extra.unsigned}),
-            .int_literal_too_big => m.write("integer literal is too large to be represented in any integer type"),
-            .indirection_ptr => m.write("indirection requires pointer operand"),
-            .addr_of_rvalue => m.write("cannot take the address of an rvalue"),
-            .not_assignable => m.write("expression is not assignable"),
-            .ident_or_l_brace => m.write("expected identifier or '{'"),
-            .empty_enum => m.write("empty enum is invalid"),
-            .redefinition => m.print("redefinition of '{s}'", .{msg.extra.str}),
-            .previous_definition => m.write("previous definition is here"),
-            .expected_identifier => m.write("expected identifier"),
-            .expected_str_literal => m.write("expected string literal for diagnostic message in static_assert"),
-            .expected_str_literal_in => m.print("expected string literal in '{s}'", .{msg.extra.str}),
-            .parameter_missing => m.print("parameter named '{s}' is missing", .{msg.extra.str}),
-            .empty_record => m.print("empty {s} is a GNU extension", .{msg.extra.str}),
-            .wrong_tag => m.print("use of '{s}' with tag type that does not match previous definition", .{msg.extra.str}),
-            .expected_parens_around_typename => m.write("expected parentheses around type name"),
-            .alignof_expr => m.write("'_Alignof' applied to an expression is a GNU extension"),
-            .invalid_sizeof => m.print("invalid application of 'sizeof' to an incomplete type '{s}'", .{msg.extra.str}),
-            .macro_redefined => m.print("'{s}' macro redefined", .{msg.extra.str}),
-            .generic_qual_type => m.write("generic association with qualifiers cannot be matched with"),
-            .generic_duplicate => m.print("type '{s}' in generic association compatible with previously specified type", .{msg.extra.str}),
-            .generic_duplicate_default => m.write("duplicate default generic association"),
-            .generic_no_match => m.print("controlling expression type '{s}' not compatible with any generic association type", .{msg.extra.str}),
-            .escape_sequence_overflow => m.write("escape sequence out of range"),
-            .invalid_universal_character => m.write("invalid universal character"),
-            .multichar_literal => m.write("multi-character character constant"),
-            .char_lit_too_wide => m.write("character constant too long for its type"),
-            .must_use_struct => m.print("must use 'struct' tag to refer to type '{s}'", .{msg.extra.str}),
-            .must_use_union => m.print("must use 'union' tag to refer to type '{s}'", .{msg.extra.str}),
-            .must_use_enum => m.print("must use 'enum' tag to refer to type '{s}'", .{msg.extra.str}),
-            .redefinition_different_sym => m.print("redefinition of '{s}' as different kind of symbol", .{msg.extra.str}),
-            .redefinition_incompatible => m.print("redefinition of '{s}' with a different type", .{msg.extra.str}),
-            .redefinition_of_parameter => m.print("redefinition of parameter '{s}'", .{msg.extra.str}),
-            .invalid_bin_types => m.print("invalid operands to binary expression ({s})", .{msg.extra.str}),
-            .comparison_ptr_int => m.print("comparison between pointer and integer ({s})", .{msg.extra.str}),
-            .comparison_distinct_ptr => m.print("comparison of distinct pointer types ({s})", .{msg.extra.str}),
-            .incompatible_pointers => m.print("incompatible pointer types ({s})", .{msg.extra.str}),
-            .invalid_argument_un => m.print("invalid argument type '{s}' to unary expression", .{msg.extra.str}),
-            .incompatible_assign => m.print("assignment to {s}", .{msg.extra.str}),
-            .implicit_ptr_to_int => m.print("implicit pointer to integer conversion from {s}", .{msg.extra.str}),
-            .invalid_cast_to_float => m.print("pointer cannot be cast to type '{s}'", .{msg.extra.str}),
-            .invalid_cast_to_pointer => m.print("operand of type '{s}' cannot be cast to a pointer type", .{msg.extra.str}),
-            .invalid_cast_type => m.print("cannot cast to non arithmetic or pointer type '{s}'", .{msg.extra.str}),
-            .qual_cast => m.print("cast to type '{s}' will not preserve qualifiers", .{msg.extra.str}),
-            .invalid_index => m.write("array subscript is not an integer"),
-            .invalid_subscript => m.write("subscripted value is not an array or pointer"),
-            .array_after => m.print("array index {d} is past the end of the array", .{msg.extra.unsigned}),
-            .array_before => m.print("array index {d} is before the beginning of the array", .{msg.extra.signed}),
-            .statement_int => m.print("statement requires expression with integer type ('{s}' invalid)", .{msg.extra.str}),
-            .statement_scalar => m.print("statement requires expression with scalar type ('{s}' invalid)", .{msg.extra.str}),
-            .func_should_return => m.print("non-void function '{s}' should return a value", .{msg.extra.str}),
-            .incompatible_return => m.print("returning '{s}' from a function with incompatible result type", .{msg.extra.str}),
-            .implicit_int_to_ptr => m.print("implicit integer to pointer conversion from {s}", .{msg.extra.str}),
-            .func_does_not_return => m.print("non-void function '{s}' does not return a value", .{msg.extra.str}),
-            .incompatible_param => m.print("passing '{s}' to parameter of incompatible type", .{msg.extra.str}),
-            .parameter_here => m.write("passing argument to parameter here"),
-            .atomic_array => m.print("atomic cannot be applied to array type '{s}'", .{msg.extra.str}),
-            .atomic_func => m.print("atomic cannot be applied to function type '{s}'", .{msg.extra.str}),
-            .atomic_incomplete => m.print("atomic cannot be applied to incomplete type '{s}'", .{msg.extra.str}),
-            .addr_of_register => m.write("address of register variable requested"),
-            .variable_incomplete_ty => m.print("variable has incomplete type '{s}'", .{msg.extra.str}),
-            .parameter_incomplete_ty => m.print("parameter has incomplete type '{s}'", .{msg.extra.str}),
-            .deref_incomplete_ty_ptr => m.print("dereferencing pointer to incomplete type '{s}'", .{msg.extra.str}),
-            .alignas_on_func => m.write("'_Alignas' attribute only applies to variables and fields"),
-            .alignas_on_param => m.write("'_Alignas' attribute cannot be applied to a function parameter"),
-            .minimum_alignment => m.print("requested alignment is less than minimum alignment of {d}", .{msg.extra.unsigned}),
-            .maximum_alignment => m.print("requested alignment of {d} is too large", .{msg.extra.unsigned}),
-            .negative_alignment => m.print("requested negative alignment of {d} is invalid", .{msg.extra.signed}),
-            .align_ignored => m.write("'_Alignas' attribute is ignored here"),
-            .zero_align_ignored => m.write("requested alignment of zero is ignored"),
-            .non_pow2_align => m.write("requested alignment is not a power of 2"),
-            .pointer_mismatch => m.print("pointer type mismatch ({s})", .{msg.extra.str}),
-            .static_assert_not_constant => m.write("static_assert expression is not an integral constant expression"),
-            .static_assert_missing_message => m.write("static_assert with no message is a C2X extension"),
-            .unbound_vla => m.write("variable length array must be bound in function definition"),
-            .array_too_large => m.write("array is too large"),
-            .incompatible_ptr_init => m.print("incompatible pointer types initializing {s}", .{msg.extra.str}),
-            .incompatible_ptr_assign => m.print("incompatible pointer types assigning to {s}", .{msg.extra.str}),
-            .vla_init => m.write("variable-sized object may not be initialized"),
-            .func_init => m.write("illegal initializer type"),
-            .incompatible_init => m.print("initializing {s}", .{msg.extra.str}),
-            .empty_scalar_init => m.write("scalar initializer cannot be empty"),
-            .excess_scalar_init => m.write("excess elements in scalar initializer"),
-            .excess_str_init => m.write("excess elements in string initializer"),
-            .excess_struct_init => m.write("excess elements in struct initializer"),
-            .excess_array_init => m.write("excess elements in array initializer"),
-            .str_init_too_long => m.write("initializer-string for char array is too long"),
-            .arr_init_too_long => m.print("cannot initialize type ({s})", .{msg.extra.str}),
-            .invalid_typeof => m.print("'{s} typeof' is invalid", .{msg.extra.str}),
-            .division_by_zero => m.print("{s} by zero is undefined", .{msg.extra.str}),
-            .division_by_zero_macro => m.print("{s} by zero in preprocessor expression", .{msg.extra.str}),
-            .builtin_choose_cond => m.write("'__builtin_choose_expr' requires a constant expression"),
-            .alignas_unavailable => m.write("'_Alignas' attribute requires integer constant expression"),
-            .case_val_unavailable => m.write("case value must be an integer constant expression"),
-            .enum_val_unavailable => m.write("enum value must be an integer constant expression"),
-            .incompatible_array_init => m.print("cannot initialize array of type {s}", .{msg.extra.str}),
-            .initializer_overrides => m.write("initializer overrides previous initialization"),
-            .previous_initializer => m.write("previous initialization"),
-            .invalid_array_designator => m.print("array designator used for non-array type '{s}'", .{msg.extra.str}),
-            .negative_array_designator => m.print("array designator value {d} is negative", .{msg.extra.signed}),
-            .oob_array_designator => m.print("array designator index {d} exceeds array bounds", .{msg.extra.unsigned}),
-            .invalid_field_designator => m.print("field designator used for non-record type '{s}'", .{msg.extra.str}),
-            .no_such_field_designator => m.print("record type has no field named '{s}'", .{msg.extra.str}),
-            .empty_aggregate_init_braces => m.write("initializer for aggregate with no elements requires explicit braces"),
-            .ptr_init_discards_quals => m.print("initializing {s} discards qualifiers", .{msg.extra.str}),
-            .ptr_assign_discards_quals => m.print("assigning to {s} discards qualifiers", .{msg.extra.str}),
-            .unknown_attribute => m.print("unknown attribute '{s}' ignored", .{msg.extra.str}),
-            .ignored_attribute => m.print("{s}", .{msg.extra.str}),
-            .invalid_fallthrough => m.write("fallthrough annotation does not directly precede switch label"),
-            .cannot_apply_attribute_to_statement => m.write("attribute cannot be applied to a statement"),
-            .builtin_macro_redefined => m.write("redefining builtin macro"),
-            .feature_check_requires_identifier => m.write("builtin feature check macro requires a parenthesized identifier"),
-            .missing_tok_builtin => m.print("missing '{s}', after builtin feature-check macro", .{msg.extra.tok_id.expected.symbol()}),
-            .gnu_label_as_value => m.write("use of GNU address-of-label extension"),
-            .expected_record_ty => m.print("member reference base type '{s}' is not a structure or union", .{msg.extra.str}),
-            .member_expr_not_ptr => m.print("member reference type '{s}' is not a pointer; did you mean to use '.'?", .{msg.extra.str}),
-            .member_expr_ptr => m.print("member reference type '{s}' is a pointer; did you mean to use '->'?", .{msg.extra.str}),
-            .no_such_member => m.print("no member named {s}", .{msg.extra.str}),
-            .malformed_warning_check => m.print("{s} expected option name (e.g. \"-Wundef\")", .{msg.extra.str}),
-            .invalid_computed_goto => m.write("computed goto in function with no address-of-label expressions"),
-            .pragma_warning_message, .pragma_error_message => m.write(msg.extra.str),
-            .pragma_requires_string_literal => m.print("pragma {s} requires string literal", .{msg.extra.str}),
-            .poisoned_identifier => m.write("attempt to use a poisoned identifier"),
-            .pragma_poison_identifier => m.write("can only poison identifier tokens"),
-            .pragma_poison_macro => m.write("poisoning existing macro"),
-            .newline_eof => m.write("no newline at end of file"),
-            .empty_translation_unit => m.write("ISO C requires a translation unit to contain at least one declaration"),
-            .omitting_parameter_name => m.write("omitting the parameter name in a function definition is a C2x extension"),
-            .non_int_bitfield => m.print("bit-field has non-integer type '{s}'", .{msg.extra.str}),
-            .negative_bitwidth => m.print("bit-field has negative width ({d})", .{msg.extra.signed}),
-            .zero_width_named_field => m.write("named bit-field has zero width"),
-            .bitfield_too_big => m.write("width of bit-field exceeds width of its type"),
-            .invalid_utf8 => m.write("source file is not valid UTF-8"),
-            .implicitly_unsigned_literal => m.write("integer literal is too large to be represented in a signed integer type, interpreting as unsigned"),
-            .invalid_preproc_operator => m.write("token is not a valid binary operator in a preprocessor subexpression"),
-            .invalid_preproc_expr_start => m.write("invalid token at start of a preprocessor expression"),
-            .c99_compat => m.write("using this character in an identifier is incompatible with C99"),
-            .unicode_zero_width => m.print("identifier contains Unicode character <U+{X:0>4}> that is invisible in some environments", .{
-                msg.extra.codepoints.actual,
-            }),
-            .unicode_homoglyph => m.print("treating Unicode character <U+{X:0>4}> as identifier character rather than as '{u}' symbol", .{
-                msg.extra.codepoints.actual,
-                msg.extra.codepoints.resembles,
-            }),
-            .pragma_inside_macro => m.write("#pragma directive in macro expansion"),
-            .meaningless_asm_qual => m.print("meaningless '{s}' on assembly outside function", .{msg.extra.str}),
-            .duplicate_asm_qual => m.print("duplicate asm qualifier '{s}'", .{msg.extra.str}),
-            .invalid_asm_str => m.print("cannot use {s} string literal in assembly", .{msg.extra.str}),
-        }
+        inline for (std.meta.fields(Tag)) |field| {
+            if (field.value == @enumToInt(msg.tag)) {
+                const info = @field(messages, field.name);
+                if (@hasDecl(info, "extra")) {
+                    switch (info.extra) {
+                        .str => m.print(info.msg, .{msg.extra.str}),
+                        .tok_id => m.print(info.msg, .{
+                            msg.extra.tok_id.expected.symbol(),
+                            msg.extra.tok_id.actual.symbol(),
+                        }),
+                        .tok_id_expected => m.print(info.msg, .{msg.extra.tok_id_expected.symbol()}),
+                        .arguments => m.print(info.msg, .{ msg.extra.arguments.expected, msg.extra.arguments.actual }),
+                        .codepoints => m.print(info.msg, .{
+                            msg.extra.codepoints.actual,
+                            msg.extra.codepoints.resembles,
+                        }),
+                        .actual_codepoint => m.print(info.msg, .{msg.extra.actual_codepoint}),
+                        .unsigned => m.print(info.msg, .{msg.extra.unsigned}),
+                        .signed => m.print(info.msg, .{msg.extra.signed}),
+                        else => unreachable,
+                    }
+                } else {
+                    m.write(info.msg);
+                }
 
-        if (comp.diag.tagOption(msg.tag)) |opt| {
-            if (msg.kind == .@"error") {
-                m.print(" [-Werror={s}]", .{opt});
-            } else {
-                m.print(" [-W{s}]", .{opt});
+                if (@hasDecl(info, "opt")) {
+                    if (@field(comp.diag.options, info.opt) != null and @field(comp.diag.options, info.opt).? == .@"error") {
+                        m.print(" [-Werror={s}]", .{info.opt});
+                    } else {
+                        m.print(" [-W{s}]", .{info.opt});
+                    }
+                }
             }
         }
 
@@ -744,328 +1439,27 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
     comp.diag.errors += errors;
 }
 
-fn tagOption(diag: *Diagnostics, tag: Tag) ?[]const u8 {
-    _ = diag;
-    return switch (tag) {
-        .unsupported_pragma => "unsupported-pragma",
-        .whitespace_after_macro_name => "c99-extensions",
-        .missing_type_specifier => "implicit-int",
-        .duplicate_decl_spec => "duplicate-decl-specifier",
-        .missing_declaration => "missing-declaration",
-        .extern_initializer => "extern-initializer",
-        .implicit_func_decl => "implicit-function-declaration",
-        .unused_value => "unused-value",
-        .unreachable_code => "unreachable-code",
-        .unknown_warning => "unknown-warning-option",
-        .empty_record => "empty-struct",
-        .alignof_expr => "gnu-alignof-expression",
-        .macro_redefined => "macro-redefined",
-        .generic_qual_type => "generic-qual-type",
-        .multichar_literal => "multichar",
-        .comparison_ptr_int => "pointer-integer-compare",
-        .comparison_distinct_ptr => "compare-distinct-pointer-types",
-        .implicit_ptr_to_int => "literal-conversion",
-        .qual_cast => "cast-qualifiers",
-        .array_after => "array-bounds",
-        .array_before => "array-bounds",
-        .implicit_int_to_ptr => "int-conversion",
-        .pointer_mismatch => "pointer-type-mismatch",
-        .omitting_parameter_name,
-        .static_assert_missing_message,
-        => "c2x-extension",
-        .incompatible_ptr_init,
-        .incompatible_ptr_assign,
-        => "incompatible-pointer-types",
-        .ptr_init_discards_quals,
-        .ptr_assign_discards_quals,
-        => "incompatible-pointer-types-discards-qualifiers",
-        .excess_scalar_init,
-        .excess_str_init,
-        .excess_struct_init,
-        .excess_array_init,
-        .str_init_too_long,
-        => "excess-initializers",
-        .division_by_zero => "division-by-zero",
-        .initializer_overrides => "initializer-overrides",
-        .unknown_attribute => "unknown-attributes",
-        .ignored_attribute => "ignored-attributes",
-        .builtin_macro_redefined => "builtin-macro-redefined",
-        .gnu_label_as_value => "gnu-label-as-value",
-        .malformed_warning_check => "malformed-warning-check",
-        .pragma_warning_message => "#pragma-messages",
-        .newline_eof => "newline-eof",
-        .empty_translation_unit => "empty-translation-unit",
-        .implicitly_unsigned_literal => "implicitly-unsigned-literal",
-        .c99_compat => "c99-compat",
-        .unicode_zero_width => "unicode-zero-width",
-        .unicode_homoglyph => "unicode-homoglyph",
-        else => null,
-    };
-}
-
-pub const Kind = enum { @"fatal error", @"error", note, warning, off };
-
 fn tagKind(diag: *Diagnostics, tag: Tag) Kind {
-    var kind: Kind = switch (tag) {
-        .todo,
-        .error_directive,
-        .elif_without_if,
-        .elif_after_else,
-        .else_without_if,
-        .else_after_else,
-        .endif_without_if,
-        .line_simple_digit,
-        .line_invalid_filename,
-        .unterminated_conditional_directive,
-        .invalid_preprocessing_directive,
-        .macro_name_missing,
-        .extra_tokens_directive_end,
-        .expected_value_in_expr,
-        .closing_paren,
-        .header_str_closing,
-        .string_literal_in_pp_expr,
-        .float_literal_in_pp_expr,
-        .defined_as_macro_name,
-        .macro_name_must_be_identifier,
-        .hash_hash_at_start,
-        .hash_hash_at_end,
-        .pasting_formed_invalid,
-        .missing_paren_param_list,
-        .unterminated_macro_param_list,
-        .invalid_token_param_list,
-        .hash_not_followed_param,
-        .expected_filename,
-        .empty_filename,
-        .expected_invalid,
-        .expected_token,
-        .expected_expr,
-        .expected_integer_constant_expr,
-        .multiple_storage_class,
-        .static_assert_failure,
-        .static_assert_failure_message,
-        .expected_type,
-        .cannot_combine_spec,
-        .restrict_non_pointer,
-        .expected_external_decl,
-        .expected_ident_or_l_paren,
-        .func_not_in_root,
-        .illegal_initializer,
-        .type_is_invalid,
-        .param_before_var_args,
-        .void_only_param,
-        .void_param_qualified,
-        .void_must_be_first_param,
-        .invalid_storage_on_param,
-        .threadlocal_non_var,
-        .func_spec_non_func,
-        .illegal_storage_on_func,
-        .illegal_storage_on_global,
-        .expected_stmt,
-        .func_cannot_return_func,
-        .func_cannot_return_array,
-        .undeclared_identifier,
-        .not_callable,
-        .unsupported_str_cat,
-        .static_func_not_global,
-        .expected_param_decl,
-        .expected_fn_body,
-        .invalid_void_param,
-        .continue_not_in_loop,
-        .break_not_in_loop_or_switch,
-        .duplicate_label,
-        .undeclared_label,
-        .case_not_in_switch,
-        .duplicate_switch_case_signed,
-        .duplicate_switch_case_unsigned,
-        .multiple_default,
-        .expected_arguments,
-        .expected_at_least_arguments,
-        .invalid_static_star,
-        .static_non_param,
-        .array_qualifiers,
-        .star_non_param,
-        .variable_len_array_file_scope,
-        .negative_array_size,
-        .array_incomplete_elem,
-        .array_func_elem,
-        .static_non_outermost_array,
-        .qualifier_non_outermost_array,
-        .unterminated_macro_arg_list,
-        .int_literal_too_big,
-        .indirection_ptr,
-        .addr_of_rvalue,
-        .not_assignable,
-        .ident_or_l_brace,
-        .empty_enum,
-        .redefinition,
-        .expected_identifier,
-        .wrong_tag,
-        .expected_str_literal,
-        .expected_str_literal_in,
-        .parameter_missing,
-        .expected_parens_around_typename,
-        .invalid_sizeof,
-        .generic_duplicate,
-        .generic_duplicate_default,
-        .generic_no_match,
-        .escape_sequence_overflow,
-        .invalid_universal_character,
-        .must_use_struct,
-        .must_use_union,
-        .must_use_enum,
-        .redefinition_different_sym,
-        .redefinition_incompatible,
-        .redefinition_of_parameter,
-        .invalid_bin_types,
-        .incompatible_pointers,
-        .invalid_argument_un,
-        .incompatible_assign,
-        .invalid_cast_to_float,
-        .invalid_cast_to_pointer,
-        .invalid_cast_type,
-        .invalid_index,
-        .invalid_subscript,
-        .statement_int,
-        .statement_scalar,
-        .func_should_return,
-        .incompatible_return,
-        .incompatible_param,
-        .atomic_array,
-        .atomic_func,
-        .atomic_incomplete,
-        .addr_of_register,
-        .variable_incomplete_ty,
-        .parameter_incomplete_ty,
-        .alignas_on_func,
-        .alignas_on_param,
-        .minimum_alignment,
-        .maximum_alignment,
-        .negative_alignment,
-        .non_pow2_align,
-        .static_assert_not_constant,
-        .unbound_vla,
-        .array_too_large,
-        .vla_init,
-        .func_init,
-        .incompatible_init,
-        .empty_scalar_init,
-        .arr_init_too_long,
-        .invalid_typeof,
-        .builtin_choose_cond,
-        .alignas_unavailable,
-        .case_val_unavailable,
-        .enum_val_unavailable,
-        .incompatible_array_init,
-        .invalid_array_designator,
-        .negative_array_designator,
-        .oob_array_designator,
-        .invalid_field_designator,
-        .no_such_field_designator,
-        .empty_aggregate_init_braces,
-        .invalid_fallthrough,
-        .cannot_apply_attribute_to_statement,
-        .missing_tok_builtin,
-        .feature_check_requires_identifier,
-        .expected_record_ty,
-        .member_expr_not_ptr,
-        .member_expr_ptr,
-        .no_such_member,
-        .invalid_computed_goto,
-        .pragma_requires_string_literal,
-        .pragma_error_message,
-        .poisoned_identifier,
-        .pragma_poison_identifier,
-        .non_int_bitfield,
-        .negative_bitwidth,
-        .zero_width_named_field,
-        .bitfield_too_big,
-        .division_by_zero_macro,
-        .invalid_utf8,
-        .deref_incomplete_ty_ptr,
-        .invalid_preproc_operator,
-        .invalid_preproc_expr_start,
-        .pragma_inside_macro,
-        .meaningless_asm_qual,
-        .duplicate_asm_qual,
-        .invalid_asm_str,
-        => .@"error",
-        .to_match_paren,
-        .to_match_brace,
-        .to_match_bracket,
-        .header_str_match,
-        .spec_from_typedef,
-        .previous_label,
-        .previous_case,
-        .previous_definition,
-        .parameter_here,
-        .previous_initializer,
-        => .note,
-        .invalid_old_style_params,
-        .expected_arguments_old,
-        .useless_static,
-        .overflow_unsigned,
-        .overflow_signed,
-        .char_lit_too_wide,
-        .func_does_not_return,
-        .align_ignored,
-        .zero_align_ignored,
-        .pragma_poison_macro,
-        => .warning,
-        .unsupported_pragma => diag.options.@"unsupported-pragma",
-        .whitespace_after_macro_name => diag.options.@"c99-extensions",
-        .missing_type_specifier => diag.options.@"implicit-int",
-        .duplicate_decl_spec => diag.options.@"duplicate-decl-specifier",
-        .missing_declaration => diag.options.@"missing-declaration",
-        .extern_initializer => diag.options.@"extern-initializer",
-        .implicit_func_decl => diag.options.@"implicit-function-declaration",
-        .unused_value => diag.options.@"unused-value",
-        .unreachable_code => diag.options.@"unreachable-code",
-        .unknown_warning => diag.options.@"unknown-warning-option",
-        .empty_record => diag.options.@"empty-struct",
-        .alignof_expr => diag.options.@"gnu-alignof-expression",
-        .macro_redefined => diag.options.@"macro-redefined",
-        .generic_qual_type => diag.options.@"generic-qual-type",
-        .multichar_literal => diag.options.multichar,
-        .comparison_ptr_int => diag.options.@"pointer-integer-compare",
-        .comparison_distinct_ptr => diag.options.@"compare-distinct-pointer-types",
-        .implicit_ptr_to_int => diag.options.@"literal-conversion",
-        .qual_cast => diag.options.@"cast-qualifiers",
-        .array_after => diag.options.@"array-bounds",
-        .array_before => diag.options.@"array-bounds",
-        .implicit_int_to_ptr => diag.options.@"int-conversion",
-        .pointer_mismatch => diag.options.@"pointer-type-mismatch",
-        .omitting_parameter_name,
-        .static_assert_missing_message,
-        => diag.options.@"c2x-extension",
-        .incompatible_ptr_init,
-        .incompatible_ptr_assign,
-        => diag.options.@"incompatible-pointer-types",
-        .ptr_init_discards_quals,
-        .ptr_assign_discards_quals,
-        => diag.options.@"incompatible-pointer-types-discards-qualifiers",
-        .excess_scalar_init,
-        .excess_str_init,
-        .excess_struct_init,
-        .excess_array_init,
-        .str_init_too_long,
-        => diag.options.@"excess-initializers",
-        .division_by_zero => diag.options.@"division-by-zero",
-        .initializer_overrides => diag.options.@"initializer-overrides",
-        .unknown_attribute => diag.options.@"unknown-attributes",
-        .ignored_attribute => diag.options.@"ignored-attributes",
-        .builtin_macro_redefined => diag.options.@"builtin-macro-redefined",
-        .gnu_label_as_value => diag.options.@"gnu-label-as-value",
-        .malformed_warning_check => diag.options.@"malformed-warning-check",
-        .pragma_warning_message => diag.options.@"#pragma-messages",
-        .newline_eof => diag.options.@"newline-eof",
-        .empty_translation_unit => diag.options.@"empty-translation-unit",
-        .implicitly_unsigned_literal => diag.options.@"implicitly-unsigned-literal",
-        .c99_compat => diag.options.@"c99-compat",
-        .unicode_zero_width => diag.options.@"unicode-zero-width",
-        .unicode_homoglyph => diag.options.@"unicode-homoglyph",
-    };
-    if (kind == .@"error" and diag.fatal_errors) kind = .@"fatal error";
-    return kind;
+    // XXX: horrible hack, do not do this
+    const comp = @fieldParentPtr(Compilation, "diag", diag);
+
+    var kind: Kind = undefined;
+    inline for (std.meta.fields(Tag)) |field| {
+        if (field.value == @enumToInt(tag)) {
+            const info = @field(messages, field.name);
+            kind = info.kind;
+
+            // stage1 doesn't like when I combine these ifs
+            if (@hasDecl(info, "opt")) {
+                if (@field(diag.options, info.opt)) |some| kind = some;
+            }
+            if (@hasDecl(info, "suppress_version")) if (comp.langopts.standard.atLeast(info.suppress_version)) return .off;
+            if (@hasDecl(info, "suppress_gnu")) if (comp.langopts.standard.isExplicitGNU()) return .off;
+            if (kind == .@"error" and diag.fatal_errors) kind = .@"fatal error";
+            return kind;
+        }
+    }
+    unreachable;
 }
 
 const MsgWriter = struct {

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -98,6 +98,7 @@ pub const Options = struct {
     @"c99-compat": ?Kind = null,
     @"unicode-zero-width": ?Kind = null,
     @"unicode-homoglyph": ?Kind = null,
+    @"return-type": ?Kind = null,
 };
 
 const messages = struct {
@@ -806,6 +807,7 @@ const messages = struct {
     const func_should_return = struct {
         const msg = "non-void function '{s}' should return a value";
         const extra = .str;
+        const opt = "return-type";
         const kind = .@"error";
     };
     const incompatible_return = struct {
@@ -822,7 +824,14 @@ const messages = struct {
     const func_does_not_return = struct {
         const msg = "non-void function '{s}' does not return a value";
         const extra = .str;
+        const opt = "return-type";
         const kind = .warning;
+    };
+    const void_func_returns_value = struct {
+        const msg = "void function '{s}' should not return a value";
+        const extra = .str;
+        const opt = "return-type";
+        const kind = .@"error";
     };
     const incompatible_param = struct {
         const msg = "passing '{s}' to parameter of incompatible type";

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -76,13 +76,3 @@ short_enums: bool = false,
 pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!void {
     self.standard = Standard.NameMap.get(name) orelse return error.InvalidStandard;
 }
-
-pub fn suppress(langopts: LangOpts, tag: DiagnosticTag) bool {
-    return switch (tag) {
-        .omitting_parameter_name,
-        .static_assert_missing_message,
-        => langopts.standard.atLeast(.c2x),
-        .alignof_expr => langopts.standard.isExplicitGNU(),
-        else => false,
-    };
-}

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -3480,9 +3480,12 @@ fn returnStmt(p: *Parser) Error!?NodeIndex {
     if (e.node == .none) {
         if (!ret_ty.is(.void)) try p.errStr(.func_should_return, ret_tok, p.tokSlice(p.func_name));
         return try p.addNode(.{ .tag = .return_stmt, .data = .{ .un = e.node } });
+    } else if (ret_ty.is(.void)) {
+        try p.errStr(.void_func_returns_value, e_tok, p.tokSlice(p.func_name));
+        return try p.addNode(.{ .tag = .return_stmt, .data = .{ .un = e.node } });
     }
-    try e.lvalConversion(p);
 
+    try e.lvalConversion(p);
     // Return type conversion is done as if it was assignment
     if (ret_ty.is(.bool)) {
         // this is ridiculous but it's what clang does
@@ -3519,10 +3522,8 @@ fn returnStmt(p: *Parser) Error!?NodeIndex {
         if (!ret_ty.eql(e.ty, false)) {
             try p.errStr(.incompatible_return, e_tok, try p.typeStr(e.ty));
         }
-    } else {
-        // should be unreachable
-        try p.errStr(.incompatible_return, e_tok, try p.typeStr(e.ty));
-    }
+    } else unreachable;
+
     try e.saveValue(p);
     return try p.addNode(.{ .tag = .return_stmt, .data = .{ .un = e.node } });
 }

--- a/src/pragmas/once.zig
+++ b/src/pragmas/once.zig
@@ -42,7 +42,7 @@ fn preprocessorHandler(pragma: *Pragma, pp: *Preprocessor, start_idx: TokenIndex
     const name_tok = pp.tokens.get(start_idx);
     const next = pp.tokens.get(start_idx + 1);
     if (next.id != .nl) {
-        try pp.comp.addDiagnostic(.{
+        try pp.comp.diag.add(.{
             .tag = .extra_tokens_directive_end,
             .loc = name_tok.loc,
         });

--- a/test/cases/adjust diagnostic levels.c
+++ b/test/cases/adjust diagnostic levels.c
@@ -12,7 +12,7 @@
 // #pragma GCC diagnostic push
 // #pragma GCC diagnostic pop
 
-#define EXPECTED_ERRORS "adjust diagnostic levels.c:2:9: warning: 'FOO' macro redefined" \
-	"adjust diagnostic levels.c:6:9: error: 'BAR' macro redefined"
+#define EXPECTED_ERRORS "adjust diagnostic levels.c:2:9: warning: 'FOO' macro redefined [-Wmacro-redefined]" \
+	"adjust diagnostic levels.c:6:9: error: 'BAR' macro redefined [-Wmacro-redefined]"
 
 #define TESTS_SKIPPED 2

--- a/test/cases/functions.c
+++ b/test/cases/functions.c
@@ -57,7 +57,7 @@ enum EE e;
 
 #define EXPECTED_ERRORS "functions.c:10:12: error: parameter named 'quux' is missing" \
     "functions.c:20:14: error: illegal initializer (only variables can be initialized)" \
-    "functions.c:18:2: warning: non-void function 'foooo' does not return a value" \
+    "functions.c:18:2: warning: non-void function 'foooo' does not return a value [-Wreturn-type]" \
     "functions.c:22:13: error: variable length array must be bound in function definition" \
     "functions.c:42:35: error: parameter has incomplete type 'struct S'" \
     "functions.c:44:10: error: parameter has incomplete type 'struct S'" \

--- a/test/cases/return.c
+++ b/test/cases/return.c
@@ -26,6 +26,15 @@ int *ip(void) {
     return &a;
 }
 
+int foo(void) {
+}
+int bar(void) {
+    return;
+}
+void baz(void) {
+    return 1;
+}
+
 #define EXPECTED_ERRORS "return.c:2:5: error: non-void function 'b' should return a value" \
     "return.c:3:5: warning: unreachable code" \
     "return.c:6:12: error: returning 'void' from a function with incompatible result type" \
@@ -36,4 +45,7 @@ int *ip(void) {
     "return.c:22:12: warning: implicit integer to pointer conversion from 'int' to 'int *'" \
     "return.c:23:5: warning: unreachable code" \
     "return.c:24:12: error: returning 'float *' from a function with incompatible result type" \
-    "return.c:26:12: error: returning '_Atomic(int) (*)[3]' from a function with incompatible result type"
+    "return.c:26:12: error: returning '_Atomic(int) (*)[3]' from a function with incompatible result type" \
+    "return.c:30:1: warning: non-void function 'foo' does not return a value [-Wreturn-type]" \
+    "return.c:32:5: error: non-void function 'bar' should return a value [-Wreturn-type]" \
+    "return.c:35:12: error: void function 'baz' should not return a value [-Wreturn-type]" \

--- a/test/cases/sizeof alignof.c
+++ b/test/cases/sizeof alignof.c
@@ -23,5 +23,5 @@ _Static_assert(sizeof((void)1, (int*)0) == sizeof(int*), "sizeof");
 
 #define EXPECTED_ERRORS "sizeof alignof.c:10:19: error: expected parentheses around type name" \
     "sizeof alignof.c:10:37: error: expected parentheses around type name" \
-    "sizeof alignof.c:14:32: warning: '_Alignof' applied to an expression is a GNU extension" \
-    "sizeof alignof.c:19:20: warning: '_Alignof' applied to an expression is a GNU extension"
+    "sizeof alignof.c:14:32: warning: '_Alignof' applied to an expression is a GNU extension [-Wgnu-alignof-expression]" \
+    "sizeof alignof.c:19:20: warning: '_Alignof' applied to an expression is a GNU extension [-Wgnu-alignof-expression]"

--- a/test/cases/static assert messages.c
+++ b/test/cases/static assert messages.c
@@ -11,8 +11,8 @@ void bar(void) {
 _Static_assert(1 == 0, "They are not equal!");
 
 #define EXPECTED_ERRORS "static assert messages.c:2:20: error: static_assert expression is not an integral constant expression" \
-    "static assert messages.c:3:5: warning: static_assert with no message is a C2X extension" \
-    "static assert messages.c:4:5: warning: static_assert with no message is a C2X extension" \
+    "static assert messages.c:3:5: warning: static_assert with no message is a C2X extension [-Wc2x-extensions]" \
+    "static assert messages.c:4:5: warning: static_assert with no message is a C2X extension [-Wc2x-extensions]" \
     "static assert messages.c:4:5: error: static assertion failed" \
     "static assert messages.c:8:27: error: expected ')', found ','" \
     "static assert messages.c:8:19: note: to match this '('" \


### PR DESCRIPTION
A long overdue quality of life improvement to the diagnostics system so that you only have to modify one plave to add a new error instead of 4-5 spread accross many files.

Closes #81.