### PR TITLE
Attribute fixes

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1956,21 +1956,6 @@ fn enumSpec(p: *Parser) Error!Type {
         }
         break :enum_ty try Type.Enum.create(p.arena, p.tokSlice(ident));
     } else try Type.Enum.create(p.arena, try p.getAnonymousName(enum_tok));
-    const ty = try p.withAttributes(
-        .{ .specifier = .@"enum", .data = .{ .@"enum" = enum_ty } },
-        attr_buf_top,
-    );
-
-    // declare a symbol for the type
-    if (maybe_ident != null and !defined) {
-        try p.syms.syms.append(p.pp.comp.gpa, .{
-            .kind = .@"enum",
-            .name = p.tokSlice(maybe_ident.?),
-            .ty = ty,
-            .tok = maybe_ident.?,
-            .val = .{},
-        });
-    }
 
     // reserve space for this enum
     try p.decl_buf.append(.none);
@@ -1996,6 +1981,22 @@ fn enumSpec(p: *Parser) Error!Type {
     if (p.enum_buf.items.len == enum_buf_top) try p.err(.empty_enum);
     try p.expectClosing(l_brace, .r_brace);
     try p.attributeSpecifier(); // record
+
+    const ty = try p.withAttributes(
+        .{ .specifier = .@"enum", .data = .{ .@"enum" = enum_ty } },
+        attr_buf_top,
+    );
+
+    // declare a symbol for the type
+    if (maybe_ident != null and !defined) {
+        try p.syms.syms.append(p.pp.comp.gpa, .{
+            .kind = .@"enum",
+            .name = p.tokSlice(maybe_ident.?),
+            .ty = ty,
+            .tok = maybe_ident.?,
+            .val = .{},
+        });
+    }
 
     // finish by creating a node
     var node: Tree.Node = .{ .tag = .enum_decl_two, .ty = ty, .data = .{

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1562,7 +1562,8 @@ fn typeSpec(p: *Parser, ty: *Type.Builder) Error!bool {
             },
             .keyword_enum => {
                 const tag_tok = p.tok_i;
-                try ty.combine(p, .{ .@"enum" = try p.enumSpec() }, tag_tok);
+                const enum_ty = try p.enumSpec();
+                try ty.combine(p, Type.Builder.fromType(enum_ty), tag_tok);
                 continue;
             },
             .identifier, .extended_identifier => {
@@ -1906,7 +1907,7 @@ fn specQual(p: *Parser) Error!?Type {
 /// enumSpec
 ///  : keyword_enum IDENTIFIER? { enumerator (',' enumerator)? ',') }
 ///  | keyword_enum IDENTIFIER
-fn enumSpec(p: *Parser) Error!*Type.Enum {
+fn enumSpec(p: *Parser) Error!Type {
     const enum_tok = p.tok_i;
     p.tok_i += 1;
     const attr_buf_top = p.attr_buf.len;
@@ -1921,7 +1922,7 @@ fn enumSpec(p: *Parser) Error!*Type.Enum {
         };
         // check if this is a reference to a previous type
         if (try p.syms.findTag(p, .keyword_enum, ident)) |prev| {
-            return prev.ty.get(.@"enum").?.data.@"enum";
+            return prev.ty;
         } else {
             // this is a forward declaration, create a new enum Type.
             const enum_ty = try Type.Enum.create(p.arena, p.tokSlice(ident));
@@ -1936,7 +1937,7 @@ fn enumSpec(p: *Parser) Error!*Type.Enum {
                 .ty = ty,
                 .val = .{},
             });
-            return enum_ty;
+            return ty;
         }
     };
 
@@ -2011,7 +2012,7 @@ fn enumSpec(p: *Parser) Error!*Type.Enum {
         },
     }
     p.decl_buf.items[decl_buf_top - 1] = try p.addNode(node);
-    return enum_ty;
+    return ty;
 }
 
 const Enumerator = struct {

--- a/test/cases/attributes.c
+++ b/test/cases/attributes.c
@@ -98,7 +98,7 @@ int baz;
 }
 
 _Static_assert(sizeof(struct S2) == 1, "sizeof aligned struct"); /* TODO: Should be 8 */
-_Static_assert(_Alignof(union U1) == 1, "_Alignof aligned union"); /* TODO: should be 8 */
+_Static_assert(_Alignof(union U1) == 8, "_Alignof aligned union");
 
 typedef struct {
     short i:1 __attribute__((aligned(8)));
@@ -106,7 +106,7 @@ typedef struct {
 
 __attribute__(()) // test attribute at eof
 
-#define TESTS_SKIPPED 5
+#define TESTS_SKIPPED 4
 
 #define EXPECTED_ERRORS \
 	/* "attributes.c:8:26: warning: Attribute 'noreturn' ignored in variable context [-Wignored-attributes]" */ \

--- a/test/cases/enum attributes.c
+++ b/test/cases/enum attributes.c
@@ -19,6 +19,11 @@ enum __attribute__((aligned(16))) Attributed {
 };
 _Static_assert(_Alignof(enum Attributed) == 16, "enum align");
 
+enum Trailing {
+  Foo
+} __attribute__((aligned(32)));
+_Static_assert(_Alignof(enum Trailing) == 32, "enum align");
+
 #define EXPECTED_ERRORS "enum attributes.c:11:7: warning: 'is_deprecated' is deprecated [-Wdeprecated-declarations]" \
   "enum attributes.c:2:33: note: 'is_deprecated' has been explicitly marked deprecated here" \
   "enum attributes.c:12:7: warning: 'is_deprecated_with_msg' is deprecated: I am deprecated [-Wdeprecated-declarations]" \

--- a/test/cases/enum attributes.c
+++ b/test/cases/enum attributes.c
@@ -14,10 +14,10 @@ void foo(void) {
   a = is_unavailable_with_msg;
 }
 
-enum __attribute__((aligned)) Attributed {
+enum __attribute__((aligned(16))) Attributed {
   Val,
 };
-_Static_assert(sizeof(enum Attributed) == sizeof(int), "enum size");
+_Static_assert(_Alignof(enum Attributed) == 16, "enum align");
 
 #define EXPECTED_ERRORS "enum attributes.c:11:7: warning: 'is_deprecated' is deprecated [-Wdeprecated-declarations]" \
   "enum attributes.c:2:33: note: 'is_deprecated' has been explicitly marked deprecated here" \


### PR DESCRIPTION
1. Ensure trailing attributes after an `enum` r_brace are attached to the enum
2. Fetch the attributed type when a struct/union/enum is referenced by name