### PR TITLE
Tree: store cast kind as part of implicit/explicit cast nodes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.zig text eol=lf
 test/cases/expanded/* text eol=lf
+test/cases/ast/* text eol=lf 
 
 deps/** linguist-vendored

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -667,38 +667,38 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
     const ty = tree.nodes.items(.ty)[@enumToInt(node)];
     try w.writeByteNTimes(' ', level);
 
-    util.setColor(if (tag.isImplicit()) IMPLICIT else TAG, w);
+    if (tree.comp.diag.color) util.setColor(if (tag.isImplicit()) IMPLICIT else TAG, w);
     try w.print("{s}: ", .{@tagName(tag)});
     if (tag == .implicit_cast or tag == .explicit_cast) {
-        util.setColor(.white, w);
+        if (tree.comp.diag.color) util.setColor(.white, w);
         try w.print("({s}) ", .{@tagName(data.cast.kind)});
     }
-    util.setColor(TYPE, w);
+    if (tree.comp.diag.color) util.setColor(TYPE, w);
     try w.writeByte('\'');
     try ty.dump(w);
     try w.writeByte('\'');
 
     if (isLval(tree.nodes, tree.data, tree.value_map, node)) {
-        util.setColor(ATTRIBUTE, w);
+        if (tree.comp.diag.color) util.setColor(ATTRIBUTE, w);
         try w.writeAll(" lvalue");
     }
     if (tree.value_map.get(node)) |val| {
-        util.setColor(LITERAL, w);
+        if (tree.comp.diag.color) util.setColor(LITERAL, w);
         try w.writeAll(" (value: ");
         try val.dump(ty, tree.comp, w);
         try w.writeByte(')');
     }
     try w.writeAll("\n");
-    util.setColor(.reset, w);
+    if (tree.comp.diag.color) util.setColor(.reset, w);
 
     if (ty.specifier == .attributed) {
-        util.setColor(ATTRIBUTE, w);
+        if (tree.comp.diag.color) util.setColor(ATTRIBUTE, w);
         for (ty.data.attributed.attributes) |attr| {
             try w.writeByteNTimes(' ', level + half);
             try w.print("attr: {s} ", .{@tagName(attr.tag)});
             try dumpAttribute(attr, w);
         }
-        util.setColor(.reset, w);
+        if (tree.comp.diag.color) util.setColor(.reset, w);
     }
 
     switch (tag) {
@@ -720,9 +720,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         => {
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("name: ");
-            util.setColor(NAME, w);
+            if (tree.comp.diag.color) util.setColor(NAME, w);
             try w.print("{s}\n", .{tree.tokSlice(data.decl.name)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
         },
         .fn_def,
         .static_fn_def,
@@ -731,9 +731,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         => {
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("name: ");
-            util.setColor(NAME, w);
+            if (tree.comp.diag.color) util.setColor(NAME, w);
             try w.print("{s}\n", .{tree.tokSlice(data.decl.name)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("body:\n");
             try tree.dumpNode(data.decl.node, level + delta, w);
@@ -749,9 +749,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         => {
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("name: ");
-            util.setColor(NAME, w);
+            if (tree.comp.diag.color) util.setColor(NAME, w);
             try w.print("{s}\n", .{tree.tokSlice(data.decl.name)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
             if (data.decl.node != .none) {
                 try w.writeByteNTimes(' ', level + half);
                 try w.writeAll("init:\n");
@@ -761,9 +761,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         .enum_field_decl => {
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("name: ");
-            util.setColor(NAME, w);
+            if (tree.comp.diag.color) util.setColor(NAME, w);
             try w.print("{s}\n", .{tree.tokSlice(data.decl.name)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
             if (data.decl.node != .none) {
                 try w.writeByteNTimes(' ', level + half);
                 try w.writeAll("value:\n");
@@ -774,9 +774,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
             if (data.decl.name != 0) {
                 try w.writeByteNTimes(' ', level + half);
                 try w.writeAll("name: ");
-                util.setColor(NAME, w);
+                if (tree.comp.diag.color) util.setColor(NAME, w);
                 try w.print("{s}\n", .{tree.tokSlice(data.decl.name)});
-                util.setColor(.reset, w);
+                if (tree.comp.diag.color) util.setColor(.reset, w);
             }
             if (data.decl.node != .none) {
                 try w.writeByteNTimes(' ', level + half);
@@ -812,9 +812,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         .union_init_expr => {
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("field index: ");
-            util.setColor(LITERAL, w);
+            if (tree.comp.diag.color) util.setColor(LITERAL, w);
             try w.print("{d}\n", .{data.union_init.field_index});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
             if (data.union_init.node != .none) {
                 try tree.dumpNode(data.union_init.node, level + delta, w);
             }
@@ -825,9 +825,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         .labeled_stmt => {
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("label: ");
-            util.setColor(LITERAL, w);
+            if (tree.comp.diag.color) util.setColor(LITERAL, w);
             try w.print("{s}\n", .{tree.tokSlice(data.decl.name)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
             if (data.decl.node != .none) {
                 try w.writeByteNTimes(' ', level + half);
                 try w.writeAll("stmt:\n");
@@ -969,9 +969,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         .goto_stmt, .addr_of_label => {
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("label: ");
-            util.setColor(LITERAL, w);
+            if (tree.comp.diag.color) util.setColor(LITERAL, w);
             try w.print("{s}\n", .{tree.tokSlice(data.decl_ref)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
         },
         .continue_stmt, .break_stmt, .implicit_return, .null_stmt => {},
         .return_stmt => {
@@ -983,9 +983,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         },
         .attr_arg_ident => {
             try w.writeByteNTimes(' ', level + half);
-            util.setColor(ATTRIBUTE, w);
+            if (tree.comp.diag.color) util.setColor(ATTRIBUTE, w);
             try w.print("name: {s}\n", .{tree.tokSlice(data.decl_ref)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
         },
         .call_expr => {
             try w.writeByteNTimes(' ', level + half);
@@ -1009,9 +1009,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         .builtin_call_expr => {
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("name: ");
-            util.setColor(NAME, w);
+            if (tree.comp.diag.color) util.setColor(NAME, w);
             try w.print("{s}\n", .{tree.tokSlice(@enumToInt(tree.data[data.range.start]))});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
 
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("args:\n");
@@ -1020,9 +1020,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         .builtin_call_expr_one => {
             try w.writeByteNTimes(' ', level + half);
             try w.writeAll("name: ");
-            util.setColor(NAME, w);
+            if (tree.comp.diag.color) util.setColor(NAME, w);
             try w.print("{s}\n", .{tree.tokSlice(data.decl.name)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
             if (data.decl.node != .none) {
                 try w.writeByteNTimes(' ', level + half);
                 try w.writeAll("arg:\n");
@@ -1088,16 +1088,16 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         .decl_ref_expr => {
             try w.writeByteNTimes(' ', level + 1);
             try w.writeAll("name: ");
-            util.setColor(NAME, w);
+            if (tree.comp.diag.color) util.setColor(NAME, w);
             try w.print("{s}\n", .{tree.tokSlice(data.decl_ref)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
         },
         .enumeration_ref => {
             try w.writeByteNTimes(' ', level + 1);
             try w.writeAll("name: ");
-            util.setColor(NAME, w);
+            if (tree.comp.diag.color) util.setColor(NAME, w);
             try w.print("{s}\n", .{tree.tokSlice(data.decl_ref)});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
         },
         .int_literal,
         .char_literal,
@@ -1116,9 +1116,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
 
             try w.writeByteNTimes(' ', level + 1);
             try w.writeAll("name: ");
-            util.setColor(NAME, w);
+            if (tree.comp.diag.color) util.setColor(NAME, w);
             try w.print("{s}\n", .{lhs_ty.data.record.fields[data.member.index].name});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
         },
         .array_access_expr => {
             if (data.bin.lhs != .none) {
@@ -1165,9 +1165,9 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         .array_filler_expr => {
             try w.writeByteNTimes(' ', level + 1);
             try w.writeAll("count: ");
-            util.setColor(LITERAL, w);
+            if (tree.comp.diag.color) util.setColor(LITERAL, w);
             try w.print("{d}\n", .{data.int});
-            util.setColor(.reset, w);
+            if (tree.comp.diag.color) util.setColor(.reset, w);
         },
         .struct_forward_decl,
         .union_forward_decl,

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -629,6 +629,7 @@ fn dumpAttribute(attr: Attribute, writer: anytype) !void {
                 try writer.writeByte('\n');
                 return;
             }
+            try writer.writeByte(' ');
             inline for (@typeInfo(@TypeOf(args)).Struct.fields) |f, i| {
                 if (comptime std.mem.eql(u8, f.name, "__name_tok")) continue;
                 if (i != 0) {
@@ -695,7 +696,7 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
         if (tree.comp.diag.color) util.setColor(ATTRIBUTE, w);
         for (ty.data.attributed.attributes) |attr| {
             try w.writeByteNTimes(' ', level + half);
-            try w.print("attr: {s} ", .{@tagName(attr.tag)});
+            try w.print("attr: {s}", .{@tagName(attr.tag)});
             try dumpAttribute(attr, w);
         }
         if (tree.comp.diag.color) util.setColor(.reset, w);

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -207,10 +207,6 @@ pub const CastKind = enum(u8) {
     int_cast,
     /// Convert one floating type to another
     float_cast,
-    /// Convert pointer to one with same child type but more CV-quals,
-    /// OR to appropriately-qualified void *
-    /// only appears on the branches of a conditional expr
-    qual_cast,
     /// Convert type to void
     to_void,
     /// Convert a literal 0 to a null pointer

--- a/src/codegen/x86_64.zig
+++ b/src/codegen/x86_64.zig
@@ -145,8 +145,14 @@ fn genNode(func: *Fn, node: NodeIndex) Codegen.Error!Value {
         else
             return func.genCall(data.bin.lhs, &.{}),
         .call_expr => return func.genCall(func.c.tree.data[data.range.start], func.c.tree.data[data.range.start + 1 .. data.range.end]),
-        .function_to_pointer => return func.genNode(data.un), // no-op
-        .array_to_pointer => return func.genNode(data.un), // no-op
+        .explicit_cast, .implicit_cast => {
+            switch (data.cast.kind) {
+                .function_to_pointer,
+                .array_to_pointer,
+                => return func.genNode(data.cast.operand), // no-op
+                else => return func.c.comp.diag.fatalNoSrc("TODO x86_64 genNode for cast {s}\n", .{@tagName(data.cast.kind)}),
+            }
+        },
         .decl_ref_expr => {
             // TODO locals and arguments
             return Value{ .symbol = func.c.tree.tokSlice(data.decl_ref) };

--- a/test/cases/ast/cast kinds.c
+++ b/test/cases/ast/cast kinds.c
@@ -1,0 +1,208 @@
+union_decl_two: 'union U'
+  record_field_decl: 'int'
+   name: x
+  record_field_decl: 'float'
+   name: y
+
+fn_def: 'fn () int'
+ name: bar
+ body:
+  compound_stmt_two: 'void'
+    return_stmt: 'void'
+     expr:
+      int_literal: 'int' (value: 42)
+
+fn_def: 'fn () void'
+ name: foo
+ body:
+  compound_stmt: 'void'
+    var: 'int'
+     name: x
+
+    var: 'float'
+     name: f
+
+    var: 'double'
+     name: d
+
+    var: '[2]int'
+     name: arr
+
+    var: '*int'
+     name: p
+
+    assign_expr: '*int'
+     lhs:
+      decl_ref_expr: '*int' lvalue
+       name: p
+     rhs:
+      explicit_cast: (bitcast) '*int'
+        addr_of_expr: '*float'
+         operand:
+          decl_ref_expr: 'float' lvalue
+           name: f
+
+    assign_expr: '*int'
+     lhs:
+      decl_ref_expr: '*int' lvalue
+       name: p
+     rhs:
+      implicit_cast: (array_to_pointer) 'd[2]int'
+        decl_ref_expr: '[2]int' lvalue
+         name: arr
+
+    assign_expr: 'int'
+     lhs:
+      decl_ref_expr: 'int' lvalue
+       name: x
+     rhs:
+      call_expr_one: 'int'
+       lhs:
+        implicit_cast: (function_to_pointer) '*fn () int'
+          decl_ref_expr: 'fn () int' lvalue
+           name: bar
+
+    var: '_Bool'
+     name: b
+     init:
+      implicit_cast: (pointer_to_bool) '_Bool'
+        implicit_cast: (lval_to_rval) '*int'
+          decl_ref_expr: '*int' lvalue
+           name: p
+
+    assign_expr: 'int'
+     lhs:
+      decl_ref_expr: 'int' lvalue
+       name: x
+     rhs:
+      implicit_cast: (pointer_to_int) 'int'
+        implicit_cast: (lval_to_rval) '*int'
+          decl_ref_expr: '*int' lvalue
+           name: p
+
+    assign_expr: 'int'
+     lhs:
+      decl_ref_expr: 'int' lvalue
+       name: x
+     rhs:
+      implicit_cast: (bool_to_int) 'int'
+        implicit_cast: (lval_to_rval) '_Bool'
+          decl_ref_expr: '_Bool' lvalue
+           name: b
+
+    assign_expr: 'float'
+     lhs:
+      decl_ref_expr: 'float' lvalue
+       name: f
+     rhs:
+      implicit_cast: (bool_to_float) 'float'
+        implicit_cast: (lval_to_rval) '_Bool'
+          decl_ref_expr: '_Bool' lvalue
+           name: b
+
+    assign_expr: '*int'
+     lhs:
+      decl_ref_expr: '*int' lvalue
+       name: p
+     rhs:
+      implicit_cast: (bool_to_pointer) '*int'
+        implicit_cast: (lval_to_rval) '_Bool'
+          decl_ref_expr: '_Bool' lvalue
+           name: b
+
+    assign_expr: '_Bool'
+     lhs:
+      decl_ref_expr: '_Bool' lvalue
+       name: b
+     rhs:
+      implicit_cast: (int_to_bool) '_Bool'
+        implicit_cast: (lval_to_rval) 'int'
+          decl_ref_expr: 'int' lvalue
+           name: x
+
+    assign_expr: 'float'
+     lhs:
+      decl_ref_expr: 'float' lvalue
+       name: f
+     rhs:
+      implicit_cast: (int_to_float) 'float'
+        implicit_cast: (lval_to_rval) 'int'
+          decl_ref_expr: 'int' lvalue
+           name: x
+
+    assign_expr: '*int'
+     lhs:
+      decl_ref_expr: '*int' lvalue
+       name: p
+     rhs:
+      implicit_cast: (int_to_pointer) '*int'
+        implicit_cast: (lval_to_rval) 'int'
+          decl_ref_expr: 'int' lvalue
+           name: x
+
+    assign_expr: '_Bool'
+     lhs:
+      decl_ref_expr: '_Bool' lvalue
+       name: b
+     rhs:
+      implicit_cast: (float_to_bool) '_Bool'
+        implicit_cast: (lval_to_rval) 'float'
+          decl_ref_expr: 'float' lvalue
+           name: f
+
+    assign_expr: 'int'
+     lhs:
+      decl_ref_expr: 'int' lvalue
+       name: x
+     rhs:
+      implicit_cast: (float_to_int) 'int'
+        implicit_cast: (lval_to_rval) 'float'
+          decl_ref_expr: 'float' lvalue
+           name: f
+
+    assign_expr: 'int'
+     lhs:
+      decl_ref_expr: 'int' lvalue
+       name: x
+     rhs:
+      implicit_cast: (int_cast) 'int'
+        int_literal: 'long' (value: 1)
+
+    assign_expr: 'float'
+     lhs:
+      decl_ref_expr: 'float' lvalue
+       name: f
+     rhs:
+      implicit_cast: (float_cast) 'float'
+        implicit_cast: (lval_to_rval) 'double'
+          decl_ref_expr: 'double' lvalue
+           name: d
+
+    assign_expr: 'double'
+     lhs:
+      decl_ref_expr: 'double' lvalue
+       name: d
+     rhs:
+      implicit_cast: (float_cast) 'double'
+        implicit_cast: (lval_to_rval) 'float'
+          decl_ref_expr: 'float' lvalue
+           name: f
+
+    assign_expr: '*int'
+     lhs:
+      decl_ref_expr: '*int' lvalue
+       name: p
+     rhs:
+      implicit_cast: (null_to_pointer) '*int'
+        int_literal: 'int' (value: 0)
+
+    explicit_cast: (to_void) 'void'
+      implicit_cast: (lval_to_rval) '*int'
+        decl_ref_expr: '*int' lvalue
+         name: p
+
+    var: 'union U'
+     name: u
+
+    implicit_return: 'void'
+

--- a/test/cases/ast/types.c
+++ b/test/cases/ast/types.c
@@ -1,0 +1,65 @@
+var: 'attributed(int)'
+ attr: aligned alignment: .aro.Attribute.Alignment{ .node = .aro.Tree.NodeIndex.none, .requested = 4, .alignas = true }
+ attr: aligned alignment: .aro.Attribute.Alignment{ .node = .aro.Tree.NodeIndex.none, .requested = 4, .alignas = true }
+ attr: aligned alignment: .aro.Attribute.Alignment{ .node = .aro.Tree.NodeIndex(1), .requested = 16, .alignas = true }
+ name: a
+
+var: 'const volatile int'
+ name: b
+
+var: 'const volatile int'
+ name: c
+
+var: 'const volatile int'
+ name: d
+
+fn_proto: 'fn (a: restrict *int, b: restrict *int, c: restrict *int) int'
+ name: foo
+
+fn_proto: 'fn (n: int, bar: d[<expr>]int) int'
+ name: bar
+
+typedef: 'void'
+ name: baz
+
+fn_proto: 'attributed(fn () void)'
+ attr: noreturn
+ name: abort
+
+typedef: 'int'
+ name: A
+
+typedef: 'int'
+ name: B
+
+typedef: 'int'
+ name: C
+
+typedef: 'int'
+ name: B
+
+typedef: '[2]int'
+ name: I
+
+fn_def: 'fn (a: d[2]const int, b: d[2]const int) void'
+ name: baz
+ body:
+  compound_stmt: 'void'
+    add_assign_expr: 'd[2]const int'
+     lhs:
+      decl_ref_expr: 'd[2]const int' lvalue
+       name: b
+     rhs:
+      implicit_cast: (int_to_pointer) 'd[2]const int'
+        int_literal: 'int' (value: 1)
+
+    add_assign_expr: 'd[2]const int'
+     lhs:
+      decl_ref_expr: 'd[2]const int' lvalue
+       name: a
+     rhs:
+      implicit_cast: (int_to_pointer) 'd[2]const int'
+        int_literal: 'int' (value: 1)
+
+    implicit_return: 'void'
+

--- a/test/cases/cast kinds.c
+++ b/test/cases/cast kinds.c
@@ -1,0 +1,55 @@
+//aro-args -Wno-int-conversion
+union U {
+    int x;
+    float y;
+};
+
+int bar(void) {
+    return 42;
+}
+void foo(void) {
+    int x;
+    float f;
+    double d;
+    int arr[2];
+    int *p;
+
+    p = (int *)&f; // bitcast
+    p = arr; // array_to_pointer
+
+    x = bar(); // function_to_pointer
+
+    _Bool b = p; // pointer_to_bool
+
+    x = p; // pointer_to_int
+
+    x = b; // bool_to_int
+
+    f = b;  // bool_to_float
+
+    p = b;  // bool_to_pointer
+
+    b = x;  // int_to_bool
+
+    f = x; // int_to_float
+
+    p = x; // int_to_pointer
+
+    b = f; //float_to_bool
+
+    x = f; //float_to_int
+
+    x = 1L; // int_cast
+
+    f = d; // float_cast
+    d = f; // float_cast
+
+    p = 0; // null_to_pointer
+
+    (void)p; // to_void
+
+    union U u;
+    // TODO: cast to union
+    // u = (union U)x;
+    // u = (union U)f;
+}

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -232,10 +232,10 @@ pub fn main() !void {
             }
 
             const expected_output = blk: {
-                const expaned_path = try std.fs.path.join(gpa, &.{ args[1], "expanded", std.fs.path.basename(path) });
-                defer gpa.free(expaned_path);
+                const expanded_path = try std.fs.path.join(gpa, &.{ args[1], "expanded", std.fs.path.basename(path) });
+                defer gpa.free(expanded_path);
 
-                break :blk std.fs.cwd().readFileAlloc(gpa, expaned_path, std.math.maxInt(u32)) catch |err| {
+                break :blk std.fs.cwd().readFileAlloc(gpa, expanded_path, std.math.maxInt(u32)) catch |err| {
                     fail_count += 1;
                     progress.log("could not open expanded file '{s}': {s}\n", .{ path, @errorName(err) });
                     continue;


### PR DESCRIPTION
Briefly discussed here: https://github.com/Vexu/arocc/pull/232#issuecomment-1030530859

If you like this approach I can fill out the `fromExplicitCast` function.