### PR TITLE
Tokenizer: CharInfo functions expect codepoint > 0x7F

### DIFF
--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -587,7 +587,7 @@ pub const Token = struct {
     /// case on the fast path
     pub fn mayAppearInIdent(comp: *const Compilation, codepoint: u21, where: enum { start, inside }) bool {
         if (codepoint == '$') return comp.langopts.dollars_in_identifiers;
-        if (codepoint < 0x7F) return false;
+        if (codepoint <= 0x7F) return false;
         return switch (where) {
             .start => if (comp.langopts.standard.atLeast(.c11))
                 CharInfo.isC11IdChar(codepoint) and !CharInfo.isC11DisallowedInitialIdChar(codepoint)


### PR DESCRIPTION
Prevents a `'\x7F'` character from triggering an assert