### PR TITLE
Parser: treat non-integer casts and address-of operations as unavailable

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4801,7 +4801,9 @@ fn castExpr(p: *Parser) Error!Result {
                     try p.errStr(.invalid_cast_to_pointer, l_paren, try p.typeStr(operand.ty));
 
                 const is_unsigned = ty.isUnsignedInt(p.pp.comp);
-                if (is_unsigned and operand.val == .signed) {
+                if (!ty.isInt()) {
+                    try operand.saveValue(p);
+                } else if (is_unsigned and operand.val == .signed) {
                     const copy = operand.val.signed;
                     operand.val = .{ .unsigned = @bitCast(u64, copy) };
                 } else if (!is_unsigned and operand.val == .unsigned) {
@@ -4948,6 +4950,7 @@ fn unExpr(p: *Parser) Error!Result {
                 .specifier = .pointer,
                 .data = .{ .sub_type = elem_ty },
             };
+            try operand.saveValue(p);
             try operand.un(p, .addr_of_expr);
             return operand;
         },

--- a/test/cases/unavailable results.c
+++ b/test/cases/unavailable results.c
@@ -1,0 +1,12 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+void foo(void) {
+    1.0f == 1.0f;
+    (double)1 + 1U == 2.0;
+    (_Complex float)1 + 2U;
+    1U + (int *)1;
+    1U + &2;
+}
+#pragma GCC diagnostic pop
+
+#define EXPECTED_ERRORS "unavailable results.c:8:10: error: cannot take the address of an rvalue" \


### PR DESCRIPTION
Fixes #175
Fixes #85