### PR TITLE
Reverse order of macro backtrace, make generated behave more like other sources

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -214,10 +214,7 @@ fn tokSlice(p: *Parser, tok: TokenIndex) []const u8 {
     if (p.tok_ids[tok].lexeme()) |some| return some;
     const loc = p.pp.tokens.items(.loc)[tok];
     var tmp_tokenizer = Tokenizer{
-        .buf = if (loc.id == .generated)
-            p.pp.generated.items
-        else
-            p.pp.comp.getSource(loc.id).buf,
+        .buf = p.pp.comp.getSource(loc.id).buf,
         .comp = p.pp.comp,
         .index = loc.byte_offset,
         .source = .generated,
@@ -664,7 +661,7 @@ pub fn parse(pp: *Preprocessor) Compilation.Error!Tree {
         .comp = pp.comp,
         .tokens = pp.tokens.slice(),
         .arena = arena,
-        .generated = pp.generated.items,
+        .generated = pp.comp.generated_buf.items,
         .nodes = p.nodes.toOwnedSlice(),
         .data = p.data.toOwnedSlice(),
         .root_decls = root_decls,

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -577,10 +577,7 @@ pub fn tokSlice(tree: Tree, tok_i: TokenIndex) []const u8 {
     if (tree.tokens.items(.id)[tok_i].lexeme()) |some| return some;
     const loc = tree.tokens.items(.loc)[tok_i];
     var tmp_tokenizer = Tokenizer{
-        .buf = if (loc.id == .generated)
-            tree.generated
-        else
-            tree.comp.getSource(loc.id).buf,
+        .buf = tree.comp.getSource(loc.id).buf,
         .comp = tree.comp,
         .index = loc.byte_offset,
         .source = .generated,

--- a/src/main.zig
+++ b/src/main.zig
@@ -61,12 +61,14 @@ const usage =
     \\  -E                      Only run the preprocessor
     \\  -fcolor-diagnostics     Enable colors in diagnostics
     \\  -fno-color-diagnostics  Disable colors in diagnostics
-    \\  -fshort-enums           Use the narrowest possible integer type for enums.
-    \\  -fno-short-enums        Use "int" as the tag type for enums.
     \\  -fdollars-in-identifiers        
     \\                          Allow '$' in identifiers
     \\  -fno-dollars-in-identifiers     
     \\                          Disallow '$' in identifiers
+    \\  -fmacro-backtrace-limit=<limit>
+    \\                          Set limit on how many macro expansion traces are shown in errors (default 6)
+    \\  -fshort-enums           Use the narrowest possible integer type for enums
+    \\  -fno-short-enums        Use "int" as the tag type for enums
     \\  -I <dir>                Add directory to include search path
     \\  -isystem                Add directory to SYSTEM include search path
     \\  -o <file>               Write output to <file>
@@ -143,14 +145,21 @@ fn handleArgs(comp: *Compilation, args: [][]const u8) !void {
                 comp.diag.color = true;
             } else if (mem.eql(u8, arg, "-fno-color-diagnostics")) {
                 comp.diag.color = false;
-            } else if (mem.eql(u8, arg, "-fshort-enums")) {
-                comp.langopts.short_enums = true;
-            } else if (mem.eql(u8, arg, "-fno-short-enums")) {
-                comp.langopts.short_enums = false;
             } else if (mem.eql(u8, arg, "-fdollars-in-identifiers")) {
                 comp.langopts.dollars_in_identifiers = true;
             } else if (mem.eql(u8, arg, "-fno-dollars-in-identifiers")) {
                 comp.langopts.dollars_in_identifiers = false;
+            } else if (mem.startsWith(u8, arg, "-fmacro-backtrace-limit=")) {
+                const limit_str = arg["-fmacro-backtrace-limit=".len..];
+                var limit = std.fmt.parseInt(u32, limit_str, 10) catch
+                    return comp.diag.fatalNoSrc("-fmacro-backtrace-limit takes a number argument", .{});
+
+                if (limit == 0) limit = std.math.maxInt(u32);
+                comp.diag.macro_backtrace_limit = limit;
+            } else if (mem.eql(u8, arg, "-fshort-enums")) {
+                comp.langopts.short_enums = true;
+            } else if (mem.eql(u8, arg, "-fno-short-enums")) {
+                comp.langopts.short_enums = false;
             } else if (mem.startsWith(u8, arg, "-I")) {
                 var path = arg["-I".len..];
                 if (path.len == 0) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -253,6 +253,7 @@ fn handleArgs(comp: *Compilation, args: [][]const u8) !void {
 }
 
 fn processSource(comp: *Compilation, source: Source, builtin: Source, user_macros: Source) !void {
+    comp.generated_buf.items.len = 0;
     var pp = Preprocessor.init(comp);
     defer pp.deinit();
     try pp.addBuiltinMacros();

--- a/src/pragmas/once.zig
+++ b/src/pragmas/once.zig
@@ -45,7 +45,7 @@ fn preprocessorHandler(pragma: *Pragma, pp: *Preprocessor, start_idx: TokenIndex
         try pp.comp.diag.add(.{
             .tag = .extra_tokens_directive_end,
             .loc = name_tok.loc,
-        });
+        }, next.expansionSlice());
     }
     const seen = self.preprocess_count == pp.preprocess_count;
     const prev = try self.pragma_once.fetchPut(name_tok.loc.id, {});

--- a/test/cases/generated location.c
+++ b/test/cases/generated location.c
@@ -1,3 +1,4 @@
 __has_attribute(foo)
 
-#define EXPECTED_ERRORS "generated location.c:1:1: error: expected external declaration"
+#define EXPECTED_ERRORS "generated location.c:1:1: error: expected external declaration" \
+    "generated location.c:1:1: note: expanded from here" \

--- a/test/cases/generated location.c
+++ b/test/cases/generated location.c
@@ -1,4 +1,4 @@
 __has_attribute(foo)
 
 #define EXPECTED_ERRORS "generated location.c:1:1: error: expected external declaration" \
-    "generated location.c:1:1: note: expanded from here" \
+    "<scratch space>:1:1: note: expanded from here" \

--- a/test/cases/macro backtrace.c
+++ b/test/cases/macro backtrace.c
@@ -1,0 +1,96 @@
+#define a 1 ## 2
+#define b a
+#define c b
+#define d c
+#define e d
+#define f e
+#define g f
+#define h g
+#define i h
+#define j i
+#define k j
+a
+b
+c
+d
+e
+f
+g
+h
+i
+j
+k
+
+#define EXPECTED_ERRORS "macro backtrace.c:12:1: error: expected external declaration" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:1:1: note: expanded from here" \
+    "macro backtrace.c:13:1: error: expected external declaration" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:2:1: note: expanded from here" \
+    "macro backtrace.c:14:1: error: expected external declaration" \
+    "macro backtrace.c:3:11: note: expanded from here" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:3:1: note: expanded from here" \
+    "macro backtrace.c:15:1: error: expected external declaration" \
+    "macro backtrace.c:4:11: note: expanded from here" \
+    "macro backtrace.c:3:11: note: expanded from here" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:4:1: note: expanded from here" \
+    "macro backtrace.c:16:1: error: expected external declaration" \
+    "macro backtrace.c:5:11: note: expanded from here" \
+    "macro backtrace.c:4:11: note: expanded from here" \
+    "macro backtrace.c:3:11: note: expanded from here" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:5:1: note: expanded from here" \
+    "macro backtrace.c:17:1: error: expected external declaration" \
+    "macro backtrace.c:6:11: note: expanded from here" \
+    "macro backtrace.c:5:11: note: expanded from here" \
+    "macro backtrace.c:4:11: note: expanded from here" \
+    "note: (skipping 1 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:6:1: note: expanded from here" \
+    "macro backtrace.c:18:1: error: expected external declaration" \
+    "macro backtrace.c:7:11: note: expanded from here" \
+    "macro backtrace.c:6:11: note: expanded from here" \
+    "macro backtrace.c:5:11: note: expanded from here" \
+    "note: (skipping 2 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:7:1: note: expanded from here" \
+    "macro backtrace.c:19:1: error: expected external declaration" \
+    "macro backtrace.c:8:11: note: expanded from here" \
+    "macro backtrace.c:7:11: note: expanded from here" \
+    "macro backtrace.c:6:11: note: expanded from here" \
+    "note: (skipping 3 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:8:1: note: expanded from here" \
+    "macro backtrace.c:20:1: error: expected external declaration" \
+    "macro backtrace.c:9:11: note: expanded from here" \
+    "macro backtrace.c:8:11: note: expanded from here" \
+    "macro backtrace.c:7:11: note: expanded from here" \
+    "note: (skipping 4 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:9:1: note: expanded from here" \
+    "macro backtrace.c:21:1: error: expected external declaration" \
+    "macro backtrace.c:10:11: note: expanded from here" \
+    "macro backtrace.c:9:11: note: expanded from here" \
+    "macro backtrace.c:8:11: note: expanded from here" \
+    "note: (skipping 5 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:10:1: note: expanded from here" \
+    "macro backtrace.c:22:1: error: expected external declaration" \
+    "macro backtrace.c:11:11: note: expanded from here" \
+    "macro backtrace.c:10:11: note: expanded from here" \
+    "macro backtrace.c:9:11: note: expanded from here" \
+    "note: (skipping 6 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)" \
+    "macro backtrace.c:2:11: note: expanded from here" \
+    "macro backtrace.c:1:11: note: expanded from here" \
+    "<scratch space>:11:1: note: expanded from here" \

--- a/test/cases/pragma in macro middle.c
+++ b/test/cases/pragma in macro middle.c
@@ -1,5 +1,9 @@
 #define p(x) x
 p(token #pragma once)
 
-#define EXPECTED_ERRORS "pragma in macro middle.c:2:3: warning: type specifier missing, defaults to 'int' [-Wimplicit-int]" \
-	"pragma in macro middle.c:2:9: error: expected ';', found '#'" \
+#define EXPECTED_ERRORS "pragma in macro middle.c:2:1: warning: type specifier missing, defaults to 'int' [-Wimplicit-int]" \
+	"pragma in macro middle.c:1:14: note: expanded from here" \
+	"pragma in macro middle.c:2:3: note: expanded from here" \
+	"pragma in macro middle.c:2:1: error: expected ';', found '#'" \
+	"pragma in macro middle.c:1:14: note: expanded from here" \
+	"pragma in macro middle.c:2:9: note: expanded from here" \

--- a/test/cases/pragma in macro start.c
+++ b/test/cases/pragma in macro start.c
@@ -1,5 +1,9 @@
 #define p(x) x
 p(#pragma once)
 
-#define EXPECTED_ERRORS "pragma in macro start.c:2:3: error: expected external declaration" \
-	"pragma in macro start.c:2:4: error: #pragma directive in macro expansion" \
+#define EXPECTED_ERRORS "pragma in macro start.c:2:1: error: expected external declaration" \
+	"pragma in macro start.c:1:14: note: expanded from here" \
+	"pragma in macro start.c:2:3: note: expanded from here" \
+	"pragma in macro start.c:2:1: error: #pragma directive in macro expansion" \
+	"pragma in macro start.c:1:14: note: expanded from here" \
+	"pragma in macro start.c:2:4: note: expanded from here" \

--- a/test/cases/preprocessor binary operators.c
+++ b/test/cases/preprocessor binary operators.c
@@ -72,6 +72,8 @@ error "failed"
 	"preprocessor binary operators.c:42:5: error: expected expression" \
 	"preprocessor binary operators.c:46:5: error: string literal in preprocessor expression" \
 	"preprocessor binary operators.c:50:5: error: string literal in preprocessor expression" \
-	"preprocessor binary operators.c:53:13: error: token is not a valid binary operator in a preprocessor subexpression" \
-	"preprocessor binary operators.c:53:13: error: invalid token at start of a preprocessor expression" \
+	"preprocessor binary operators.c:54:7: error: token is not a valid binary operator in a preprocessor subexpression" \
+	"preprocessor binary operators.c:53:13: note: expanded from here" \
+	"preprocessor binary operators.c:58:5: error: invalid token at start of a preprocessor expression" \
+	"preprocessor binary operators.c:53:13: note: expanded from here" \
 	"preprocessor binary operators.c:62:9: error: token is not a valid binary operator in a preprocessor subexpression" \

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -95,6 +95,7 @@ pub fn main() !void {
         comp.langopts.standard = .default;
         comp.diag.options = initial_options;
         comp.only_preprocess = false;
+        comp.generated_buf.items.len = 0;
         const file = comp.addSource(path) catch |err| {
             fail_count += 1;
             progress.log("could not add source '{s}': {s}\n", .{ path, @errorName(err) });
@@ -181,7 +182,7 @@ pub fn main() !void {
                 progress.log("invalid TESTS_SKIPPED, definition should contain exactly one integer literal {}\n", .{macro});
                 continue;
             }
-            const tok_slice = pp.tokSliceSafe(macro.tokens[0]);
+            const tok_slice = pp.tokSlice(macro.tokens[0]);
             const tests_skipped = try std.fmt.parseInt(u32, tok_slice, 0);
             progress.log("{d} test{s} skipped\n", .{ tests_skipped, if (tests_skipped == 1) @as([]const u8, "") else "s" });
             skip_count += tests_skipped;
@@ -218,7 +219,7 @@ pub fn main() !void {
                 defer i += 1;
                 if (i >= actual.types.items.len) continue;
 
-                const expected_type = std.mem.trim(u8, pp.tokSliceSafe(str), "\"");
+                const expected_type = std.mem.trim(u8, pp.tokSlice(str), "\"");
                 const actual_type = actual.types.items[i];
                 if (!std.mem.eql(u8, expected_type, actual_type)) {
                     fail_count += 1;
@@ -264,7 +265,7 @@ pub fn main() !void {
 
                 defer buf.items.len = 0;
                 // realistically the strings will only contain \" if any escapes so we can use Zig's string parsing
-                std.debug.assert((try std.zig.string_literal.parseAppend(&buf, pp.tokSliceSafe(str))) == .success);
+                std.debug.assert((try std.zig.string_literal.parseAppend(&buf, pp.tokSlice(str))) == .success);
                 const expected_error = buf.items;
 
                 const index = std.mem.indexOf(u8, m.buf.items, expected_error);
@@ -318,7 +319,7 @@ pub fn main() !void {
 
             defer buf.items.len = 0;
             // realistically the strings will only contain \" if any escapes so we can use Zig's string parsing
-            std.debug.assert((try std.zig.string_literal.parseAppend(&buf, pp.tokSliceSafe(macro.tokens[0]))) == .success);
+            std.debug.assert((try std.zig.string_literal.parseAppend(&buf, pp.tokSlice(macro.tokens[0]))) == .success);
             const expected_output = buf.items;
 
             const obj_name = "test_object.o";


### PR DESCRIPTION
This changes the order in which macro backtrace appears in diagnostics from the current which matches GCC to the reverse which maches clang and in my opinion makes more sense. It also adds a limit to how many backtrace notes are shown by default also matching clang.

Should unblock #157