### PR TITLE
Parser: ensure attributed specifier is not lost for old-style functions

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -872,7 +872,11 @@ fn decl(p: *Parser) Error!bool {
 
         // Collect old style parameter declarations.
         if (init_d.d.old_style_func != null) {
-            init_d.d.ty.specifier = .func;
+            const attrs = init_d.d.ty.getAttributes();
+            var base_ty = if (init_d.d.ty.specifier == .attributed) init_d.d.ty.elemType() else init_d.d.ty;
+            base_ty.specifier = .func;
+            init_d.d.ty = try base_ty.withAttributes(p.arena, attrs);
+
             const param_buf_top = p.param_buf.items.len;
             defer p.param_buf.items.len = param_buf_top;
 

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -443,12 +443,13 @@ pub fn elemType(ty: Type) Type {
         .pointer, .unspecified_variable_len_array, .decayed_unspecified_variable_len_array => ty.data.sub_type.*,
         .array, .static_array, .incomplete_array, .decayed_array, .decayed_static_array, .decayed_incomplete_array => ty.data.array.elem,
         .variable_len_array, .decayed_variable_len_array => ty.data.expr.ty,
-        .typeof_type, .decayed_typeof_type, .typeof_expr, .decayed_typeof_expr, .attributed => {
+        .typeof_type, .decayed_typeof_type, .typeof_expr, .decayed_typeof_expr => {
             const unwrapped = ty.canonicalize(.preserve_quals);
             var elem = unwrapped.elemType();
             elem.qual = elem.qual.mergeAll(unwrapped.qual);
             return elem;
         },
+        .attributed => ty.data.attributed.base,
         else => unreachable,
     };
 }

--- a/test/cases/attributes.c
+++ b/test/cases/attributes.c
@@ -92,6 +92,11 @@ typedef struct {
       __attribute__((__aligned__(__alignof__(long double))));
 } max_align_t;
 
+__attribute__((unused)) void attributed_old_style_func(baz)
+int baz;
+{
+}
+
 __attribute__(()) // test attribute at eof
 
 #define TESTS_SKIPPED 3
@@ -103,4 +108,4 @@ __attribute__(()) // test attribute at eof
     "attributes.c:36:5: error: fallthrough annotation does not directly precede switch label" \
     /* "attributes.c:40:20: error: attribute cannot be applied to a statement" */ \
     "attributes.c:76:6: error: cannot call non function type 'int'" \
-    "attributes.c:95:18: error: expected identifier or '('" \
+    "attributes.c:100:18: error: expected identifier or '('" \


### PR DESCRIPTION
Fixes #230