### PR TITLE
Parser: Compute sizeof / alignof struct and union types

### DIFF
--- a/test/cases/record sizeof.c
+++ b/test/cases/record sizeof.c
@@ -1,3 +1,5 @@
+#if defined(__linux__) && defined(__x86_64__)
+
 union my_union {
   int foo;
   char bar;
@@ -22,3 +24,20 @@ _Static_assert(sizeof(struct my_struct) == 16, "differs from gcc x86_64 linux");
 _Static_assert(sizeof(union my_union) == 8, "differs from gcc x86_64 linux");
 _Static_assert(sizeof(struct complicated) == 160,
                "differs from gcc x86_64 linux");
+
+// Test sizeof with alignment attributes
+
+struct S1 {
+    __attribute__((aligned(64))) int x;
+};
+_Static_assert(_Alignof(struct S1) == 64, "bad alignment");
+
+struct S2 {
+    __attribute__((aligned(1))) int y;
+};
+_Static_assert(_Alignof(struct S2) == _Alignof(int), "bad alignment");
+
+int __attribute__((aligned(1))) z;
+_Static_assert(_Alignof(z) == 1, "bad alignment");
+
+#endif

--- a/test/cases/record sizeof.c
+++ b/test/cases/record sizeof.c
@@ -1,0 +1,24 @@
+union my_union {
+  int foo;
+  char bar;
+  long long baz;
+};
+
+struct my_struct {
+  int foo;
+  char bar;
+  long long baz;
+};
+
+struct complicated {
+  char a;
+  union my_union union_arr[7];
+  short b;
+  struct my_struct struct_arr[5];
+  int c;
+};
+
+_Static_assert(sizeof(struct my_struct) == 16, "differs from gcc x86_64 linux");
+_Static_assert(sizeof(union my_union) == 8, "differs from gcc x86_64 linux");
+_Static_assert(sizeof(struct complicated) == 160,
+               "differs from gcc x86_64 linux");


### PR DESCRIPTION
Compute sizeof/alignof records.

This isn't a perfect solution - I'm unsure if it works identically to other compilers in all cases & it definitely doesn't factor in packed attributes. But it's good enough - I wanted to load `netinet/in.h`, which fails with the following error otherwise:

```
Compiler error:
/usr/include/netinet/in.h:244:53: warning: overflow in expression; result is '18446744073709551615' [-Winteger-overflow]
    unsigned char sin_zero[sizeof (struct sockaddr) -
                                                    ^
/usr/include/netinet/in.h:244:27: error: array is too large
    unsigned char sin_zero[sizeof (struct sockaddr) -


// Because of this expression:
unsigned char sin_zero[sizeof (struct sockaddr) -
                        __SOCKADDR_COMMON_SIZE -
                        sizeof (in_port_t) -
                        sizeof (struct in_addr)];
```

Two questions: 
1. How can i report a compiler error? see line 1711. I poked around Compilation.zig but nothing jumped out.
2. The test is obviously flawed, I just matched whatever GCC produced on my system. I can either remove the test, or maybe there's a way to skip it on non-x64-linux systems?