### PR TITLE
Stdlib updates

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,7 +41,7 @@ pub fn build(b: *Builder) !void {
 
     const zig_pkg = std.build.Pkg{
         .name = "zig",
-        .path = .{ .path = "deps/zig/lib.zig" },
+        .source = .{ .path = "deps/zig/lib.zig" },
     };
 
     const exe = b.addExecutable("arocc", "src/main.zig");
@@ -70,7 +70,7 @@ pub fn build(b: *Builder) !void {
     const integration_tests = b.addExecutable("arocc", "test/runner.zig");
     integration_tests.addPackage(.{
         .name = "aro",
-        .path = .{ .path = "src/lib.zig" },
+        .source = .{ .path = "src/lib.zig" },
         .dependencies = &.{zig_pkg},
     });
     const test_runner_options = b.addOptions();

--- a/src/Attribute.zig
+++ b/src/Attribute.zig
@@ -222,7 +222,7 @@ pub fn diagnoseAlignment(attr: Tag, arguments: *Arguments, arg_idx: u32, val: Va
                     if (val.compare(.lt, Value.int(0), ty, comp)) {
                         return Diagnostics.Message{ .tag = .negative_alignment, .extra = .{ .signed = val.signExtend(ty, comp) } };
                     }
-                    const requested = std.math.cast(u29, val.data.int) catch {
+                    const requested = std.math.cast(u29, val.data.int) orelse {
                         return Diagnostics.Message{ .tag = .maximum_alignment, .extra = .{ .unsigned = val.data.int } };
                     };
                     if (!std.mem.isValidAlign(requested)) return Diagnostics.Message{ .tag = .non_pow2_align };

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -628,7 +628,7 @@ pub fn addSourceFromReader(comp: *Compilation, reader: anytype, path: []const u8
 pub fn addSourceFromBuffer(comp: *Compilation, path: []const u8, buf: []const u8) !Source {
     if (comp.sources.get(path)) |some| return some;
 
-    const size = std.math.cast(u32, buf.len) catch return error.StreamTooLong;
+    const size = std.math.cast(u32, buf.len) orelse return error.StreamTooLong;
     const reader = std.io.fixedBufferStream(buf).reader();
 
     return comp.addSourceFromReader(reader, path, size);
@@ -645,7 +645,7 @@ pub fn addSourceFromPath(comp: *Compilation, path: []const u8) !Source {
     const file = try std.fs.cwd().openFile(path, .{});
     defer file.close();
 
-    const size = std.math.cast(u32, try file.getEndPos()) catch return error.StreamTooLong;
+    const size = std.math.cast(u32, try file.getEndPos()) orelse return error.StreamTooLong;
     var reader = std.io.bufferedReader(file.reader()).reader();
 
     return comp.addSourceFromReader(reader, path, size);


### PR DESCRIPTION
1. `std.build.Pkg.path` renamed to `std.build.Pkg.source`
2. std.math.cast now returns an optional instead of error