### PR TITLE
Preprocessor: ensure expansion_locs of trimmed tokens are freed.

### DIFF
--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -1312,6 +1312,9 @@ fn expandMacroExhaustive(
     // end of scanning phase
 
     // trim excess buffer
+    for (buf.items[moving_end_idx..]) |item| {
+        Token.free(item.expansion_locs, pp.comp.gpa);
+    }
     buf.items.len = moving_end_idx;
 }
 

--- a/test/cases/macro unbalanced parens call.c
+++ b/test/cases/macro unbalanced parens call.c
@@ -1,8 +1,6 @@
-// //aro-args -E
+//aro-args -E
 
-// #define FIRST(x) x
-// #define SECOND FIRST
-// #define THIRD SECOND( FIRST
-// THIRD 42)
-
-#define TESTS_SKIPPED 1
+#define FIRST(x) x
+#define SECOND FIRST
+#define THIRD SECOND( FIRST
+THIRD 42)


### PR DESCRIPTION
Fixes #159