### PR TITLE
Parser: issue an error for unavailable designated init indices.

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -2462,6 +2462,7 @@ fn initializerItem(p: *Parser, il: *InitList, init_ty: Type) Error!bool {
                     try p.errStr(.invalid_array_designator, l_bracket, try p.typeStr(cur_ty));
                     return error.ParsingFailed;
                 }
+                const expr_tok = p.tok_i;
                 const index_res = try p.constExpr();
                 try p.expectClosing(l_bracket, .r_bracket);
 
@@ -2471,7 +2472,10 @@ fn initializerItem(p: *Parser, il: *InitList, init_ty: Type) Error!bool {
                         try p.errExtra(.negative_array_designator, l_bracket + 1, .{ .signed = val });
                         return error.ParsingFailed;
                     } else @intCast(u64, val),
-                    .unavailable => unreachable,
+                    .unavailable => {
+                        try p.errTok(.expected_integer_constant_expr, expr_tok);
+                        return error.ParsingFailed;
+                    },
                 };
                 const max_len = cur_ty.arrayLen() orelse std.math.maxInt(usize);
                 if (index_unchecked >= max_len) {

--- a/test/cases/initializers.c
+++ b/test/cases/initializers.c
@@ -37,6 +37,10 @@ void foo(void) {
     void v[1] = {1};
     (void){};
 }
+void bar(void) {
+    int x = 1;
+    int arr[] = {[x] = 2};
+}
 
 #define TESTS_SKIPPED 2
 #define EXPECTED_ERRORS "initializers.c:2:17: error: variable-sized object may not be initialized" \
@@ -70,3 +74,4 @@ void foo(void) {
     "initializers.c:36:13: error: variable has incomplete type 'union U'" \
     "initializers.c:37:11: error: array has incomplete element type 'void'" \
     "initializers.c:38:11: error: variable has incomplete type 'void'" \
+    "initializers.c:42:19: error: expression is not an integer constant expression" \


### PR DESCRIPTION
Note: this fixes the crash in #170 but not the issue causing `const int` variable value to not be available.