### PR TITLE
set default compiler, and other target queires

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -899,6 +899,65 @@ pub fn isTlsSupported(comp: *Compilation) bool {
     };
 }
 
+pub fn ignoreNonZeroSizedBitfieldTypeAlignment(comp: *const Compilation) bool {
+    switch (comp.target.cpu.arch) {
+        .avr => return true,
+        .arm => {
+            if (std.Target.arm.featureSetHas(comp.target.cpu.features, .has_v7)) {
+                switch (comp.target.os.tag) {
+                    .ios => return true,
+                    else => return false,
+                }
+            }
+        },
+        else => return false,
+    }
+    return false;
+}
+
+pub fn minZeroWidthBitfieldAlignment(comp: *const Compilation) ?u29 {
+    switch (comp.target.cpu.arch) {
+        .avr => return 8,
+        .arm => {
+            if (std.Target.arm.featureSetHas(comp.target.cpu.features, .has_v7)) {
+                switch (comp.target.os.tag) {
+                    .ios => return 32,
+                    else => return null,
+                }
+            } else return null;
+        },
+        else => return null,
+    }
+}
+
+pub fn unnamedFieldAffectsAlignment(comp: *const Compilation) bool {
+    switch (comp.target.cpu.arch) {
+        .arch64 => {
+            if (comp.target.os.isDarwin() or comp.target.os.windows) return false;
+            return true;
+        },
+        .armeb => {
+            if (std.Target.arm.featureSetHas(comp.target.cpu.features, .has_v7)) {
+                if (comp.target.abi.default(comp.target.cpu.arch, comp.target.os) == .eabi) return true;
+            }
+        },
+        .arm => return true,
+        .avr => return true,
+        .thumb => {
+            if (comp.target.os.isWindows()) return false;
+            return true;
+        },
+    }
+    return false;
+}
+
+pub fn packAllEnums(comp: *const Compilation) bool {
+    return switch (comp.target.cpu.arch) {
+        .hexagon => true,
+        else => false,
+    };
+}
+
 /// Default alignment (in bytes) for __attribute__((aligned)) when no alignment is specified
 pub fn defaultAlignment(comp: *const Compilation) u29 {
     switch (comp.target.cpu.arch) {
@@ -914,6 +973,29 @@ pub fn defaultAlignment(comp: *const Compilation) u29 {
         else => {},
     }
     return 16;
+}
+pub fn systemCompiler(comp: *const Compilation) LangOpts.Compiler {
+    const target = comp.target;
+    // andorid is linux but not gcc, so these checks go first
+    // the rest for documentation as fn returns .clang
+    if (target.isDarwin() or
+        target.isAndroid() or
+        target.isBSD() or
+        target.os.tag == .fuchsia or
+        target.os.tag == .solaris)
+    {
+        return .clang;
+    }
+    // this is before windows to gram WindowsGnu
+    if (target.abi.isGnu() or
+        target.os.tag == .linux)
+    {
+        return .gcc;
+    }
+    if (target.os.tag == .windows) {
+        return .msvc;
+    }
+    return .clang;
 }
 
 test "addSourceFromReader" {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1103,12 +1103,7 @@ test "alignment functions - smoke test" {
 
     try std.testing.expect(!comp.isTlsSupported());
     try std.testing.expect(comp.ignoreNonZeroSizedBitfieldTypeAlignment());
-    // stage 0 can't compare a ?u29 with a ?u29
-    if (comp.minZeroWidthBitfieldAlignment()) |zero_algin| {
-        try std.testing.expect(zero_algin == 32);
-    } else {
-        try std.testing.expect(false);
-    }
+    try std.testing.expectEqual(@as(?u29, 32), comp.minZeroWidthBitfieldAlignment());
     try std.testing.expect(comp.unnamedFieldAffectsAlignment());
     try std.testing.expect(comp.defaultAlignment() == 16);
     try std.testing.expect(!comp.packAllEnums());

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -986,7 +986,7 @@ pub fn systemCompiler(comp: *const Compilation) LangOpts.Compiler {
     {
         return .clang;
     }
-    // this is before windows to gram WindowsGnu
+    // this is before windows to grab WindowsGnu
     if (target.abi.isGnu() or
         target.os.tag == .linux)
     {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -932,21 +932,22 @@ pub fn minZeroWidthBitfieldAlignment(comp: *const Compilation) ?u29 {
 
 pub fn unnamedFieldAffectsAlignment(comp: *const Compilation) bool {
     switch (comp.target.cpu.arch) {
-        .arch64 => {
-            if (comp.target.os.isDarwin() or comp.target.os.windows) return false;
+        .aarch64 => {
+            if (comp.target.isDarwin() or comp.target.os.tag == .windows) return false;
             return true;
         },
         .armeb => {
             if (std.Target.arm.featureSetHas(comp.target.cpu.features, .has_v7)) {
-                if (comp.target.abi.default(comp.target.cpu.arch, comp.target.os) == .eabi) return true;
+                if (std.Target.Abi.default(comp.target.cpu.arch, comp.target.os) == .eabi) return true;
             }
         },
         .arm => return true,
         .avr => return true,
         .thumb => {
-            if (comp.target.os.isWindows()) return false;
+            if (comp.target.os.tag == .windows) return false;
             return true;
         },
+        else => return false,
     }
     return false;
 }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1094,6 +1094,7 @@ test "alignment functions - smoke test" {
     try std.testing.expect(!comp.unnamedFieldAffectsAlignment());
     try std.testing.expect(comp.defaultAlignment() == 16);
     try std.testing.expect(!comp.packAllEnums());
+    try std.testing.expect(comp.systemCompiler() == .gcc);
 
     const arm = std.Target.Cpu.Arch.arm;
     comp.target.cpu = std.Target.Cpu.baseline(arm);
@@ -1111,4 +1112,5 @@ test "alignment functions - smoke test" {
     try std.testing.expect(comp.unnamedFieldAffectsAlignment());
     try std.testing.expect(comp.defaultAlignment() == 16);
     try std.testing.expect(!comp.packAllEnums());
+    try std.testing.expect(comp.systemCompiler() == .clang);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -39,9 +39,7 @@ pub fn main() u8 {
             return 1;
         },
     };
-    if (comp.target.abi == .msvc or comp.target.os.tag == .windows) {
-        comp.langopts.setEmulatedCompiler(.msvc);
-    }
+    comp.langopts.setEmulatedCompiler(comp.systemCompiler());
 
     mainExtra(&comp, args) catch |er| switch (er) {
         error.OutOfMemory => {
@@ -259,9 +257,7 @@ pub fn parseArgs(
                     continue;
                 };
                 comp.target = cross.toTarget(); // TODO deprecated
-                if (comp.target.abi == .msvc or comp.target.os.tag == .windows) {
-                    comp.langopts.setEmulatedCompiler(.msvc);
-                }
+                comp.langopts.setEmulatedCompiler(comp.systemCompiler());
             } else if (mem.eql(u8, arg, "--verbose-ast")) {
                 comp.verbose_ast = true;
             } else {


### PR DESCRIPTION
Some target-specific question FNs needed for layout.

The most controversial is setting the compiler emulation based on the target. It sets the emulation to the compiler the target system is typically built with. So for example, Linux is built w/ gcc, so that's the compiler to emulate for linux targets. the `--emulate` flag overrides.

