### PR TITLE
Preprocessor: check for include guards

### DIFF
--- a/test/cases/guard defined outside header.c
+++ b/test/cases/guard defined outside header.c
@@ -1,0 +1,3 @@
+#include "incorrect_guard.h"
+#define INCORRECT_GUARD_H
+#include "incorrect_guard.h"

--- a/test/cases/guard undef.c
+++ b/test/cases/guard undef.c
@@ -1,0 +1,8 @@
+#include "correct_guard.h"
+#undef CORRECT_GUARD_H
+#include "correct_guard.h"
+
+#define EXPECTED_ERRORS \
+	"correct_guard.h:3:5: error: redefinition of 'x'" \
+	"correct_guard.h:3:5: note: previous definition is here" \
+

--- a/test/cases/include/correct_guard.h
+++ b/test/cases/include/correct_guard.h
@@ -1,0 +1,4 @@
+#ifndef CORRECT_GUARD_H
+#define CORRECT_GUARD_H
+int x = 42;
+#endif // CORRECT_GUARD_H

--- a/test/cases/include/incorrect_guard.h
+++ b/test/cases/include/incorrect_guard.h
@@ -1,0 +1,4 @@
+#ifndef INCORRECT_GUARD_H
+// missing #define INCORRECT_GUARD_H
+int x = 42;
+#endif // INCORRECT_GUARD_H

--- a/test/cases/incorrect guard.c
+++ b/test/cases/incorrect guard.c
@@ -1,0 +1,7 @@
+#include "incorrect_guard.h"
+#include "incorrect_guard.h"
+
+#define EXPECTED_ERRORS \
+	"incorrect_guard.h:3:5: error: redefinition of 'x'" \
+	"incorrect_guard.h:3:5: note: previous definition is here" \
+


### PR DESCRIPTION
We can skip preprocessing a file if it is entirely contained in
an #ifndef ... #endif guard and the guard macro is defined.

Closes #341