### PR TITLE
Type: allow `_Complex` to combine with `long`

### DIFF
--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1298,6 +1298,7 @@ pub const Builder = struct {
                 .sint => .slong_int,
                 .ulong => .ulong_long,
                 .long_long, .ulong_long => return b.duplicateSpec(p, "long"),
+                .complex => .complex_long,
                 else => return b.cannotCombine(p, source_tok),
             },
             .float => b.specifier = switch (b.specifier) {

--- a/test/cases/imaginary constants.c
+++ b/test/cases/imaginary constants.c
@@ -5,10 +5,14 @@ void foo(void) {
     _Complex double cd = 1.0 + 2.0i;
 #pragma GCC diagnostic pop
     _Complex float cf = 1.0f + 2.0if;
+
+    _Complex long double cld;
+//    cld = 1.0l + 2.0il; /* TODO: long double literals */
 }
 
 #if 1.0i
 #endif
 
+#define TESTS_SKIPPED 1
 #define EXPECTED_ERRORS "imaginary constants.c:5:32: warning: imaginary constants are a GNU extension" \
-    "imaginary constants.c:10:5: error: floating point literal in preprocessor expression" \
+    "imaginary constants.c:13:5: error: floating point literal in preprocessor expression" \

--- a/test/cases/invalid types.c
+++ b/test/cases/invalid types.c
@@ -7,6 +7,7 @@ _Atomic void e;
 void f[4];
 struct Bar f;
 int x[2305843009213693951u];
+_Complex long cl; /* TODO: complex integers extension */
 
 // int g[];
 // extern int h[];
@@ -15,7 +16,7 @@ int x[2305843009213693951u];
 //     char j[] = "hello";
 // }
 
-#define TESTS_SKIPPED 5
+#define TESTS_SKIPPED 6
 #define EXPECTED_ERRORS \
     "invalid types.c:1:6: error: cannot combine with previous 'long' specifier" \
     "invalid types.c:2:14: warning: duplicate 'atomic' declaration specifier" \
@@ -27,4 +28,6 @@ int x[2305843009213693951u];
     "invalid types.c:6:14: error: variable has incomplete type 'void'" \
     "invalid types.c:7:7: error: array has incomplete element type 'void'" \
     "invalid types.c:8:12: error: variable has incomplete type 'struct Bar'" \
-    "invalid types.c:9:6: error: array is too large"
+    "invalid types.c:9:6: error: array is too large" \
+    "invalid types.c:10:15: error: '_Complex long' is invalid" \
+    "invalid types.c:10:15: warning: type specifier missing, defaults to 'int'" \


### PR DESCRIPTION
With this PR an extra `warning: type specifier missing, defaults to 'int'`
warning is generated; but once complex integers are supported it will go
away

Fixes #190