### PR TITLE
Enums: issue a warning if enumerator constants too small/large

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -469,6 +469,26 @@ fn generateVaListType(comp: *Compilation) !Type {
     return ty;
 }
 
+pub fn minInt(comp: *const Compilation) i64 {
+    const ty = Type{ .specifier = .int };
+    return switch (ty.sizeof(comp).?) {
+        2 => std.math.minInt(i16),
+        4 => std.math.minInt(i32),
+        8 => std.math.minInt(i64),
+        else => unreachable,
+    };
+}
+
+pub fn maxInt(comp: *const Compilation) u64 {
+    const ty = Type{ .specifier = .int };
+    return switch (ty.sizeof(comp).?) {
+        2 => std.math.maxInt(i16),
+        4 => std.math.maxInt(i32),
+        8 => std.math.maxInt(i64),
+        else => unreachable,
+    };
+}
+
 fn generateIntMax(comp: *Compilation, w: anytype, name: []const u8, ty: Type) !void {
     const bit_count = @intCast(u8, ty.sizeof(comp).? * 8);
     const unsigned = ty.isUnsignedInt(comp);

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -1767,6 +1767,18 @@ const messages = struct {
         const msg = "#include nested too deeply";
         const kind = .@"error";
     };
+    const enumerator_too_small = struct {
+        const msg = "ISO C restricts enumerator values to range of 'int' ({d} is too small)";
+        const extra = .signed;
+        const kind = .off;
+        const opt = "pedantic";
+    };
+    const enumerator_too_large = struct {
+        const msg = "ISO C restricts enumerator values to range of 'int' ({d} is too large)";
+        const extra = .unsigned;
+        const kind = .off;
+        const opt = "pedantic";
+    };
 };
 
 list: std.ArrayListUnmanaged(Message) = .{},

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -2079,6 +2079,22 @@ fn enumerator(p: *Parser, e: *Enumerator) Error!?EnumFieldAndNode {
     var res = e.res;
     res.ty = try p.withAttributes(res.ty, attr_buf_top);
 
+    if (e.res.val.compare(.lt, Value.int(0), e.res.ty, p.pp.comp)) {
+        const val = e.res.val.getInt(i64);
+        if (val < p.pp.comp.minInt()) {
+            try p.errExtra(.enumerator_too_small, name_tok, .{
+                .signed = val,
+            });
+        }
+    } else {
+        const val = e.res.val.getInt(u64);
+        if (val > p.pp.comp.maxInt()) {
+            try p.errExtra(.enumerator_too_large, name_tok, .{
+                .unsigned = val,
+            });
+        }
+    }
+
     try p.syms.defineEnumeration(p, res.ty, name_tok, e.res.val);
     const node = try p.addNode(.{
         .tag = .enum_field_decl,

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -624,7 +624,7 @@ pub fn sizeCompare(a: Type, b: Type, comp: *Compilation) TypeSizeOrder {
 }
 
 /// Size of type as reported by sizeof
-pub fn sizeof(ty: Type, comp: *Compilation) ?u64 {
+pub fn sizeof(ty: Type, comp: *const Compilation) ?u64 {
     // TODO get target from compilation
     return switch (ty.specifier) {
         .variable_len_array, .unspecified_variable_len_array, .incomplete_array => return null,

--- a/test/cases/enumerator constants.c
+++ b/test/cases/enumerator constants.c
@@ -1,10 +1,14 @@
 enum E {
-	A,
-	B = 10,
-	C,
-	D = 2,
-	E = -2,
-	F,
+    A,
+    B = 10,
+    C,
+    D = 2,
+    E = -2,
+    F,
+#pragma GCC diagnostic warning "-Wpedantic"
+    G = -2147483649,
+    H = 2147483648,
+#pragma GCC diagnostic ignored "-Wpedantic"
 };
 
 _Static_assert(A == 0, "A is wrong");
@@ -15,8 +19,15 @@ _Static_assert(E == -2, "E is wrong");
 _Static_assert(F == -1, "F is wrong");
 
 void foo(enum E e) {
-	switch (e) {
-		case A: return;
-		default: return;
-	}
+    switch (e) {
+        case A: return;
+        default: return;
+    }
 }
+
+#if __INT_MAX__ <= 2147483647 // 2 or 4 byte ints
+#define EXPECTED_ERRORS \
+    "enumerator constants.c:9:5: warning: ISO C restricts enumerator values to range of 'int' (-2147483649 is too small) [-Wpedantic]" \
+    "enumerator constants.c:10:5: warning: ISO C restricts enumerator values to range of 'int' (2147483648 is too large) [-Wpedantic]" \
+
+#endif


### PR DESCRIPTION
According to the C standard they should fit in an int, but gcc and clang allow them to use a larger type.