### PR TITLE
Pragma: improve misleading warning messages

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -1290,12 +1290,12 @@ const messages = struct {
         const msg = "_Pragma requires exactly one string literal token";
         const kind = .@"error";
     };
-    const unknown_pragmas = struct {
-        const msg = "pragma expected 'error', 'warning', 'diagnostic', 'poison'";
+    const unknown_gcc_pragma = struct {
+        const msg = "pragma GCC expected 'error', 'warning', 'diagnostic', 'poison'";
         const kind = .@"warning";
     };
-    const unknown_pragmas_directive = struct {
-        const msg = "pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'";
+    const unknown_gcc_pragma_directive = struct {
+        const msg = "pragma GCC diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'";
         const opt = "unknown-pragmas";
         const kind = .@"warning";
     };

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -100,6 +100,7 @@ pub const Options = struct {
     @"unicode-homoglyph": ?Kind = null,
     @"return-type": ?Kind = null,
     @"dollar-in-identifier-extension": ?Kind = null,
+    @"unknown-pragmas": ?Kind = null,
 };
 
 const messages = struct {
@@ -1288,6 +1289,15 @@ const messages = struct {
     const pragma_operator_string_literal = struct {
         const msg = "_Pragma requires exactly one string literal token";
         const kind = .@"error";
+    };
+    const unknown_pragmas = struct {
+        const msg = "pragma expected 'error', 'warning', 'diagnostic', 'poison'";
+        const kind = .@"warning";
+    };
+    const unknown_pragmas_directive = struct {
+        const msg = "pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'";
+        const opt = "unknown-pragmas";
+        const kind = .@"warning";
     };
 };
 

--- a/src/pragmas/gcc.zig
+++ b/src/pragmas/gcc.zig
@@ -131,7 +131,7 @@ fn preprocessorHandler(_: *Pragma, pp: *Preprocessor, start_idx: TokenIndex) Pra
                 error.UnknownPragma => {
                     const tok = pp.tokens.get(start_idx + 2);
                     return pp.comp.diag.add(.{
-                        .tag = .unknown_pragmas_directive,
+                        .tag = .unknown_gcc_pragma_directive,
                         .loc = tok.loc,
                     }, tok.expansionSlice());
                 },
@@ -163,7 +163,7 @@ fn preprocessorHandler(_: *Pragma, pp: *Preprocessor, start_idx: TokenIndex) Pra
         }
     } else {
         return pp.comp.diag.add(.{
-            .tag = .unknown_pragmas,
+            .tag = .unknown_gcc_pragma,
             .loc = directive_tok.loc,
         }, directive_tok.expansionSlice());
     }

--- a/src/pragmas/gcc.zig
+++ b/src/pragmas/gcc.zig
@@ -99,6 +99,7 @@ fn diagnosticHandler(pp: *Preprocessor, start_idx: TokenIndex) Pragma.Error!void
             .push, .pop => {},
         }
     }
+
     return error.UnknownPragma;
 }
 
@@ -126,7 +127,16 @@ fn preprocessorHandler(_: *Pragma, pp: *Preprocessor, start_idx: TokenIndex) Pra
                     directive_tok.expansionSlice(),
                 );
             },
-            .diagnostic => return diagnosticHandler(pp, start_idx + 2),
+            .diagnostic => return diagnosticHandler(pp, start_idx + 2) catch |err| switch (err) {
+                error.UnknownPragma => {
+                    const tok = pp.tokens.get(start_idx + 2);
+                    return pp.comp.diag.add(.{
+                        .tag = .unknown_pragmas_directive,
+                        .loc = tok.loc,
+                    }, tok.expansionSlice());
+                },
+                else => |e| return e,
+            },
             .poison => {
                 var i: usize = 2;
                 while (true) : (i += 1) {
@@ -151,8 +161,12 @@ fn preprocessorHandler(_: *Pragma, pp: *Preprocessor, start_idx: TokenIndex) Pra
                 return;
             },
         }
+    } else {
+        return pp.comp.diag.add(.{
+            .tag = .unknown_pragmas,
+            .loc = directive_tok.loc,
+        }, directive_tok.expansionSlice());
     }
-    return error.UnknownPragma;
 }
 
 fn parserHandler(_: *Pragma, p: *Parser, start_idx: TokenIndex) Compilation.Error!void {

--- a/test/cases/unknown GCC pragmas.c
+++ b/test/cases/unknown GCC pragmas.c
@@ -3,5 +3,5 @@
 #pragma GCC diagnostic unknown_option_again
 
 #define EXPECTED_ERRORS \
-    "unknown GCC pragmas.c:1:13: warning: pragma expected 'error', 'warning', 'diagnostic', 'poison'" \
-    "unknown GCC pragmas.c:3:24: warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'" \
+    "unknown GCC pragmas.c:1:13: warning: pragma GCC expected 'error', 'warning', 'diagnostic', 'poison'" \
+    "unknown GCC pragmas.c:3:24: warning: pragma GCC diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'" \

--- a/test/cases/unknown GCC pragmas.c
+++ b/test/cases/unknown GCC pragmas.c
@@ -1,0 +1,7 @@
+#pragma GCC unknown_option
+
+#pragma GCC diagnostic unknown_option_again
+
+#define EXPECTED_ERRORS \
+    "unknown GCC pragmas.c:1:13: warning: pragma expected 'error', 'warning', 'diagnostic', 'poison'" \
+    "unknown GCC pragmas.c:3:24: warning: pragma diagnostic expected 'error', 'warning', 'ignored', 'fatal', 'push', or 'pop'" \


### PR DESCRIPTION
An attempt to fix #166 

This creates two different warning messages for both cases mentioned here. But controlling option is only made available for the second (diagnostics case) following clang's style.