### PR TITLE
Parser: Do not allow incomplete-size fields in anonymous records.

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1798,7 +1798,7 @@ fn recordDeclarator(p: *Parser) Error!bool {
         }
 
         if (name_tok == 0 and bits_node == .none) unnamed: {
-            if (ty.is(.@"enum")) break :unnamed;
+            if (ty.is(.@"enum") or ty.hasIncompleteSize()) break :unnamed;
             if (ty.isAnonymousRecord()) {
                 // An anonymous record appears as indirect fields on the parent
                 try p.record_buf.append(.{


### PR DESCRIPTION
Fixes #275