### PR TITLE
Test all allocation failures

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -33,6 +33,8 @@ pub fn build(b: *Builder) !void {
     // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
 
+    const test_all_allocation_failures = b.option(bool, "test-all-allocation-failures", "Test all allocation failures") orelse false;
+
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
     const mode = b.standardReleaseOptions();
@@ -71,6 +73,9 @@ pub fn build(b: *Builder) !void {
         .path = .{ .path = "src/lib.zig" },
         .dependencies = &.{zig_pkg},
     });
+    const test_runner_options = b.addOptions();
+    integration_tests.addOptions("build_options", test_runner_options);
+    test_runner_options.addOption(bool, "test_all_allocation_failures", test_all_allocation_failures);
 
     const integration_test_runner = integration_tests.run();
     integration_test_runner.addArg(b.pathFromRoot("test/cases"));

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -5967,17 +5967,7 @@ fn parseFloat(p: *Parser, tok: TokenIndex, comptime T: type) Error!T {
         .imaginary_literal_f, .imaginary_literal_l => bytes = bytes[0 .. bytes.len - 2],
         else => unreachable,
     }
-    if (bytes.len > 2 and (bytes[1] == 'x' or bytes[1] == 'X')) {
-        assert(bytes[0] == '0'); // validated by Tokenizer
-        return std.fmt.parseHexFloat(T, bytes) catch |e| switch (e) {
-            error.InvalidCharacter => unreachable, // validated by Tokenizer
-            error.Overflow => p.todo("what to do with hex floats too big"),
-        };
-    } else {
-        return std.fmt.parseFloat(T, bytes) catch |e| switch (e) {
-            error.InvalidCharacter => unreachable, // validated by Tokenizer
-        };
-    }
+    return std.fmt.parseFloat(T, bytes) catch unreachable; // valid hex chars enforced by Tokenizer
 }
 
 fn integerLiteral(p: *Parser) Error!Result {

--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -1155,26 +1155,38 @@ fn collectMacroFuncArguments(
         switch (tok.id) {
             .comma => {
                 if (parens == 0) {
-                    try args.append(curArgument.toOwnedSlice());
+                    const owned = curArgument.toOwnedSlice();
+                    errdefer pp.comp.gpa.free(owned);
+                    try args.append(owned);
                 } else {
-                    try curArgument.append(try tok.dupe(pp.comp.gpa));
+                    const duped = try tok.dupe(pp.comp.gpa);
+                    errdefer Token.free(duped.expansion_locs, pp.comp.gpa);
+                    try curArgument.append(duped);
                 }
             },
             .l_paren => {
-                try curArgument.append(try tok.dupe(pp.comp.gpa));
+                const duped = try tok.dupe(pp.comp.gpa);
+                errdefer Token.free(duped.expansion_locs, pp.comp.gpa);
+                try curArgument.append(duped);
                 parens += 1;
             },
             .r_paren => {
                 if (parens == 0) {
-                    try args.append(curArgument.toOwnedSlice());
+                    const owned = curArgument.toOwnedSlice();
+                    errdefer pp.comp.gpa.free(owned);
+                    try args.append(owned);
                     break;
                 } else {
-                    try curArgument.append(try tok.dupe(pp.comp.gpa));
+                    const duped = try tok.dupe(pp.comp.gpa);
+                    errdefer Token.free(duped.expansion_locs, pp.comp.gpa);
+                    try curArgument.append(duped);
                     parens -= 1;
                 }
             },
             .eof => {
-                try args.append(curArgument.toOwnedSlice());
+                const owned = curArgument.toOwnedSlice();
+                errdefer pp.comp.gpa.free(owned);
+                try args.append(owned);
                 deinitMacroArguments(pp.comp.gpa, &args);
                 tokenizer.* = saved_tokenizer;
                 end_idx.* = old_end;

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -30,7 +30,9 @@ pub const Token = struct {
             std.mem.set(Source.Location, list.items.ptr[list.items.len..list.capacity], .{});
             // add a sentinel since the allocator is not guaranteed
             // to return the exact desired size
-            list.items.ptr[list.capacity - 1].byte_offset = 1;
+            if (list.capacity > 0) {
+                list.items.ptr[list.capacity - 1].byte_offset = 1;
+            }
             tok.expansion_locs = list.items.ptr;
         }
 

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -51,7 +51,9 @@ fn testFn(allocator: std.mem.Allocator) !void {
 
             defer buf.items.len = 0;
             try buf.writer().print("{s}{c}{s}", .{ args[1], std.fs.path.sep, entry.name });
-            try cases.append(try allocator.dupe(u8, buf.items));
+            const case = try allocator.dupe(u8, buf.items);
+            errdefer allocator.free(case);
+            try cases.append(case);
         }
     }
 

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -495,7 +495,9 @@ const StmtTypeDumper = struct {
         if (tag == .implicit_return) return;
         const ty = tree.nodes.items(.ty)[@enumToInt(node)];
         ty.dump(m.buf.writer()) catch {};
-        try self.types.append(m.buf.toOwnedSlice());
+        const owned = m.buf.toOwnedSlice();
+        errdefer m.buf.allocator.free(owned);
+        try self.types.append(owned);
     }
 
     fn dump(self: *StmtTypeDumper, tree: *const aro.Tree, decl_idx: NodeIndex, allocator: std.mem.Allocator) AllocatorError!void {

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -456,7 +456,9 @@ const StmtTypeDumper = struct {
         if (tag == .implicit_return) return;
         const ty = tree.nodes.items(.ty)[@enumToInt(node)];
         ty.dump(m.buf.writer()) catch {};
-        try self.types.append(m.buf.toOwnedSlice());
+        const slice = m.buf.toOwnedSlice();
+        errdefer m.buf.allocator.free(slice);
+        try self.types.append(slice);
     }
 
     fn dump(self: *StmtTypeDumper, tree: *const aro.Tree, decl_idx: NodeIndex, allocator: std.mem.Allocator) AllocatorError!void {

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -69,6 +69,11 @@ fn testFn(allocator: std.mem.Allocator) !void {
 
     // apparently we can't use setAstCwd without libc on windows yet
     const win = @import("builtin").os.tag == .windows;
+
+    var old_cwd_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    const old_cwd = if (!win) try std.os.getcwd(&old_cwd_buf);
+    defer if (!win) std.os.chdir(old_cwd) catch unreachable;
+
     var tmp_dir = if (!win) std.testing.tmpDir(.{});
     defer if (!win) tmp_dir.cleanup();
 

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -6,12 +6,17 @@ const Tree = aro.Tree;
 const Token = Tree.Token;
 const NodeIndex = Tree.NodeIndex;
 const AllocatorError = std.mem.Allocator.Error;
+const build_options = @import("build_options");
 
 pub fn main() !void {
-    std.testing.checkAllAllocationFailures(std.testing.allocator, testFn, .{}) catch |err| switch (err) {
-        error.OutOfMemory => {},
-        else => |e| return e,
-    };
+    if (build_options.test_all_allocation_failures) {
+        std.testing.checkAllAllocationFailures(std.testing.allocator, testFn, .{}) catch |err| switch (err) {
+            error.OutOfMemory => {},
+            else => |e| return e,
+        };
+    } else {
+        try testFn(std.testing.allocator);
+    }
 }
 
 fn testFn(allocator: std.mem.Allocator) !void {

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -320,9 +320,7 @@ pub fn main() !void {
                 try obj.finish(out_file);
             }
 
-            var child = try std.ChildProcess.init(&.{ args[2], "run", "-lc", obj_name }, gpa);
-            defer child.deinit();
-
+            var child = std.ChildProcess.init(&.{ args[2], "run", "-lc", obj_name }, gpa);
             child.stdout_behavior = .Pipe;
 
             try child.spawn();


### PR DESCRIPTION
Initial support for #74

Run with `zig build test -Dtest-all-allocation-failures=true` (currently finds some leaks)

Eventually `checkAllAllocationFailures` should be used per test-case, but for now was easier to just apply it to the whole test suite