### PR TITLE
Basic implementation of #include_next

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -718,7 +718,13 @@ pub fn hasInclude(comp: *const Compilation, filename: []const u8, cwd_source_id:
     return false;
 }
 
-pub fn findInclude(comp: *Compilation, filename: []const u8, cwd_source_id: ?Source.Id) !?Source {
+pub const WhichInclude = enum {
+    first,
+    next,
+};
+
+pub fn findInclude(comp: *Compilation, filename: []const u8, cwd_source_id: ?Source.Id, which: WhichInclude) !?Source {
+    _ = which;
     var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
     var it = IncludeDirIterator{ .comp = comp, .cwd_source_id = cwd_source_id, .path_buf = &path_buf };
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -723,10 +723,44 @@ pub const WhichInclude = enum {
     next,
 };
 
-pub fn findInclude(comp: *Compilation, filename: []const u8, cwd_source_id: ?Source.Id, which: WhichInclude) !?Source {
-    _ = which;
+pub const IncludeType = enum {
+    quotes,
+    angle_brackets,
+};
+
+pub fn findInclude(
+    comp: *Compilation,
+    filename: []const u8,
+    includer_token_source: Source.Id,
+    include_type: IncludeType,
+    which: WhichInclude,
+) !?Source {
     var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    if (std.fs.path.isAbsolute(filename)) {
+        if (which == .next) return null;
+        return if (comp.addSourceFromPath(filename)) |some|
+            some
+        else |err| switch (err) {
+            error.OutOfMemory => |e| return e,
+            else => null,
+        };
+    }
+    const cwd_source_id = switch (include_type) {
+        .quotes => switch (which) {
+            .first => includer_token_source,
+            .next => null,
+        },
+        .angle_brackets => null,
+    };
     var it = IncludeDirIterator{ .comp = comp, .cwd_source_id = cwd_source_id, .path_buf = &path_buf };
+
+    if (which == .next) {
+        const path = comp.getSource(includer_token_source).path;
+        const includer_path = std.fs.path.dirname(path) orelse ".";
+        while (it.next()) |dir| {
+            if (mem.eql(u8, includer_path, dir)) break;
+        }
+    }
 
     while (it.nextWithFile(filename)) |path| {
         if (comp.addSourceFromPath(path)) |some|

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -131,6 +131,9 @@ pub const Options = packed struct {
     @"gnu-folding-constant": Kind = .default,
     undef: Kind = .default,
     @"ignored-pragmas": Kind = .default,
+    @"gnu-include-next": Kind = .default,
+    @"include-next-outside-header": Kind = .default,
+    @"include-next-absolute-path": Kind = .default,
 };
 
 const messages = struct {
@@ -1778,6 +1781,17 @@ const messages = struct {
         const extra = .unsigned;
         const kind = .off;
         const opt = "pedantic";
+    };
+    const include_next = struct {
+        const msg = "#include_next is a language extension";
+        const kind = .off;
+        const pedantic = true;
+        const opt = "gnu-include-next";
+    };
+    const include_next_outside_header = struct {
+        const msg = "#include_next in primary source file; will search from start of include path";
+        const kind = .warning;
+        const opt = "include-next-outside-header";
     };
 };
 

--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -337,7 +337,8 @@ fn preprocessExtra(pp: *Preprocessor, source: Source) MacroError!Token {
                         _ = pp.defines.remove(macro_name);
                         try pp.expectNl(&tokenizer);
                     },
-                    .keyword_include => try pp.include(&tokenizer),
+                    .keyword_include => try pp.include(&tokenizer, .first),
+                    .keyword_include_next => try pp.include(&tokenizer, .next),
                     .keyword_pragma => try pp.pragma(&tokenizer, directive, null, &.{}),
                     .keyword_line => {
                         // #line number "file"
@@ -1834,10 +1835,9 @@ fn defineFn(pp: *Preprocessor, tokenizer: *Tokenizer, macro_name: RawToken, l_pa
 }
 
 // Handle a #include directive.
-fn include(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!void {
+fn include(pp: *Preprocessor, tokenizer: *Tokenizer, which: Compilation.WhichInclude) MacroError!void {
     const first = tokenizer.nextNoWS();
-
-    const new_source = findIncludeSource(pp, first, tokenizer) catch |er| switch (er) {
+    const new_source = findIncludeSource(pp, tokenizer, first, which) catch |er| switch (er) {
         error.InvalidInclude => return,
         else => |e| return e,
     };
@@ -1967,7 +1967,7 @@ fn findIncludeFilenameToken(
     return filename_tok;
 }
 
-fn findIncludeSource(pp: *Preprocessor, first: RawToken, tokenizer: *Tokenizer) !Source {
+fn findIncludeSource(pp: *Preprocessor, tokenizer: *Tokenizer, first: RawToken, which: Compilation.WhichInclude) !Source {
     const filename_tok = try pp.findIncludeFilenameToken(first, tokenizer, .expect_nl_eof);
 
     // Check for empty filename.
@@ -1981,7 +1981,7 @@ fn findIncludeSource(pp: *Preprocessor, first: RawToken, tokenizer: *Tokenizer) 
     const filename = tok_slice[1 .. tok_slice.len - 1];
     const cwd_source_id = if (filename_tok.id == .string_literal) first.source else null;
 
-    return (try pp.comp.findInclude(filename, cwd_source_id)) orelse
+    return (try pp.comp.findInclude(filename, cwd_source_id, which)) orelse
         pp.fatal(first, "'{s}' not found", .{filename});
 }
 

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -205,6 +205,7 @@ pub const Token = struct {
 
         // Preprocessor directives
         keyword_include,
+        keyword_include_next,
         keyword_define,
         keyword_defined,
         keyword_undef,
@@ -263,6 +264,7 @@ pub const Token = struct {
         pub fn isMacroIdentifier(id: Id) bool {
             switch (id) {
                 .keyword_include,
+                .keyword_include_next,
                 .keyword_define,
                 .keyword_defined,
                 .keyword_undef,
@@ -368,6 +370,7 @@ pub const Token = struct {
         pub fn simplifyMacroKeyword(id: *Id) void {
             switch (id.*) {
                 .keyword_include,
+                .keyword_include_next,
                 .keyword_define,
                 .keyword_defined,
                 .keyword_undef,
@@ -538,6 +541,7 @@ pub const Token = struct {
                 .keyword_static_assert => "_Static_assert",
                 .keyword_thread_local => "_Thread_local",
                 .keyword_include => "include",
+                .keyword_include_next => "include_next",
                 .keyword_define => "define",
                 .keyword_defined => "defined",
                 .keyword_undef => "undef",
@@ -787,6 +791,7 @@ pub const Token = struct {
 
         // Preprocessor directives
         .{ "include", .keyword_include },
+        .{ "include_next", .keyword_include_next },
         .{ "define", .keyword_define },
         .{ "defined", .keyword_defined },
         .{ "undef", .keyword_undef },
@@ -1952,6 +1957,7 @@ test "keywords" {
 test "preprocessor keywords" {
     try expectTokens(
         \\#include
+        \\#include_next
         \\#define
         \\#ifdef
         \\#ifndef
@@ -1961,6 +1967,9 @@ test "preprocessor keywords" {
     , &.{
         .hash,
         .keyword_include,
+        .nl,
+        .hash,
+        .keyword_include_next,
         .nl,
         .hash,
         .keyword_define,

--- a/test/cases/include/my_include.h
+++ b/test/cases/include/my_include.h
@@ -1,3 +1,4 @@
 #define FOO 1
 
 #include_next <my_include.h> // test/cases/include/next/my_include.h
+#include_next <other.h>  // test/cases/include/next/other.h 

--- a/test/cases/include/my_include.h
+++ b/test/cases/include/my_include.h
@@ -1,0 +1,3 @@
+#define FOO 1
+
+#include_next <my_include.h> // test/cases/include/next/my_include.h

--- a/test/cases/include/next/my_include.h
+++ b/test/cases/include/next/my_include.h
@@ -1,0 +1,1 @@
+#define BAR 2

--- a/test/cases/include/next/other.h
+++ b/test/cases/include/next/other.h
@@ -1,0 +1,4 @@
+#if defined(OTHER_INCLUDED)
+#error should not have been included yet
+#endif
+#define NEXT_OTHER_INCLUDED 1

--- a/test/cases/include/other.h
+++ b/test/cases/include/other.h
@@ -1,0 +1,1 @@
+#define OTHER_INCLUDED 1

--- a/test/cases/include_next.c
+++ b/test/cases/include_next.c
@@ -1,0 +1,10 @@
+//aro-args -Wgnu-include-next
+#include <my_include.h> // test/cases/include/my_include.h
+#include_next <stdalign.h>
+_Static_assert(FOO == 1, "Did not include correct file");
+_Static_assert(BAR == 2, "Did not include_next correct file");
+
+#define EXPECTED_ERRORS \
+	"my_include.h:3:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
+	"include_next.c:3:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
+	"include_next.c:3:2: warning: #include_next in primary source file; will search from start of include path [-Winclude-next-outside-header]" \

--- a/test/cases/include_next.c
+++ b/test/cases/include_next.c
@@ -1,10 +1,14 @@
-//aro-args -Wgnu-include-next
+//aro-args -Wgnu-include-next -Wno-gnu-alignof-expression
 #include <my_include.h> // test/cases/include/my_include.h
 #include_next <stdalign.h>
+#include_next "global_var.h"
 _Static_assert(FOO == 1, "Did not include correct file");
 _Static_assert(BAR == 2, "Did not include_next correct file");
+_Static_assert(alignof(multiple) == _Alignof(int), "#include_next quotes");
 
 #define EXPECTED_ERRORS \
 	"my_include.h:3:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
 	"include_next.c:3:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
 	"include_next.c:3:2: warning: #include_next in primary source file; will search from start of include path [-Winclude-next-outside-header]" \
+	"include_next.c:4:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
+	"include_next.c:4:2: warning: #include_next in primary source file; will search from start of include path [-Winclude-next-outside-header]" \

--- a/test/cases/include_next.c
+++ b/test/cases/include_next.c
@@ -2,13 +2,19 @@
 #include <my_include.h> // test/cases/include/my_include.h
 #include_next <stdalign.h>
 #include_next "global_var.h"
+#include_next <other.h>
 _Static_assert(FOO == 1, "Did not include correct file");
 _Static_assert(BAR == 2, "Did not include_next correct file");
 _Static_assert(alignof(multiple) == _Alignof(int), "#include_next quotes");
+_Static_assert(OTHER_INCLUDED == 1, "OTHER_INCLUDED");
+_Static_assert(NEXT_OTHER_INCLUDED == 1, "NEXT_OTHER_INCLUDED");
 
 #define EXPECTED_ERRORS \
 	"my_include.h:3:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
+	"my_include.h:4:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
 	"include_next.c:3:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
 	"include_next.c:3:2: warning: #include_next in primary source file; will search from start of include path [-Winclude-next-outside-header]" \
 	"include_next.c:4:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
 	"include_next.c:4:2: warning: #include_next in primary source file; will search from start of include path [-Winclude-next-outside-header]" \
+	"include_next.c:5:2: warning: #include_next is a language extension [-Wgnu-include-next]" \
+	"include_next.c:5:2: warning: #include_next in primary source file; will search from start of include path [-Winclude-next-outside-header]" \

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -131,6 +131,11 @@ pub fn main() !void {
 
     try initial_comp.include_dirs.append(cases_include_dir);
 
+    const cases_next_include_dir = try std.fs.path.join(gpa, &.{ args[1], "include", "next" });
+    defer gpa.free(cases_next_include_dir);
+
+    try initial_comp.include_dirs.append(cases_next_include_dir);
+
     try initial_comp.addDefaultPragmaHandlers();
     try initial_comp.defineSystemIncludes();
 


### PR DESCRIPTION
This is a very basic implementation of `#include_next` that just uses exact string matches to advance the iterator past the directory of the current file.

The clang code for looking up includes has a lot going on: https://github.com/llvm/llvm-project/blob/264c09b732ab61936a499f133abdfc67df422a86/clang/lib/Lex/HeaderSearch.cpp#L836= which could be a fruitful source of ideas of how to improve things.

Not sure if these should be separate issues, but possible enhancements include: caching so that we're not repeatedly looking up nonexistent files, Apple Framework support, `O(1)` advancement of the `include_next` iterator, MSVC-style "include stacks", tracking whether the current file was included by quoted include / angled include / absolute path