### PR TITLE
prep record struct for layout

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -438,11 +438,11 @@ fn generateVaListType(comp: *Compilation) !Type {
             const void_ty = try arena.create(Type);
             void_ty.* = .{ .specifier = .void };
             const void_ptr = Type{ .specifier = .pointer, .data = .{ .sub_type = void_ty } };
-            record_ty.fields[0] = .{ .name = try comp.intern("__stack"), .ty = void_ptr, .layout = undefined };
-            record_ty.fields[1] = .{ .name = try comp.intern("__gr_top"), .ty = void_ptr, .layout = undefined };
-            record_ty.fields[2] = .{ .name = try comp.intern("__vr_top"), .ty = void_ptr, .layout = undefined };
-            record_ty.fields[3] = .{ .name = try comp.intern("__gr_offs"), .ty = .{ .specifier = .int }, .layout = undefined };
-            record_ty.fields[4] = .{ .name = try comp.intern("__vr_offs"), .ty = .{ .specifier = .int }, .layout = undefined };
+            record_ty.fields[0] = .{ .name = try comp.intern("__stack"), .ty = void_ptr };
+            record_ty.fields[1] = .{ .name = try comp.intern("__gr_top"), .ty = void_ptr };
+            record_ty.fields[2] = .{ .name = try comp.intern("__vr_top"), .ty = void_ptr };
+            record_ty.fields[3] = .{ .name = try comp.intern("__gr_offs"), .ty = .{ .specifier = .int } };
+            record_ty.fields[4] = .{ .name = try comp.intern("__vr_offs"), .ty = .{ .specifier = .int } };
             ty = .{ .specifier = .@"struct", .data = .{ .record = record_ty } };
         },
         .x86_64_va_list => {
@@ -456,10 +456,10 @@ fn generateVaListType(comp: *Compilation) !Type {
             const void_ty = try arena.create(Type);
             void_ty.* = .{ .specifier = .void };
             const void_ptr = Type{ .specifier = .pointer, .data = .{ .sub_type = void_ty } };
-            record_ty.fields[0] = .{ .name = try comp.intern("gp_offset"), .ty = .{ .specifier = .uint }, .layout = undefined };
-            record_ty.fields[1] = .{ .name = try comp.intern("fp_offset"), .ty = .{ .specifier = .uint }, .layout = undefined };
-            record_ty.fields[2] = .{ .name = try comp.intern("overflow_arg_area"), .ty = void_ptr, .layout = undefined };
-            record_ty.fields[3] = .{ .name = try comp.intern("reg_save_area"), .ty = void_ptr, .layout = undefined };
+            record_ty.fields[0] = .{ .name = try comp.intern("gp_offset"), .ty = .{ .specifier = .uint } };
+            record_ty.fields[1] = .{ .name = try comp.intern("fp_offset"), .ty = .{ .specifier = .uint } };
+            record_ty.fields[2] = .{ .name = try comp.intern("overflow_arg_area"), .ty = void_ptr };
+            record_ty.fields[3] = .{ .name = try comp.intern("reg_save_area"), .ty = void_ptr };
             ty = .{ .specifier = .@"struct", .data = .{ .record = record_ty } };
         },
     }

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -432,18 +432,17 @@ fn generateVaListType(comp: *Compilation) !Type {
             record_ty.* = .{
                 .name = try comp.intern("__va_list_tag"),
                 .fields = try arena.alloc(Type.Record.Field, 5),
-                .size = 32,
-                .alignment = 8,
                 .field_attributes = null,
+                .type_layout = Type.TypeLayout.init(32, 8),
             };
             const void_ty = try arena.create(Type);
             void_ty.* = .{ .specifier = .void };
             const void_ptr = Type{ .specifier = .pointer, .data = .{ .sub_type = void_ty } };
-            record_ty.fields[0] = .{ .name = try comp.intern("__stack"), .ty = void_ptr };
-            record_ty.fields[1] = .{ .name = try comp.intern("__gr_top"), .ty = void_ptr };
-            record_ty.fields[2] = .{ .name = try comp.intern("__vr_top"), .ty = void_ptr };
-            record_ty.fields[3] = .{ .name = try comp.intern("__gr_offs"), .ty = .{ .specifier = .int } };
-            record_ty.fields[4] = .{ .name = try comp.intern("__vr_offs"), .ty = .{ .specifier = .int } };
+            record_ty.fields[0] = .{ .name = try comp.intern("__stack"), .ty = void_ptr, .layout = undefined };
+            record_ty.fields[1] = .{ .name = try comp.intern("__gr_top"), .ty = void_ptr, .layout = undefined };
+            record_ty.fields[2] = .{ .name = try comp.intern("__vr_top"), .ty = void_ptr, .layout = undefined };
+            record_ty.fields[3] = .{ .name = try comp.intern("__gr_offs"), .ty = .{ .specifier = .int }, .layout = undefined };
+            record_ty.fields[4] = .{ .name = try comp.intern("__vr_offs"), .ty = .{ .specifier = .int }, .layout = undefined };
             ty = .{ .specifier = .@"struct", .data = .{ .record = record_ty } };
         },
         .x86_64_va_list => {
@@ -451,17 +450,16 @@ fn generateVaListType(comp: *Compilation) !Type {
             record_ty.* = .{
                 .name = try comp.intern("__va_list_tag"),
                 .fields = try arena.alloc(Type.Record.Field, 4),
-                .size = 24,
-                .alignment = 8,
                 .field_attributes = null,
+                .type_layout = Type.TypeLayout.init(24, 8),
             };
             const void_ty = try arena.create(Type);
             void_ty.* = .{ .specifier = .void };
             const void_ptr = Type{ .specifier = .pointer, .data = .{ .sub_type = void_ty } };
-            record_ty.fields[0] = .{ .name = try comp.intern("gp_offset"), .ty = .{ .specifier = .uint } };
-            record_ty.fields[1] = .{ .name = try comp.intern("fp_offset"), .ty = .{ .specifier = .uint } };
-            record_ty.fields[2] = .{ .name = try comp.intern("overflow_arg_area"), .ty = void_ptr };
-            record_ty.fields[3] = .{ .name = try comp.intern("reg_save_area"), .ty = void_ptr };
+            record_ty.fields[0] = .{ .name = try comp.intern("gp_offset"), .ty = .{ .specifier = .uint }, .layout = undefined };
+            record_ty.fields[1] = .{ .name = try comp.intern("fp_offset"), .ty = .{ .specifier = .uint }, .layout = undefined };
+            record_ty.fields[2] = .{ .name = try comp.intern("overflow_arg_area"), .ty = void_ptr, .layout = undefined };
+            record_ty.fields[3] = .{ .name = try comp.intern("reg_save_area"), .ty = void_ptr, .layout = undefined };
             ty = .{ .specifier = .@"struct", .data = .{ .record = record_ty } };
         },
     }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1839,7 +1839,7 @@ fn recordDeclarator(p: *Parser) Error!bool {
         var name_tok: TokenIndex = 0;
         var ty = base_ty;
         var bits_node: NodeIndex = .none;
-        var bits: ?u64 = null;
+        var bits: ?u32 = null;
         const first_tok = p.tok_i;
         if (try p.declarator(ty, .record)) |d| {
             name_tok = d.name;
@@ -1874,7 +1874,7 @@ fn recordDeclarator(p: *Parser) Error!bool {
                 break :bits;
             }
 
-            bits = res.val.getInt(u29);
+            bits = res.val.getInt(u32);
             bits_node = res.node;
         }
 

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1839,7 +1839,7 @@ fn recordDeclarator(p: *Parser) Error!bool {
         var name_tok: TokenIndex = 0;
         var ty = base_ty;
         var bits_node: NodeIndex = .none;
-        var bits: ?u29 = null;
+        var bits: ?u64 = null;
         const first_tok = p.tok_i;
         if (try p.declarator(ty, .record)) |d| {
             name_tok = d.name;

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1902,11 +1902,6 @@ fn recordDeclarator(p: *Parser) Error!bool {
                 try p.record_buf.append(.{
                     .name = try p.getAnonymousName(first_tok),
                     .ty = ty,
-                    .bit_width = null,
-                    .layout = .{
-                        .offset_bits = 0,
-                        .size_bits = 0,
-                    },
                 });
                 const node = try p.addNode(.{
                     .tag = .indirect_record_field_decl,
@@ -1925,10 +1920,6 @@ fn recordDeclarator(p: *Parser) Error!bool {
                 .ty = ty,
                 .name_tok = name_tok,
                 .bit_width = bits,
-                .layout = .{
-                    .offset_bits = 0,
-                    .size_bits = 0,
-                },
             });
             if (name_tok != 0) try p.record.addField(p, interned_name, name_tok);
             const node = try p.addNode(.{

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -170,23 +170,23 @@ pub const TypeLayout = struct {
     ///
     /// This is the value returned by `sizeof` and C and `std::mem::size_of` in Rust
     /// (but in bits instead of bytes). This is a multiple of `pointer_alignment_bits`.
-    size_bits: u29,
+    size_bits: u64,
     /// The alignment of the type, in bits, when used as a field in a record.
     ///
     /// This is usually the value returned by `_Alignof` in C, but there are some edge
     /// cases in GCC where `_Alignof` returns a smaller value.
-    field_alignment_bits: u29,
+    field_alignment_bits: u64,
     /// The alignment, in bits, of valid pointers to this type.
     ///
     /// This is the value returned by `std::mem::align_of` in Rust
     /// (but in bits instead of bytes). `size_bits` is a multiple of this value.
-    pointer_alignment_bits: u29,
+    pointer_alignment_bits: u64,
     /// The required alignment of the type in bits.
     ///
     /// This value is only used by MSVC targets. It is 8 on all other
     /// targets. On MSVC targets, this value restricts the effects of `#pragma pack` except
     /// in some cases involving bit-fields.
-    required_alignmnet_bits: u29,
+    required_alignmnet_bits: u64,
     pub fn init(size_bytes: u64, alignment_bytes: u64) TypeLayout {
         return TypeLayout{
             .size_bits = @intCast(u29, size_bytes * 8),
@@ -199,11 +199,11 @@ pub const TypeLayout = struct {
 
 pub const FieldLayout = struct {
     /// The offset of the struct, in bits, from the start of the struct.
-    offset_bits: u29,
+    offset_bits: u64,
     /// The size, in bits, of the field.
     ///
     /// For bit-fields, this is the width of the field.
-    size_bits: u29,
+    size_bits: u64,
 };
 
 // TODO improve memory usage
@@ -874,7 +874,7 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
         .decayed_unspecified_variable_len_array,
         .static_array,
         => comp.target.cpu.arch.ptrBitWidth() >> 3,
-        .@"struct", .@"union" => if (ty.data.record.isIncomplete()) 0 else ty.data.record.type_layout.field_alignment_bits / 8,
+        .@"struct", .@"union" => if (ty.data.record.isIncomplete()) 0 else @intCast(u29, ty.data.record.type_layout.field_alignment_bits / 8),
         .@"enum" => if (ty.data.@"enum".isIncomplete() and !ty.data.@"enum".fixed) 0 else ty.data.@"enum".tag_ty.alignof(comp),
         .typeof_type, .decayed_typeof_type => ty.data.sub_type.alignof(comp),
         .typeof_expr, .decayed_typeof_expr => ty.data.expr.ty.alignof(comp),

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -197,7 +197,7 @@ pub const TypeLayout = struct {
     }
 };
 
-const FieldLayout = struct {
+pub const FieldLayout = struct {
     /// The offset of the struct, in bits, from the start of the struct.
     offset_bits: u29,
     /// The size, in bits, of the field.
@@ -222,7 +222,10 @@ pub const Record = struct {
         /// zero for anonymous fields
         name_tok: TokenIndex = 0,
         bit_width: ?u29 = null,
-        layout: FieldLayout,
+        layout: FieldLayout = .{
+            .offset_bits = 0,
+            .size_bits = 0,
+        },
 
         pub fn isAnonymousRecord(f: Field) bool {
             return f.name_tok == 0 and f.ty.isRecord();

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -163,7 +163,7 @@ pub const Enum = struct {
     }
 };
 // might not need all 4 of these when finished,
-// but currently it helps havaing all 4 when diff-ing
+// but currently it helps having all 4 when diff-ing
 // the reust code.
 pub const TypeLayout = struct {
     /// The size of the type in bits.
@@ -186,13 +186,13 @@ pub const TypeLayout = struct {
     /// This value is only used by MSVC targets. It is 8 on all other
     /// targets. On MSVC targets, this value restricts the effects of `#pragma pack` except
     /// in some cases involving bit-fields.
-    required_alignmnet_bits: u64,
+    required_alignment_bits: u64,
     pub fn init(size_bytes: u64, alignment_bytes: u64) TypeLayout {
         return TypeLayout{
             .size_bits = @intCast(u29, size_bytes * 8),
             .field_alignment_bits = @intCast(u29, alignment_bytes * 8),
             .pointer_alignment_bits = @intCast(u29, alignment_bytes * 8),
-            .required_alignmnet_bits = 8,
+            .required_alignment_bits = 8,
         };
     }
 };

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -162,24 +162,67 @@ pub const Enum = struct {
         return e;
     }
 };
+// might not need all 4 of these when finished,
+// but currently it helps havaing all 4 when diff-ing
+// the reust code.
+pub const TypeLayout = struct {
+    /// The size of the type in bits.
+    ///
+    /// This is the value returned by `sizeof` and C and `std::mem::size_of` in Rust
+    /// (but in bits instead of bytes). This is a multiple of `pointer_alignment_bits`.
+    size_bits: u29,
+    /// The alignment of the type, in bits, when used as a field in a record.
+    ///
+    /// This is usually the value returned by `_Alignof` in C, but there are some edge
+    /// cases in GCC where `_Alignof` returns a smaller value.
+    field_alignment_bits: u29,
+    /// The alignment, in bits, of valid pointers to this type.
+    ///
+    /// This is the value returned by `std::mem::align_of` in Rust
+    /// (but in bits instead of bytes). `size_bits` is a multiple of this value.
+    pointer_alignment_bits: u29,
+    /// The required alignment of the type in bits.
+    ///
+    /// This value is only used by MSVC targets. It is 8 on all other
+    /// targets. On MSVC targets, this value restricts the effects of `#pragma pack` except
+    /// in some cases involving bit-fields.
+    required_alignmnet_bits: u29,
+    pub fn init(size_bytes: u64, alignment_bytes: u64) TypeLayout {
+        return TypeLayout{
+            .size_bits = @intCast(u29, size_bytes * 8),
+            .field_alignment_bits = @intCast(u29, alignment_bytes * 8),
+            .pointer_alignment_bits = @intCast(u29, alignment_bytes * 8),
+            .required_alignmnet_bits = 8,
+        };
+    }
+};
+
+const FieldLayout = struct {
+    /// The offset of the struct, in bits, from the start of the struct.
+    offset_bits: u29,
+    /// The size, in bits, of the field.
+    ///
+    /// For bit-fields, this is the width of the field.
+    size_bits: u29,
+};
 
 // TODO improve memory usage
 pub const Record = struct {
     fields: []Field,
-    size: u64,
+    type_layout: TypeLayout,
     /// If this is null, none of the fields have attributes
     /// Otherwise, it's a pointer to N items (where N == number of fields)
     /// and the item at index i is the attributes for the field at index i
     field_attributes: ?[*][]const Attribute,
     name: StringId,
-    alignment: u29,
 
     pub const Field = struct {
         ty: Type,
         name: StringId,
         /// zero for anonymous fields
         name_tok: TokenIndex = 0,
-        bit_width: u32 = 0,
+        bit_width: ?u29 = null,
+        layout: FieldLayout,
 
         pub fn isAnonymousRecord(f: Field) bool {
             return f.name_tok == 0 and f.ty.isRecord();
@@ -195,6 +238,7 @@ pub const Record = struct {
         r.name = name;
         r.fields.len = std.math.maxInt(usize);
         r.field_attributes = null;
+        r.type_layout = undefined;
         return r;
     }
 };
@@ -763,7 +807,7 @@ pub fn sizeof(ty: Type, comp: *const Compilation) ?u64 {
             const size = ty.data.array.elem.sizeof(comp) orelse return null;
             return std.mem.alignForward(size * ty.data.array.len, ty.alignof(comp));
         },
-        .@"struct", .@"union" => if (ty.data.record.isIncomplete()) null else ty.data.record.size,
+        .@"struct", .@"union" => if (ty.data.record.isIncomplete()) null else @as(u64, ty.data.record.type_layout.size_bits / 8),
         .@"enum" => if (ty.data.@"enum".isIncomplete() and !ty.data.@"enum".fixed) null else ty.data.@"enum".tag_ty.sizeof(comp),
         .typeof_type => ty.data.sub_type.sizeof(comp),
         .typeof_expr => ty.data.expr.ty.sizeof(comp),
@@ -827,7 +871,7 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
         .decayed_unspecified_variable_len_array,
         .static_array,
         => comp.target.cpu.arch.ptrBitWidth() >> 3,
-        .@"struct", .@"union" => if (ty.data.record.isIncomplete()) 0 else ty.data.record.alignment,
+        .@"struct", .@"union" => if (ty.data.record.isIncomplete()) 0 else ty.data.record.type_layout.field_alignment_bits / 8,
         .@"enum" => if (ty.data.@"enum".isIncomplete() and !ty.data.@"enum".fixed) 0 else ty.data.@"enum".tag_ty.alignof(comp),
         .typeof_type, .decayed_typeof_type => ty.data.sub_type.alignof(comp),
         .typeof_expr, .decayed_typeof_expr => ty.data.expr.ty.alignof(comp),

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -874,7 +874,7 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
         .decayed_unspecified_variable_len_array,
         .static_array,
         => comp.target.cpu.arch.ptrBitWidth() >> 3,
-        .@"struct", .@"union" => if (ty.data.record.isIncomplete()) 0 else @intCast(u29, ty.data.record.type_layout.field_alignment_bits / 8),
+        .@"struct", .@"union" => if (ty.data.record.isIncomplete()) 0 else @truncate(u29, ty.data.record.type_layout.field_alignment_bits / 8),
         .@"enum" => if (ty.data.@"enum".isIncomplete() and !ty.data.@"enum".fixed) 0 else ty.data.@"enum".tag_ty.alignof(comp),
         .typeof_type, .decayed_typeof_type => ty.data.sub_type.alignof(comp),
         .typeof_expr, .decayed_typeof_expr => ty.data.expr.ty.alignof(comp),

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -221,7 +221,7 @@ pub const Record = struct {
         name: StringId,
         /// zero for anonymous fields
         name_tok: TokenIndex = 0,
-        bit_width: ?u29 = null,
+        bit_width: ?u64 = null,
         layout: FieldLayout = .{
             .offset_bits = 0,
             .size_bits = 0,


### PR DESCRIPTION
Add `TypeLayout` to `Record` and `FieldLayout` to `Field` in `Type.zig`

`TypeLayout` is probably too fat. I think I can cut it in half, but I'd like to finish msvc and MinGW layout emulation before doing that. It helps w/ diff-ing the rust code.

Removed `size` and `alignment` from `Record` as they are duplicative of `TypeLayout`

Changed `bits` in `Field` to be nullable, as 0 and unset mean different things to the layout code.
