### PR TITLE
Fix crash for empty unions with aggregate initializers

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -123,6 +123,7 @@ pub const Options = packed struct {
     @"backslash-newline-escape": Kind = .default,
     @"pointer-to-int-cast": Kind = .default,
     @"gnu-case-range": Kind = .default,
+    @"c++-compat": Kind = .default,
 };
 
 const messages = struct {
@@ -677,6 +678,12 @@ const messages = struct {
         const opt = "gnu-empty-struct";
         const kind = .off;
         const pedantic = true;
+    };
+    const empty_record_size = struct {
+        const msg = "empty {s} has size 0 in C, size 1 in C++";
+        const extra = .str;
+        const opt = "c++-compat";
+        const kind = .off;
     };
     const wrong_tag = struct {
         const msg = "use of '{s}' with tag type that does not match previous definition";

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -2937,6 +2937,7 @@ fn findAggregateInitializer(p: *Parser, il: **InitList, ty: *Type, start_index: 
         return false;
     } else if (ty.get(.@"union")) |union_ty| {
         if (start_index.*) |_| return false; // overrides
+        if (union_ty.data.record.fields.len == 0) return false;
 
         ty.* = union_ty.data.record.fields[0].ty;
         il.* = try il.*.find(p.pp.comp.gpa, 0);

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1822,7 +1822,10 @@ fn recordSpec(p: *Parser) Error!*Type.Record {
     record_ty.size = 1;
     record_ty.alignment = 1;
 
-    if (p.record_buf.items.len == record_buf_top) try p.errStr(.empty_record, kind_tok, p.tokSlice(kind_tok));
+    if (p.record_buf.items.len == record_buf_top) {
+        try p.errStr(.empty_record, kind_tok, p.tokSlice(kind_tok));
+        try p.errStr(.empty_record_size, kind_tok, p.tokSlice(kind_tok));
+    }
     try p.expectClosing(l_brace, .r_brace);
     try p.attributeSpecifier(); // .record
 

--- a/test/cases/empty records.c
+++ b/test/cases/empty records.c
@@ -1,0 +1,10 @@
+#pragma GCC diagnostic warning "-Wgnu-empty-struct"
+#pragma GCC diagnostic warning "-Wc++-compat"
+
+struct {}s;
+union {}u;
+
+#define EXPECTED_ERRORS "empty records.c:4:1: warning: empty struct is a GNU extension [-Wgnu-empty-struct]" \
+	"empty records.c:4:1: warning: empty struct has size 0 in C, size 1 in C++ [-Wc++-compat]" \
+	"empty records.c:5:1: warning: empty union is a GNU extension [-Wgnu-empty-struct]" \
+	"empty records.c:5:1: warning: empty union has size 0 in C, size 1 in C++ [-Wc++-compat]" \

--- a/test/cases/initializers.c
+++ b/test/cases/initializers.c
@@ -110,6 +110,10 @@ struct {
     };
 } c[2] = { [0].b = 1 };
 
+union {
+
+} empty = {{'a', 'b'}};
+
 #define TESTS_SKIPPED 1
 #define EXPECTED_ERRORS "initializers.c:2:17: error: variable-sized object may not be initialized" \
     "initializers.c:3:15: error: illegal initializer type" \
@@ -152,3 +156,7 @@ struct {
     /* "initializers.c:79:31: warning: variable 's2' is uninitialized when used within its own initialization" */ \
     /* "initializers.c:80:38: warning: variable 's3' is uninitialized when used within its own initialization" */ \
     "initializers.c:104:32: warning: excess elements in array initializer [-Wexcess-initializers]" \
+    "initializers.c:115:18: warning: excess elements in struct initializer [-Wexcess-initializers]" \
+    "initializers.c:115:12: warning: initializer overrides previous initialization [-Winitializer-overrides]" \
+    "initializers.c:115:13: note: previous initialization" \
+    "initializers.c:115:12: warning: excess elements in struct initializer [-Wexcess-initializers]" \


### PR DESCRIPTION
Also adds a warning for different empty-record sizes in C vs C++