### PR TITLE
Add Linux multiarch include dir

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -526,6 +526,17 @@ pub fn defineSystemIncludes(comp: *Compilation) !void {
         break;
     } else return error.AroIncludeNotFound;
 
+    if (comp.target.os.tag == .linux) {
+        var fib = std.heap.FixedBufferAllocator.init(&buf);
+        const triple_str = try comp.target.linuxTriple(fib.allocator());
+        const multiarch_path = try std.fs.path.join(fib.allocator(), &.{ "/usr/include", triple_str });
+
+        if (!std.meta.isError(std.fs.accessAbsolute(multiarch_path, .{}))) {
+            const duped = try comp.gpa.dupe(u8, multiarch_path);
+            errdefer comp.gpa.free(duped);
+            try comp.system_include_dirs.append(duped);
+        }
+    }
     try comp.system_include_dirs.append("/usr/include");
 }
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -25,7 +25,6 @@ diag: Diagnostics,
 include_dirs: std.ArrayList([]const u8),
 system_include_dirs: std.ArrayList([]const u8),
 output_name: ?[]const u8 = null,
-builtin_header_path: ?[]u8 = null,
 target: std.Target = @import("builtin").target,
 pragma_handlers: std.StringArrayHashMap(*Pragma),
 only_preprocess: bool = false,
@@ -67,9 +66,9 @@ pub fn deinit(comp: *Compilation) void {
     comp.sources.deinit();
     comp.diag.deinit();
     comp.include_dirs.deinit();
+    for (comp.system_include_dirs.items) |path| comp.gpa.free(path);
     comp.system_include_dirs.deinit();
     comp.pragma_handlers.deinit();
-    if (comp.builtin_header_path) |some| comp.gpa.free(some);
     comp.generated_buf.deinit();
     comp.builtins.deinit(comp.gpa);
     comp.invalid_utf8_locs.deinit(comp.gpa);
@@ -521,7 +520,7 @@ pub fn defineSystemIncludes(comp: *Compilation) !void {
 
         base_dir.access("include/stddef.h", .{}) catch continue;
         const path = try std.fs.path.join(comp.gpa, &.{ dirname, "include" });
-        comp.builtin_header_path = path;
+        errdefer comp.gpa.free(path);
         try comp.system_include_dirs.append(path);
         break;
     } else return error.AroIncludeNotFound;
@@ -537,7 +536,9 @@ pub fn defineSystemIncludes(comp: *Compilation) !void {
             try comp.system_include_dirs.append(duped);
         }
     }
-    try comp.system_include_dirs.append("/usr/include");
+    const usr_include = try comp.gpa.dupe(u8, "/usr/include");
+    errdefer comp.gpa.free(usr_include);
+    try comp.system_include_dirs.append(usr_include);
 }
 
 pub fn getSource(comp: *const Compilation, id: Source.Id) Source {

--- a/src/main.zig
+++ b/src/main.zig
@@ -290,12 +290,6 @@ fn fatal(comp: *Compilation, comptime fmt: []const u8, args: anytype) error{Fata
 }
 
 fn mainExtra(comp: *Compilation, args: [][]const u8) !void {
-    comp.defineSystemIncludes() catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        error.SelfExeNotFound => return fatal(comp, "could not find Aro executable path", .{}),
-        error.AroIncludeNotFound => return fatal(comp, "could not find Aro builtin headers", .{}),
-    };
-
     var source_files = std.ArrayList(Source).init(comp.gpa);
     defer source_files.deinit();
 
@@ -310,6 +304,12 @@ fn mainExtra(comp: *Compilation, args: [][]const u8) !void {
     } else if (source_files.items.len != 1 and comp.output_name != null) {
         return fatal(comp, "cannot specify -o when generating multiple output files", .{});
     }
+
+    comp.defineSystemIncludes() catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.SelfExeNotFound => return fatal(comp, "could not find Aro executable path", .{}),
+        error.AroIncludeNotFound => return fatal(comp, "could not find Aro builtin headers", .{}),
+    };
 
     const builtin = try comp.generateBuiltinMacros();
     const user_macros = try comp.addSourceFromBuffer("<command line>", macro_buf.items);

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -157,7 +157,6 @@ pub fn main() !void {
             comp.include_dirs = @TypeOf(comp.include_dirs).init(gpa);
             comp.system_include_dirs = @TypeOf(comp.system_include_dirs).init(gpa);
             comp.pragma_handlers = @TypeOf(comp.pragma_handlers).init(gpa);
-            comp.builtin_header_path = null;
             // reset everything else
             comp.deinit();
         }


### PR DESCRIPTION
With this change I'm able to parse the sqlite3 amalgamated source with no errors (just a bunch of spurious "unreachable code" warnings) on an x86_64 Ubuntu system without passing any additional command-line flags.