### PR TITLE
Compilation: add MSP430 target-specific types and macros

### DIFF
--- a/deps/zig/lib.zig
+++ b/deps/zig/lib.zig
@@ -2,3 +2,4 @@ pub const codegen = struct {
     pub const x86_64 = @import("codegen/x86_64.zig");
 };
 pub const RegisterManager = @import("register_manager.zig").RegisterManager;
+pub const CType = @import("type.zig").CType;

--- a/deps/zig/type.zig
+++ b/deps/zig/type.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+const Target = std.Target;
+
+pub const CType = enum {
+    short,
+    ushort,
+    int,
+    uint,
+    long,
+    ulong,
+    longlong,
+    ulonglong,
+    longdouble,
+
+    pub fn sizeInBits(self: CType, target: Target) u16 {
+        switch (target.os.tag) {
+            .freestanding, .other => switch (target.cpu.arch) {
+                .msp430 => switch (self) {
+                    .short, .ushort, .int, .uint => return 16,
+                    .long, .ulong => return 32,
+                    .longlong, .ulonglong, .longdouble => return 64,
+                },
+                else => switch (self) {
+                    .short, .ushort => return 16,
+                    .int, .uint => return 32,
+                    .long, .ulong => return target.cpu.arch.ptrBitWidth(),
+                    .longlong, .ulonglong => return 64,
+                    .longdouble => switch (target.cpu.arch) {
+                        .i386, .x86_64 => return 80,
+
+                        .riscv64,
+                        .aarch64,
+                        .aarch64_be,
+                        .aarch64_32,
+                        .s390x,
+                        .mips64,
+                        .mips64el,
+                        .sparc,
+                        .sparc64,
+                        .sparcel,
+                        .powerpc,
+                        .powerpcle,
+                        .powerpc64,
+                        .powerpc64le,
+                        => return 128,
+
+                        else => return 64,
+                    },
+                },
+            },
+
+            .linux,
+            .freebsd,
+            .netbsd,
+            .dragonfly,
+            .openbsd,
+            .wasi,
+            .emscripten,
+            .plan9,
+            .solaris,
+            => switch (self) {
+                .short, .ushort => return 16,
+                .int, .uint => return 32,
+                .long, .ulong => return target.cpu.arch.ptrBitWidth(),
+                .longlong, .ulonglong => return 64,
+                .longdouble => switch (target.cpu.arch) {
+                    .i386, .x86_64 => return 80,
+
+                    .riscv64,
+                    .aarch64,
+                    .aarch64_be,
+                    .aarch64_32,
+                    .s390x,
+                    .mips64,
+                    .mips64el,
+                    .sparc,
+                    .sparc64,
+                    .sparcel,
+                    .powerpc,
+                    .powerpcle,
+                    .powerpc64,
+                    .powerpc64le,
+                    => return 128,
+
+                    else => return 64,
+                },
+            },
+
+            .windows, .uefi => switch (self) {
+                .short, .ushort => return 16,
+                .int, .uint, .long, .ulong => return 32,
+                .longlong, .ulonglong, .longdouble => return 64,
+            },
+
+            .macos, .ios, .tvos, .watchos => switch (self) {
+                .short, .ushort => return 16,
+                .int, .uint => return 32,
+                .long, .ulong, .longlong, .ulonglong => return 64,
+                .longdouble => switch (target.cpu.arch) {
+                    .i386, .x86_64 => return 80,
+                    else => return 64,
+                },
+            },
+
+            .ananas,
+            .cloudabi,
+            .fuchsia,
+            .kfreebsd,
+            .lv2,
+            .zos,
+            .haiku,
+            .minix,
+            .rtems,
+            .nacl,
+            .aix,
+            .cuda,
+            .nvcl,
+            .amdhsa,
+            .ps4,
+            .elfiamcu,
+            .mesa3d,
+            .contiki,
+            .amdpal,
+            .hermit,
+            .hurd,
+            .opencl,
+            .glsl450,
+            .vulkan,
+            => @panic("TODO specify the C integer and float type sizes for this OS"),
+        }
+    }
+};

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -278,6 +278,11 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
             \\
         ),
         .aarch64, .aarch64_be => try w.writeAll("#define __aarch64__ 1\n"),
+        .msp430 => try w.writeAll(
+            \\#define MSP430 1
+            \\#define __MSP430__ 1
+            \\
+        ),
         else => {},
     }
 
@@ -362,7 +367,7 @@ fn generateBuiltinTypes(comp: *Compilation) !void {
     const os = comp.target.os.tag;
     const wchar: Type = switch (comp.target.cpu.arch) {
         .xcore => .{ .specifier = .uchar },
-        .ve => .{ .specifier = .uint },
+        .ve, .msp430 => .{ .specifier = .uint },
         .arm, .armeb, .thumb, .thumbeb => .{
             .specifier = if (os != .windows and os != .netbsd and os != .openbsd) .uint else .int,
         },
@@ -376,6 +381,7 @@ fn generateBuiltinTypes(comp: *Compilation) !void {
     const ptrdiff = if (os == .windows and comp.target.cpu.arch.ptrBitWidth() == 64)
         Type{ .specifier = .long_long }
     else switch (comp.target.cpu.arch.ptrBitWidth()) {
+        16 => Type{ .specifier = .int },
         32 => Type{ .specifier = .int },
         64 => Type{ .specifier = .long },
         else => unreachable,
@@ -384,6 +390,7 @@ fn generateBuiltinTypes(comp: *Compilation) !void {
     const size = if (os == .windows and comp.target.cpu.arch.ptrBitWidth() == 64)
         Type{ .specifier = .ulong_long }
     else switch (comp.target.cpu.arch.ptrBitWidth()) {
+        16 => Type{ .specifier = .uint },
         32 => Type{ .specifier = .uint },
         64 => Type{ .specifier = .ulong },
         else => unreachable,
@@ -412,7 +419,7 @@ fn generateVaListType(comp: *Compilation) !Type {
             .ios, .macos, .tvos, .watchos, .aix => @as(Kind, .char_ptr),
             else => return Type{ .specifier = .void }, // unknown
         },
-        .i386 => .char_ptr,
+        .i386, .msp430 => .char_ptr,
         .x86_64 => switch (comp.target.os.tag) {
             .windows => @as(Kind, .char_ptr),
             else => .x86_64_va_list,

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -7,6 +7,7 @@ const Compilation = @import("Compilation.zig");
 const Attribute = @import("Attribute.zig");
 const StringInterner = @import("StringInterner.zig");
 const StringId = StringInterner.StringId;
+const CType = @import("zig").CType;
 
 const Type = @This();
 
@@ -769,33 +770,19 @@ pub fn sizeof(ty: Type, comp: *const Compilation) ?u64 {
         .variable_len_array, .unspecified_variable_len_array, .incomplete_array => return null,
         .func, .var_args_func, .old_style_func, .void, .bool => 1,
         .char, .schar, .uchar => 1,
-        .short, .ushort => 2,
-        .int, .uint => switch (comp.target.cpu.arch) {
-            .msp430 => @as(u64, 2),
-            else => 4,
-        },
-        .long, .ulong => switch (comp.target.os.tag) {
-            .linux,
-            .macos,
-            .freebsd,
-            .netbsd,
-            .dragonfly,
-            .openbsd,
-            .wasi,
-            .emscripten,
-            => comp.target.cpu.arch.ptrBitWidth() >> 3,
-            .windows, .uefi => 4,
-            else => 4,
-        },
-        .long_long, .ulong_long => 8,
+        .short => @divExact(CType.sizeInBits(.short, comp.target), 8),
+        .ushort => @divExact(CType.sizeInBits(.ushort, comp.target), 8),
+        .int => @divExact(CType.sizeInBits(.int, comp.target), 8),
+        .uint => @divExact(CType.sizeInBits(.uint, comp.target), 8),
+        .long => @divExact(CType.sizeInBits(.long, comp.target), 8),
+        .ulong => @divExact(CType.sizeInBits(.ulong, comp.target), 8),
+        .long_long => @divExact(CType.sizeInBits(.longlong, comp.target), 8),
+        .ulong_long => @divExact(CType.sizeInBits(.ulonglong, comp.target), 8),
+        .long_double => @divExact(CType.sizeInBits(.longdouble, comp.target), 8),
         .int128, .uint128 => 16,
         .fp16 => 2,
         .float => 4,
         .double => 8,
-        .long_double => switch (comp.target.cpu.arch) {
-            .msp430 => @as(u64, 8),
-            else => 16,
-        },
         .float80 => 16,
         .float128 => 16,
         // zig fmt: off

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -716,6 +716,7 @@ pub fn getCharSignedness(comp: *const Compilation) std.builtin.Signedness {
         .s390x,
         .xcore,
         .arc,
+        .msp430,
         => return .unsigned,
         else => return .signed,
     }
@@ -769,7 +770,10 @@ pub fn sizeof(ty: Type, comp: *const Compilation) ?u64 {
         .func, .var_args_func, .old_style_func, .void, .bool => 1,
         .char, .schar, .uchar => 1,
         .short, .ushort => 2,
-        .int, .uint => 4,
+        .int, .uint => switch (comp.target.cpu.arch) {
+            .msp430 => @as(u64, 2),
+            else => 4,
+        },
         .long, .ulong => switch (comp.target.os.tag) {
             .linux,
             .macos,
@@ -788,7 +792,10 @@ pub fn sizeof(ty: Type, comp: *const Compilation) ?u64 {
         .fp16 => 2,
         .float => 4,
         .double => 8,
-        .long_double => 16,
+        .long_double => switch (comp.target.cpu.arch) {
+            .msp430 => @as(u64, 8),
+            else => 16,
+        },
         .float80 => 16,
         .float128 => 16,
         // zig fmt: off
@@ -846,7 +853,10 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
         .func, .var_args_func, .old_style_func => 4, // TODO check target
         .char, .schar, .uchar, .void, .bool, .complex_char, .complex_schar, .complex_uchar => 1,
         .short, .ushort, .complex_short, .complex_ushort => 2,
-        .int, .uint, .complex_int, .complex_uint => 4,
+        .int, .uint, .complex_int, .complex_uint => switch (comp.target.cpu.arch) {
+            .msp430 => @as(u29, 2),
+            else => 4,
+        },
         .long, .ulong, .complex_long, .complex_ulong => switch (comp.target.os.tag) {
             .linux,
             .macos,
@@ -858,15 +868,15 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
             .emscripten,
             => comp.target.cpu.arch.ptrBitWidth() >> 3,
             .windows, .uefi => 4,
-            else => 4,
+            else => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 4,
         },
 
-        .long_long, .ulong_long, .complex_long_long, .complex_ulong_long => 8,
+        .long_long, .ulong_long, .complex_long_long, .complex_ulong_long => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 8,
         .int128, .uint128, .complex_int128, .complex_uint128 => 16,
         .fp16, .complex_fp16 => 2,
-        .float, .complex_float => 4,
-        .double, .complex_double => 8,
-        .long_double, .complex_long_double => 16,
+        .float, .complex_float => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 4,
+        .double, .complex_double => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 8,
+        .long_double, .complex_long_double => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 16,
         .float80, .complex_float80, .float128, .complex_float128 => 16,
         .pointer,
         .decayed_array,

--- a/test/cases/msp430 builtin types.c
+++ b/test/cases/msp430 builtin types.c
@@ -1,0 +1,28 @@
+//aro-args --target=msp430-other-none
+#include <stddef.h>
+#include <stdarg.h>
+
+#if !defined(MSP430) or !defined(__MSP430__)
+#error "Missing target macros"
+#endif
+
+_Static_assert(sizeof(int) == 2, "Wrong int size");
+_Static_assert(sizeof(long double) == 8, "Wrong long double size");
+_Static_assert(sizeof(char *) == 2, "Wrong pointer size");
+_Static_assert((char)-1 >= 0, "char should be unsigned");
+_Static_assert(sizeof(ptrdiff_t) == 2, "Wrong ptrdiff_t size");
+_Static_assert(sizeof(size_t) == 2, "Wrong size_t size");
+_Static_assert(sizeof(wchar_t) == 2, "Wrong wchar_t size");
+_Static_assert(_Alignof(char *) == 2, "wrong pointer alignment");
+_Static_assert(_Alignof(int) == 2, "wrong int alignment");
+_Static_assert(_Alignof(long) == 2, "wrong long alignment");
+_Static_assert(_Alignof(long long) == 2, "wrong long long alignment");
+_Static_assert(_Alignof(float) == 2, "wrong float alignment");
+_Static_assert(_Alignof(double) == 2, "wrong double alignment");
+_Static_assert(_Alignof(long double) == 2, "wrong long double alignment");
+
+void foo(int x, ... )
+{
+    va_list list;
+    char *foo = list;
+}


### PR DESCRIPTION
Macros taken from here: https://github.com/llvm/llvm-project/blob/main/clang/lib/Basic/Targets/MSP430.cpp

Size, alignment, va_list, char signedness info: https://www.ti.com/lit/an/slaa534a/slaa534a.pdf (page 12)

The MSP430 compiler also has the concept of code models. Different code models can adjust the size
of function pointers, data pointers, size_t, and ptrdiff_t. We currently only support the small model.

Closes #346