### PR TITLE
Parser: parse attributes at end of record field decls

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -917,14 +917,7 @@ fn decl(p: *Parser) Error!bool {
         if (init_d.d.old_style_func) |tok_i| try p.errTok(.invalid_old_style_params, tok_i);
         const tag = try decl_spec.validate(p, &init_d.d.ty, init_d.initializer != .none);
         const attrs = p.attr_buf.items[attr_buf_top..];
-        if (attrs.len > 0) {
-            var attributed_type = try p.arena.create(Type.Attributed);
-            attributed_type.* = .{
-                .attributes = try p.arena.dupe(Attribute, attrs),
-                .base = init_d.d.ty,
-            };
-            init_d.d.ty = .{ .specifier = .attributed, .data = .{ .attributed = attributed_type } };
-        }
+        init_d.d.ty = try init_d.d.ty.withAttributes(p.arena, attrs);
 
         const node = try p.addNode(.{ .ty = init_d.d.ty, .tag = tag, .data = .{
             .decl = .{ .name = init_d.d.name, .node = init_d.initializer },
@@ -3193,12 +3186,7 @@ fn stmt(p: *Parser) Error!NodeIndex {
                 // but only if they close a compound statement)
                 try p.errTok(.invalid_fallthrough, expr_start);
             }
-            var attributed_type = try p.arena.create(Type.Attributed);
-            attributed_type.* = .{
-                .attributes = try p.arena.dupe(Attribute, attrs),
-                .base = null_node.ty,
-            };
-            null_node.ty = .{ .specifier = .attributed, .data = .{ .attributed = attributed_type } };
+            null_node.ty = try null_node.ty.withAttributes(p.arena, attrs);
         }
         return p.addNode(null_node);
     }

--- a/test/cases/attributes.c
+++ b/test/cases/attributes.c
@@ -86,6 +86,12 @@ extern int abs (int __x) __attribute__((__nothrow__ )) __attribute__((__const__)
 typedef int X();
 X x __attribute__((cold));
 
+typedef struct {
+  __attribute__((__aligned__(__alignof__(long long)))) long long __clang_max_align_nonce1, __attribute__((packed)) nonce2, nonce3;
+  long double __clang_max_align_nonce2
+      __attribute__((__aligned__(__alignof__(long double))));
+} max_align_t;
+
 #define EXPECTED_ERRORS "attributes.c:8:26: warning: Attribute 'noreturn' ignored in variable context" \
     "attributes.c:9:26: warning: unknown attribute 'does_not_exist' ignored" \
     "attributes.c:27:20: warning: Attribute 'deprecated' ignored in label context" \


### PR DESCRIPTION
Fixes #140

I manually verified that the provided test case matches clang's behavior (`__clang_max_align_nonce1` gets an `__aligned__(8)` attribute, `nonce2` gets `__aligned__(8)` and `packed`, `nonce3` gets `__aligned__(8)`, and `__clang_max_align_nonce2` gets `__aligned__(8)`). I don't have any good ideas of how to test this though - any thoughts?