### PR TITLE
Compilation: handle non-EOF input errors properly

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -530,7 +530,10 @@ pub fn addSourceFromReader(comp: *Compilation, reader: anytype, path: []const u8
     var line: u32 = 1;
 
     while (true) {
-        const byte = reader.readByte() catch break;
+        const byte = reader.readByte() catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => |e| return e,
+        };
         contents[i] = byte;
 
         switch (byte) {


### PR DESCRIPTION
Previously any input error would be treated as a legitimate end of stream;
instead specifically check for EndOfStream and bubble all other errors up
to the caller