### PR TITLE
Parser: fix crash when returning value from invalid function

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -3628,6 +3628,8 @@ fn returnStmt(p: *Parser) Error!?NodeIndex {
         if (!ret_ty.eql(e.ty, false)) {
             try p.errStr(.incompatible_return, e_tok, try p.typeStr(e.ty));
         }
+    } else if (ret_ty.isFunc()) {
+        // Syntax error reported earlier; just let this return as-is since it is a parse failure anyway
     } else unreachable;
 
     try e.saveValue(p);

--- a/test/cases/return.c
+++ b/test/cases/return.c
@@ -35,6 +35,11 @@ void baz(void) {
     return 1;
 }
 
+int *return_func(void)(void) {
+    return 0;
+}
+
+
 #define EXPECTED_ERRORS "return.c:2:5: error: non-void function 'b' should return a value" \
     "return.c:3:5: warning: unreachable code" \
     "return.c:6:12: error: returning 'void' from a function with incompatible result type" \
@@ -49,3 +54,4 @@ void baz(void) {
     "return.c:30:1: warning: non-void function 'foo' does not return a value [-Wreturn-type]" \
     "return.c:32:5: error: non-void function 'bar' should return a value [-Wreturn-type]" \
     "return.c:35:12: error: void function 'baz' should not return a value [-Wreturn-type]" \
+    "return.c:38:17: error: function cannot return a function" \


### PR DESCRIPTION
If a function is declared as returning a function it's already a syntax error,
so let it return whatever value it wants.