### PR TITLE
Diagnostics: Add warning for GNU binary literal extension in pedantic mode

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -117,6 +117,7 @@ pub const Options = packed struct {
     @"ignored-qualifiers": Kind = .default,
     @"integer-overflow": Kind = .default,
     @"extra-semi": Kind = .default,
+    @"gnu-binary-literal": Kind = .default,
 };
 
 const messages = struct {
@@ -1470,6 +1471,12 @@ const messages = struct {
         const msg = "duplicate member '{s}'";
         const extra = .str;
         const kind = .@"error";
+    };
+    const binary_integer_literal = struct {
+        const msg = "binary integer literals are a GNU extension";
+        const kind = .off;
+        const opt = "gnu-binary-literal";
+        const pedantic = true;
     };
 };
 

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -6132,6 +6132,7 @@ fn integerLiteral(p: *Parser) Error!Result {
         slice = slice[2..];
         base = 10;
     } else if (mem.startsWith(u8, slice, "0b") or mem.startsWith(u8, slice, "0B")) {
+        try p.err(.binary_integer_literal);
         slice = slice[2..];
         base = 2;
     } else if (slice[0] == '0') {

--- a/test/cases/binary literal.c
+++ b/test/cases/binary literal.c
@@ -1,0 +1,6 @@
+//aro-args -Wpedantic
+void foo() {
+  0b11;
+}
+
+#define EXPECTED_ERRORS "binary literal.c:3:3: warning: binary integer literals are a GNU extension [-Wgnu-binary-literal]"


### PR DESCRIPTION
Adds warning for binary integer literal which was one of the motivation behind #59 