### PR TITLE
Preprocessor: Diagnose an error if preprocessor depth limit exceeded.

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -1758,6 +1758,10 @@ const messages = struct {
         const extra = .str;
         const kind = .@"error";
     };
+    const too_many_includes = struct {
+        const msg = "#include nested too deeply";
+        const kind = .@"error";
+    };
 };
 
 list: std.ArrayListUnmanaged(Message) = .{},

--- a/test/cases/self_include.c
+++ b/test/cases/self_include.c
@@ -1,0 +1,2 @@
+#define EXPECTED_ERRORS "self_include.c:2:10: error: #include nested too deeply"
+#include "self_include.c"


### PR DESCRIPTION
Previously, overly-nested includes were silently discarded