### PR TITLE
Tree: don't try to print values of type void

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4242,6 +4242,7 @@ const Result = struct {
                 .ty = res.ty,
                 .data = .{ .un = res.node },
             });
+            res.val.tag = .unavailable;
         }
     }
 

--- a/test/cases/casts.c
+++ b/test/cases/casts.c
@@ -10,6 +10,9 @@ void foo(void) {
     int a = (char)"foo";
     int b = (float)"foo";
     unsigned long long d = (unsigned long long)"foo";
+
+    int x = 1;
+    x ? (void)1 : 1;
 }
 
 #define EXPECTED_ERRORS "casts.c:5:5: error: cannot cast to non arithmetic or pointer type 'int'" \


### PR DESCRIPTION
Values can be implicitly cast to void if the other branch of a
conditional operator is void.

Fixes #252