### PR TITLE
Parser: improve handling of record & enum forward declarations

### DIFF
--- a/include/stddef.h
+++ b/include/stddef.h
@@ -13,5 +13,4 @@ typedef struct {
 } max_align_t;
 
 #define NULL ((void*)0)
-/* TODO implement offsetof */
 #define offsetof(T, member) __builtin_offsetof(T, member)

--- a/src/Codegen.zig
+++ b/src/Codegen.zig
@@ -39,6 +39,9 @@ pub fn generateTree(comp: *Compilation, tree: Tree) Compilation.Error!*Object {
             .struct_decl,
             .union_decl,
             .enum_decl,
+            .struct_forward_decl,
+            .union_forward_decl,
+            .enum_forward_decl,
             => {},
 
             // define symbol

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1637,7 +1637,7 @@ fn recordSpec(p: *Parser) Error!Type {
             return error.ParsingFailed;
         };
         // check if this is a reference to a previous type
-        if (try p.syms.findTag(p, p.tok_ids[kind_tok], ident)) |prev| {
+        if (try p.syms.findTag(p, p.tok_ids[kind_tok], ident, p.tok_ids[p.tok_i])) |prev| {
             return prev.ty;
         } else {
             // this is a forward declaration, create a new record Type.
@@ -1653,6 +1653,11 @@ fn recordSpec(p: *Parser) Error!Type {
                 .ty = ty,
                 .val = .{},
             });
+            try p.decl_buf.append(try p.addNode(.{
+                .tag = if (is_struct) .struct_forward_decl else .union_forward_decl,
+                .ty = ty,
+                .data = undefined,
+            }));
             return ty;
         }
     };
@@ -1944,7 +1949,7 @@ fn enumSpec(p: *Parser) Error!Type {
             return error.ParsingFailed;
         };
         // check if this is a reference to a previous type
-        if (try p.syms.findTag(p, .keyword_enum, ident)) |prev| {
+        if (try p.syms.findTag(p, .keyword_enum, ident, p.tok_ids[p.tok_i])) |prev| {
             return prev.ty;
         } else {
             // this is a forward declaration, create a new enum Type.
@@ -1960,6 +1965,11 @@ fn enumSpec(p: *Parser) Error!Type {
                 .ty = ty,
                 .val = .{},
             });
+            try p.decl_buf.append(try p.addNode(.{
+                .tag = .enum_forward_decl,
+                .ty = ty,
+                .data = undefined,
+            }));
             return ty;
         }
     };

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -214,6 +214,12 @@ pub const Tag = enum(u8) {
     union_decl,
     /// { range }
     enum_decl,
+    /// struct Name;
+    struct_forward_decl,
+    /// union Name;
+    union_forward_decl,
+    /// enum Name;
+    enum_forward_decl,
 
     /// name = node
     enum_field_decl,
@@ -1164,6 +1170,11 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, w: anytype) @TypeOf(w).Erro
             try w.print("{d}\n", .{data.int});
             util.setColor(.reset, w);
         },
-        .default_init_expr, .cond_dummy_expr => {},
+        .struct_forward_decl,
+        .union_forward_decl,
+        .enum_forward_decl,
+        .default_init_expr,
+        .cond_dummy_expr,
+        => {},
     }
 }

--- a/test/cases/containers.c
+++ b/test/cases/containers.c
@@ -127,6 +127,12 @@ struct A {
 } a1;
 struct B b1;
 
+void qux(void) {
+    enum A;
+    struct A e;
+}
+struct A;
+struct A a2;
 
 #define EXPECTED_ERRORS "containers.c:15:8: error: use of 'Foo' with tag type that does not match previous definition" \
     "containers.c:9:6: note: previous definition is here" \
@@ -150,3 +156,6 @@ struct B b1;
     "containers.c:106:9: error: flexible array member is not at the end of struct" \
     "containers.c:116:9: error: flexible array member in union is not allowed" \
     "containers.c:120:19: error: field has incomplete type 'enum EnumTest1'" \
+    "containers.c:132:12: error: use of 'A' with tag type that does not match previous definition" \
+    "containers.c:131:10: note: previous definition is here" \
+    "containers.c:132:14: error: variable has incomplete type 'struct A'" \


### PR DESCRIPTION
The only situation I found where this happens is if immediately followed by a semicolon but I've been wrong before.

Closes #306