### PR TITLE
Parser: fix standalone __extension__ not followed by any other token crashes

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -591,7 +591,7 @@ pub fn parse(pp: *Preprocessor) Compilation.Error!Tree {
     _ = try p.addNode(.{ .tag = .invalid, .ty = undefined, .data = undefined });
     try p.defineVaList();
 
-    while (p.eatToken(.eof) == null) {
+    while (p.tok_i < p.tok_ids.len and p.eatToken(.eof) == null) {
         const found_pragma = p.pragma() catch |err| switch (err) {
             error.ParsingFailed => break,
             else => |e| return e,

--- a/test/cases/extension.c
+++ b/test/cases/extension.c
@@ -12,7 +12,10 @@ struct Foo {
     __extension__ int a;
 };
 
+__extension__
+
 #define EXPECTED_ERRORS "extension.c:1:14: error: expected external declaration" \
     "extension.c:6:18: error: expected expression" \
     "extension.c:7:5: warning: expression result unused [-Wunused-value]" \
     "extension.c:11:18: error: expected a type" \
+    "extension.c:15:14: error: expected external declaration" 


### PR DESCRIPTION
Now it shows an error which complains about missing declaration after ``__extension__`` in global scope
Closes #145 