### PR TITLE
Parser: ensure that attributes after a record's closing rbrace aren't ignored

### DIFF
--- a/test/cases/attributes.c
+++ b/test/cases/attributes.c
@@ -98,10 +98,11 @@ int baz;
 }
 
 _Static_assert(sizeof(struct S2) == 1, "sizeof aligned struct"); /* TODO: Should be 8 */
+_Static_assert(_Alignof(union U1) == 1, "_Alignof aligned union"); /* TODO: should be 8 */
 
 __attribute__(()) // test attribute at eof
 
-#define TESTS_SKIPPED 4
+#define TESTS_SKIPPED 5
 
 #define EXPECTED_ERRORS \
 	/* "attributes.c:8:26: warning: Attribute 'noreturn' ignored in variable context [-Wignored-attributes]" */ \
@@ -110,4 +111,4 @@ __attribute__(()) // test attribute at eof
     "attributes.c:36:5: error: fallthrough annotation does not directly precede switch label" \
     /* "attributes.c:40:20: error: attribute cannot be applied to a statement" */ \
     "attributes.c:76:6: error: cannot call non function type 'int'" \
-    "attributes.c:102:18: error: expected identifier or '('" \
+    "attributes.c:103:18: error: expected identifier or '('" \


### PR DESCRIPTION
Fixes #293