### PR TITLE
Type: don't crash on `_Complex long int`

### DIFF
--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -1387,7 +1387,10 @@ fn pasteTokens(pp: *Preprocessor, lhs_toks: *ExpandBuf, rhs_toks: []const Token)
         try pp.comp.diag.add(.{
             .tag = .pasting_formed_invalid,
             .loc = lhs.loc,
-            .extra = .{ .str = try pp.arena.allocator().dupe(u8, pp.comp.generated_buf.items[start..end]) },
+            .extra = .{ .str = try pp.comp.diag.arena.allocator().dupe(
+                u8,
+                pp.comp.generated_buf.items[start..end],
+            ) },
         }, lhs.expansionSlice());
     }
 

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1154,8 +1154,8 @@ pub const Builder = struct {
 
     fn cannotCombine(b: Builder, p: *Parser, source_tok: TokenIndex) !void {
         if (b.error_on_invalid) return error.CannotCombine;
-        const prev_ty = b.finish(p) catch unreachable;
-        try p.errExtra(.cannot_combine_spec, source_tok, .{ .str = try p.typeStr(prev_ty) });
+        const ty_str = b.specifier.str() orelse try p.typeStr(b.finish(p) catch unreachable);
+        try p.errExtra(.cannot_combine_spec, source_tok, .{ .str = ty_str });
         if (b.typedef) |some| try p.errStr(.spec_from_typedef, some.tok, try p.typeStr(some.ty));
     }
 

--- a/src/pragmas/gcc.zig
+++ b/src/pragmas/gcc.zig
@@ -130,7 +130,7 @@ fn preprocessorHandler(pragma: *Pragma, pp: *Preprocessor, start_idx: TokenIndex
                 },
                 else => |e| return e,
             };
-            const extra = Diagnostics.Message.Extra{ .str = try pp.arena.allocator().dupe(u8, text) };
+            const extra = Diagnostics.Message.Extra{ .str = try pp.comp.diag.arena.allocator().dupe(u8, text) };
             const diagnostic_tag: Diagnostics.Tag = if (gcc_pragma == .warning) .pragma_warning_message else .pragma_error_message;
             return pp.comp.diag.add(
                 .{ .tag = diagnostic_tag, .loc = directive_tok.loc, .extra = extra },

--- a/src/pragmas/message.zig
+++ b/src/pragmas/message.zig
@@ -45,6 +45,6 @@ fn preprocessorHandler(_: *Pragma, pp: *Preprocessor, start_idx: TokenIndex) Pra
         message_expansion_locs[message_expansion_locs.len - 1]
     else
         message_tok.loc;
-    const extra = Diagnostics.Message.Extra{ .str = try pp.arena.allocator().dupe(u8, str) };
+    const extra = Diagnostics.Message.Extra{ .str = try pp.comp.diag.arena.allocator().dupe(u8, str) };
     return pp.comp.diag.add(.{ .tag = .pragma_message, .loc = loc, .extra = extra }, &.{});
 }

--- a/test/cases/invalid types.c
+++ b/test/cases/invalid types.c
@@ -9,6 +9,7 @@ struct Bar f;
 int x[2305843009213693951u];
 _Complex long cl; /* TODO: complex integers extension */
 _Complex z;
+_Complex long int zi; /* TODO: complex integers extension */
 
 // int g[];
 // extern int h[];
@@ -17,7 +18,7 @@ _Complex z;
 //     char j[] = "hello";
 // }
 
-#define TESTS_SKIPPED 6
+#define TESTS_SKIPPED 7
 #define EXPECTED_ERRORS \
     "invalid types.c:1:6: error: cannot combine with previous 'long' specifier" \
     "invalid types.c:2:14: warning: duplicate 'atomic' declaration specifier" \
@@ -33,3 +34,6 @@ _Complex z;
     "invalid types.c:10:15: error: '_Complex long' is invalid" \
     "invalid types.c:10:15: warning: type specifier missing, defaults to 'int'" \
     "invalid types.c:11:1: warning: plain '_Complex' requires a type specifier; assuming '_Complex double'" \
+    "invalid types.c:12:15: error: cannot combine with previous '_Complex long' specifier" \
+    "invalid types.c:12:19: error: '_Complex long' is invalid" \
+    "invalid types.c:12:19: warning: type specifier missing, defaults to 'int'" \


### PR DESCRIPTION
The error message is not good but this one will also go away once complex
integer types are supported