### PR TITLE
Preprocessor: Fix comment after simple #define causing it to skip newline

### DIFF
--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -1242,11 +1242,10 @@ fn define(pp: *Preprocessor, tokenizer: *Tokenizer) Error!void {
     first.id.simplifyMacroKeyword();
 
     pp.token_buf.items.len = 0; // Safe to use since we can only be in one directive at a time.
-    try pp.token_buf.append(first);
 
     // Collect the token body and validate any ## found.
+    var tok = first;
     while (true) {
-        var tok = tokenizer.next();
         tok.id.simplifyMacroKeyword();
         switch (tok.id) {
             .hash_hash => {
@@ -1268,6 +1267,7 @@ fn define(pp: *Preprocessor, tokenizer: *Tokenizer) Error!void {
             .nl, .eof => break,
             else => try pp.token_buf.append(tok),
         }
+        tok = tokenizer.next();
     }
 
     const list = try pp.arena.allocator.dupe(RawToken, pp.token_buf.items);

--- a/test/cases/comment after define.c
+++ b/test/cases/comment after define.c
@@ -1,0 +1,7 @@
+#define FOO /* comment */
+#if 0
+#endif
+
+#define BAR // comment
+#if 0
+#endif


### PR DESCRIPTION
As it turns out, comment after simple #define (i.e the one without any value or function) causes it to skip the newline present in the current line and instead makes it to read till the eol of next line.

Example, the following snippet gives unexpected results:
```c
#define Y // test
#if 0
#endif  

Y;
```

arocc -E: (with error: ``error: #endif without #if``)
```c
#if 0;
```

with this PR: (which matches gcc and clang results)
```c
;
```

Possible reason:
``.whitespace => first = tokenizer.next()`` skips away the whitespace and then ``token_buf.append(first)`` appends the newline without checking.