### PR TITLE
Parser: Treat record fields as a separate type of Symbol

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -27,6 +27,7 @@ const Scope = union(enum) {
     @"enum": Symbol,
     decl: Symbol,
     def: Symbol,
+    field: Symbol,
     param: Symbol,
     enumeration: Enumeration,
     loop,
@@ -160,7 +161,7 @@ record: struct {
         while (i > r.scopes_top) {
             i -= 1;
             switch (p.scopes.items[i]) {
-                .def => |d| if (mem.eql(u8, d.name, name)) {
+                .field => |d| if (mem.eql(u8, d.name, name)) {
                     try p.errStr(.duplicate_member, name_tok, name);
                     try p.errTok(.previous_definition, d.name_tok);
                     break;
@@ -169,7 +170,7 @@ record: struct {
             }
         }
         try p.scopes.append(.{
-            .def = .{
+            .field = .{
                 .name = name,
                 .name_tok = name_tok,
                 .ty = undefined, // unused

--- a/test/cases/vla.c
+++ b/test/cases/vla.c
@@ -3,4 +3,10 @@ void foo(int x) {
     int arr[x];
 }
 
-#define EXPECTED_ERRORS "vla.c:3:13: warning: variable length array used [-Wvla]"
+struct S {
+    int x;
+    int y[x];
+};
+
+#define EXPECTED_ERRORS "vla.c:3:13: warning: variable length array used [-Wvla]" \
+    "vla.c:8:11: error: use of undeclared identifier 'x'" \


### PR DESCRIPTION
Adds a new Symbol type, `field`, to prevent the parser from attemping to
use field definitions as VLA length specifiers.

Fixes #266