### PR TITLE
Preprocessor: Handle potential integer underflow in macro expansion

### DIFF
--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -1167,6 +1167,7 @@ fn collectMacroFuncArguments(
                 }
             },
             .eof => {
+                try args.append(curArgument.toOwnedSlice());
                 deinitMacroArguments(pp.comp.gpa, &args);
                 tokenizer.* = saved_tokenizer;
                 end_idx.* = old_end;
@@ -1281,9 +1282,8 @@ fn expandMacroExhaustive(
                     const count = macro_scan_idx - idx + 1;
                     for (buf.items[idx .. idx + count]) |tok| Token.free(tok.expansion_locs, pp.comp.gpa);
                     try buf.replaceRange(idx, count, res.items);
-                    // TODO: moving_end_idx += res.items.len - (macro_scan_idx-idx+1)
-                    // doesn't work when the RHS is negative (unsigned!)
-                    moving_end_idx = moving_end_idx + res.items.len - count;
+
+                    moving_end_idx = (moving_end_idx + res.items.len) -| count;
                     idx += res.items.len;
                     do_rescan = true;
                 } else {

--- a/test/cases/nested unterminated macro.c
+++ b/test/cases/nested unterminated macro.c
@@ -1,0 +1,20 @@
+#define str(s) # s
+#define xstr(s) str(s)
+#define INCFILE(n) str(strcmp(
+xstr(INCFILE(2)) INCFILE(2))
+
+#define EXPECTED_ERRORS \
+	"nested unterminated macro.c:4:6: error: unterminated function macro argument list" \
+	"nested unterminated macro.c:3:20: note: expanded from here" \
+	"nested unterminated macro.c:4:1: error: unterminated function macro argument list" \
+	"nested unterminated macro.c:2:17: note: expanded from here" \
+	"nested unterminated macro.c:4:18: error: unterminated function macro argument list" \
+	"nested unterminated macro.c:3:20: note: expanded from here" \
+	"nested unterminated macro.c:4:18: error: unterminated function macro argument list" \
+	"nested unterminated macro.c:3:20: note: expanded from here" \
+	"nested unterminated macro.c:4:18: warning: type specifier missing, defaults to 'int' [-Wimplicit-int]" \
+	"nested unterminated macro.c:3:20: note: expanded from here" \
+	"nested unterminated macro.c:4:18: error: expected ')', found '('" \
+	"nested unterminated macro.c:3:30: note: expanded from here" \
+	"nested unterminated macro.c:4:18: note: to match this '('" \
+	"nested unterminated macro.c:3:23: note: expanded from here" \


### PR DESCRIPTION
Nested unterminated macro expansions could underflow `moving_end_idx`

Also addresses a memory leak encountered when eof occurs during
macro argument collection.

Fixes #247