### PR TITLE
Parser: handle casting of string literals

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -121,6 +121,7 @@ pub const Options = packed struct {
     @"#warnings": Kind = .default,
     @"deprecated-declarations": Kind = .default,
     @"backslash-newline-escape": Kind = .default,
+    @"pointer-to-int-cast": Kind = .default,
 };
 
 const messages = struct {
@@ -1589,6 +1590,12 @@ const messages = struct {
         const msg = "size of array has non-integer type '{s}'";
         const extra = .str;
         const kind = .@"error";
+    };
+    const cast_to_smaller_int = struct {
+        const msg = "cast to smaller integer type {s}";
+        const extra = .str;
+        const kind = .warning;
+        const opt = "pointer-to-int-cast";
     };
 };
 

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4860,7 +4860,7 @@ fn castExpr(p: *Parser) Error!Result {
             const new_float = ty.isFloat();
 
             if (new_float and operand.ty.isPtr()) {
-                try p.errStr(.invalid_cast_to_float, l_paren, try p.typeStr(operand.ty));
+                try p.errStr(.invalid_cast_to_float, l_paren, try p.typeStr(ty));
                 return error.ParsingFailed;
             } else if (old_float and ty.isPtr()) {
                 try p.errStr(.invalid_cast_to_pointer, l_paren, try p.typeStr(operand.ty));

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4856,6 +4856,8 @@ fn castExpr(p: *Parser) Error!Result {
             // everything can cast to void
             operand.val.tag = .unavailable;
         } else if (ty.isInt() or ty.isFloat() or ty.isPtr()) cast: {
+            try operand.lvalConversion(p);
+
             const old_float = operand.ty.isFloat();
             const new_float = ty.isFloat();
 
@@ -4884,6 +4886,9 @@ fn castExpr(p: *Parser) Error!Result {
             return error.ParsingFailed;
         }
         if (ty.anyQual()) try p.errStr(.qual_cast, l_paren, try p.typeStr(ty));
+        if (ty.isInt() and operand.ty.isPtr() and ty.sizeCompare(operand.ty, p.pp.comp) == .lt) {
+            try p.errStr(.cast_to_smaller_int, l_paren, try p.typePairStrExtra(ty, " from ", operand.ty));
+        }
         operand.ty = ty;
         operand.ty.qual = .{};
         try operand.un(p, .cast_expr);

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -606,6 +606,23 @@ pub fn getCharSignedness(comp: *Compilation) std.builtin.Signedness {
     }
 }
 
+const TypeSizeOrder = enum {
+    lt,
+    gt,
+    eq,
+    indeterminate,
+};
+
+pub fn sizeCompare(a: Type, b: Type, comp: *Compilation) TypeSizeOrder {
+    const a_size = a.sizeof(comp) orelse return .indeterminate;
+    const b_size = b.sizeof(comp) orelse return .indeterminate;
+    return switch (std.math.order(a_size, b_size)) {
+        .lt => .lt,
+        .gt => .gt,
+        .eq => .eq,
+    };
+}
+
 /// Size of type as reported by sizeof
 pub fn sizeof(ty: Type, comp: *Compilation) ?u64 {
     // TODO get target from compilation

--- a/test/cases/casts.c
+++ b/test/cases/casts.c
@@ -10,7 +10,7 @@ void foo(void) {
 }
 
 #define EXPECTED_ERRORS "casts.c:5:5: error: cannot cast to non arithmetic or pointer type 'int'" \
-    "casts.c:6:5: error: pointer cannot be cast to type 'int *'" \
+    "casts.c:6:5: error: pointer cannot be cast to type 'float'" \
     "casts.c:7:5: error: operand of type 'float' cannot be cast to a pointer type" \
     "casts.c:8:5: warning: cast to type 'int' will not preserve qualifiers [-Wcast-qualifiers]" \
     "casts.c:9:23: error: cannot cast to non arithmetic or pointer type 'int'" \

--- a/test/cases/casts.c
+++ b/test/cases/casts.c
@@ -7,6 +7,9 @@ void foo(void) {
     (int*)1.f;
     (const int)1;
     const int p_i[] = (typeof(p_i))0;
+    int a = (char)"foo";
+    int b = (float)"foo";
+    unsigned long long d = (unsigned long long)"foo";
 }
 
 #define EXPECTED_ERRORS "casts.c:5:5: error: cannot cast to non arithmetic or pointer type 'int'" \
@@ -14,3 +17,5 @@ void foo(void) {
     "casts.c:7:5: error: operand of type 'float' cannot be cast to a pointer type" \
     "casts.c:8:5: warning: cast to type 'int' will not preserve qualifiers [-Wcast-qualifiers]" \
     "casts.c:9:23: error: cannot cast to non arithmetic or pointer type 'int'" \
+    "casts.c:10:13: warning: cast to smaller integer type 'char' from 'char *' [-Wpointer-to-int-cast]" \
+    "casts.c:11:13: error: pointer cannot be cast to type 'float'" \


### PR DESCRIPTION
Fixes #228
Print correct type in an error message about casting