### PR TITLE
Parser: use arrayLen to get array initializer length

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1567,7 +1567,7 @@ fn initDeclarator(p: *Parser, decl_spec: *DeclSpec) Error!?InitDeclarator {
         if (!init_list_expr.ty.isArray()) break :init;
         if (init_d.d.ty.specifier == .incomplete_array) {
             // Modifying .data is exceptionally allowed for .incomplete_array.
-            init_d.d.ty.data.array.len = init_list_expr.ty.data.array.len;
+            init_d.d.ty.data.array.len = init_list_expr.ty.arrayLen().?;
             init_d.d.ty.specifier = .array;
         } else if (init_d.d.ty.is(.incomplete_array)) {
             const attrs = init_d.d.ty.getAttributes();

--- a/test/cases/typeof.c
+++ b/test/cases/typeof.c
@@ -123,6 +123,9 @@ void empty_typeof_declaration(void) {
 void initializers(void) {
     typeof(union U) u = {.x = 1};
     typeof(u) u2 = {.x = 1};
+
+    typeof(char[10]) arr1;
+    typeof(int) arr2[] = arr1;
 }
 
 #define EXPECTED_ERRORS "typeof.c:24:9: warning: incompatible pointer types assigning to 'int *' from incompatible type 'float *' [-Wincompatible-pointer-types]" \
@@ -141,3 +144,4 @@ void initializers(void) {
     "typeof.c:98:29: warning: initializing 'int *' from incompatible type 'const int *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]" \
     "typeof.c:113:5: error: invalid argument type 'char *' to unary expression" \
     "typeof.c:119:5: warning: declaration does not declare anything [-Wmissing-declaration]" \
+    "typeof.c:128:26: error: array initializer must be an initializer list or wide string literal" \


### PR DESCRIPTION
Prevents access of inactive union field when attempting to use a
typeof-type or -expression as an incomplete array initializer.