### PR TITLE
Compilation: refactor addSourceFromReader

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -507,15 +507,17 @@ pub fn getSource(comp: *Compilation, id: Source.Id) Source {
     return comp.sources.values()[@enumToInt(id) - 2];
 }
 
-/// Write bytes from `reader` into `contents`, performing newline splicing,
-/// line-ending normalization (convert line endings to \n), and UTF-8 validation.
-/// Creates a Source with `contents` as the buf and adds it to the Compilation.
-/// `contents` is assumed to be large enough to hold the entire content of `reader`.
-/// `contents` must have been allocated by `comp`'s allocator since it will be reallocated
-/// if splicing occurred.
-/// Compilation owns `contents` if and only if this call succeeds; caller always retains
-/// ownership of `path`.
-pub fn addSourceFromReader(comp: *Compilation, reader: anytype, path: []const u8, contents: []u8) !Source {
+/// Creates a Source from the contents of `reader` and adds it to the Compilation
+/// Performs newline splicing, line-ending normalization to '\n', and UTF-8 validation.
+/// caller retains ownership of `path`
+/// `expected_size` will be allocated to hold the contents of `reader` and *must* be at least
+/// as large as the entire contents of `reader`.
+/// To add a pre-existing buffer as a Source, see addSourceFromBuffer
+/// To add a file's contents given its path, see addSourceFromPath
+pub fn addSourceFromReader(comp: *Compilation, reader: anytype, path: []const u8, expected_size: u32) !Source {
+    var contents = try comp.gpa.alloc(u8, expected_size);
+    errdefer comp.gpa.free(contents);
+
     const duped_path = try comp.gpa.dupe(u8, path);
     errdefer comp.gpa.free(duped_path);
 
@@ -603,10 +605,12 @@ pub fn addSourceFromReader(comp: *Compilation, reader: anytype, path: []const u8
     const splice_locs = splice_list.toOwnedSlice();
     errdefer comp.gpa.free(splice_locs);
 
+    if (i != contents.len) contents = try comp.gpa.realloc(contents, i);
+
     var source = Source{
         .id = source_id,
         .path = duped_path,
-        .buf = if (i == contents.len) contents else try comp.gpa.realloc(contents, i),
+        .buf = contents,
         .splice_locs = splice_locs,
     };
 
@@ -619,13 +623,10 @@ pub fn addSourceFromReader(comp: *Compilation, reader: anytype, path: []const u8
 pub fn addSourceFromBuffer(comp: *Compilation, path: []const u8, buf: []const u8) !Source {
     if (comp.sources.get(path)) |some| return some;
 
-    if (buf.len > std.math.maxInt(u32)) return error.StreamTooLong;
-
+    const size = std.math.cast(u32, buf.len) catch return error.StreamTooLong;
     const reader = std.io.fixedBufferStream(buf).reader();
-    const contents = try comp.gpa.alloc(u8, buf.len);
-    errdefer comp.gpa.free(contents);
 
-    return comp.addSourceFromReader(reader, path, contents);
+    return comp.addSourceFromReader(reader, path, size);
 }
 
 /// Caller retains ownership of `path`
@@ -640,12 +641,9 @@ pub fn addSourceFromPath(comp: *Compilation, path: []const u8) !Source {
     defer file.close();
 
     const size = std.math.cast(u32, try file.getEndPos()) catch return error.StreamTooLong;
-
     var reader = std.io.bufferedReader(file.reader()).reader();
-    const contents = try comp.gpa.alloc(u8, size);
-    errdefer comp.gpa.free(contents);
 
-    return comp.addSourceFromReader(reader, path, contents);
+    return comp.addSourceFromReader(reader, path, size);
 }
 
 pub fn findInclude(comp: *Compilation, tok: Token, filename: []const u8, search_cwd: bool) !?Source {
@@ -770,14 +768,20 @@ test "addSourceFromReader" {
             var comp = Compilation.init(std.testing.allocator);
             defer comp.deinit();
 
-            const contents = try comp.gpa.alloc(u8, 1024);
-
             var reader = std.io.fixedBufferStream(str).reader();
-            const source = try comp.addSourceFromReader(reader, "path", contents);
+            const source = try comp.addSourceFromReader(reader, "path", @intCast(u32, str.len));
 
             try std.testing.expectEqualStrings(expected, source.buf);
             try std.testing.expectEqual(warning_count, @intCast(u32, comp.diag.list.items.len));
             try std.testing.expectEqualSlices(u32, splices, source.splice_locs);
+        }
+
+        fn withAllocationFailures(allocator: std.mem.Allocator) !void {
+            var comp = Compilation.init(allocator);
+            defer comp.deinit();
+
+            _ = try comp.addSourceFromBuffer("path", "spliced\\\nbuffer\n");
+            _ = try comp.addSourceFromBuffer("path", "non-spliced buffer\n");
         }
     };
     try Test.addSourceFromReader("ab\\\nc", "abc", 0, &.{2});
@@ -806,6 +810,8 @@ test "addSourceFromReader" {
     try Test.addSourceFromReader("ab\r\r\n\r", "ab\n\n\n", 0, &.{});
     try Test.addSourceFromReader("\r\\", "\n\\", 0, &.{});
     try Test.addSourceFromReader("\\\r\\", "\\", 0, &.{0});
+
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Test.withAllocationFailures, .{});
 }
 
 test "addSourceFromReader - exhaustive check for carriage return elimination" {


### PR DESCRIPTION
Refactor addSourceFromReader to take a size argument instead of a
pre-allocated buffer. This makes it easier to clean up resources in
the case of a memory allocation failure. Adds a test to ensure that
an allocation failure in addSourceFromReader will not leak memory.