### PR TITLE
Parser: allow enumeration constants to be used as constexpr's

### DIFF
--- a/src/SymbolStack.zig
+++ b/src/SymbolStack.zig
@@ -331,6 +331,7 @@ pub fn defineEnumeration(
     p: *Parser,
     ty: Type,
     tok: TokenIndex,
+    val: Value,
 ) !void {
     const name = p.tokSlice(tok);
     const kinds = s.syms.items(.kind);
@@ -358,6 +359,6 @@ pub fn defineEnumeration(
         .name = name,
         .tok = tok,
         .ty = ty,
-        .val = .{},
+        .val = val,
     });
 }

--- a/test/cases/containers.c
+++ b/test/cases/containers.c
@@ -128,8 +128,7 @@ struct A {
 struct B b1;
 
 
-#define EXPECTED_ERRORS "containers.c:11:9: error: enum value must be an integer constant expression" \
-    "containers.c:15:8: error: use of 'Foo' with tag type that does not match previous definition" \
+#define EXPECTED_ERRORS "containers.c:15:8: error: use of 'Foo' with tag type that does not match previous definition" \
     "containers.c:9:6: note: previous definition is here" \
     "containers.c:15:12: error: variable has incomplete type 'struct Foo'" \
     "containers.c:20:6: warning: declaration does not declare anything [-Wmissing-declaration]" \

--- a/test/cases/enumerator constants.c
+++ b/test/cases/enumerator constants.c
@@ -1,0 +1,22 @@
+enum E {
+	A,
+	B = 10,
+	C,
+	D = 2,
+	E = -2,
+	F,
+};
+
+_Static_assert(A == 0, "A is wrong");
+_Static_assert(B == 10, "B is wrong");
+_Static_assert(C == 11, "C is wrong");
+_Static_assert(D == 2, "D is wrong");
+_Static_assert(E == -2, "E is wrong");
+_Static_assert(F == -1, "F is wrong");
+
+void foo(enum E e) {
+	switch (e) {
+		case A: return;
+		default: return;
+	}
+}


### PR DESCRIPTION
Additionally fixes an issue where the first enumeration constant defaulted
to 1 instead of 0.

Closes #286