### PR TITLE
change logic in `Type.alignof()`

### DIFF
--- a/src/Type.zig
+++ b/src/Type.zig
@@ -840,9 +840,8 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
         if (ty.requestedAlignment(comp)) |requested| {
             // gcc does not respect alignment on enums
             if (ty.get(.@"enum")) |ty_enum| {
-                const nat_al = ty_enum.alignof(comp);
                 if (comp.langopts.emulate == .gcc) {
-                    return nat_al;
+                    return ty_enum.alignof(comp);
                 }
             }
             return requested;

--- a/test/cases/attributes.c
+++ b/test/cases/attributes.c
@@ -98,7 +98,7 @@ int baz;
 }
 
 _Static_assert(sizeof(struct S2) == 1, "sizeof aligned struct"); /* TODO: Should be 8 */
-_Static_assert(_Alignof(union U1) == 8, "_Alignof aligned union");
+_Static_assert(_Alignof(union U1) == 1, "_Alignof aligned union"); /* TODO: Should be 8 */ 
 
 typedef struct {
     short i:1 __attribute__((aligned(8)));


### PR DESCRIPTION

This is the last change needed for `record_layout.zig`.

I could put this in the PR w/ the layout code, but I wanted to draw your attention to it, as I'm not sure this is the proper way to handle these issues. There might be more of these types of exceptions in the future.


