### PR TITLE
Parser: warn if attributes placed before struct/enum/union

### DIFF
--- a/test/cases/attribute at end.c
+++ b/test/cases/attribute at end.c
@@ -1,0 +1,3 @@
+#define EXPECTED_ERRORS "attribute at end.c:3:18: error: expected identifier or '('"
+
+__attribute__(())

--- a/test/cases/attributes.c
+++ b/test/cases/attributes.c
@@ -92,7 +92,7 @@ typedef struct {
       __attribute__((__aligned__(__alignof__(long double))));
 } max_align_t;
 
-__attribute__((noreturn)) // test attribute at eof
+__attribute__((packed)) struct not_actually_packed {int x; };
 
 #define EXPECTED_ERRORS "attributes.c:8:26: warning: Attribute 'noreturn' ignored in variable context [-Wignored-attributes]" \
     "attributes.c:9:26: warning: unknown attribute 'does_not_exist' ignored [-Wunknown-attributes]" \
@@ -100,4 +100,4 @@ __attribute__((noreturn)) // test attribute at eof
     "attributes.c:36:5: error: fallthrough annotation does not directly precede switch label" \
     "attributes.c:40:20: error: attribute cannot be applied to a statement" \
     "attributes.c:76:6: error: cannot call non function type 'int'" \
-    "attributes.c:95:26: error: expected identifier or '('" \
+    "attributes.c:95:16: warning: Attribute 'packed' ignored, place it after \"struct\" to apply attribute to type declaration [-Wignored-attributes]" \


### PR DESCRIPTION
Also fixes a crash that occurred if an invalid attribute occurred at the end
of a file, since no attribute is added to the buffer in that case.