### PR TITLE
Parser: don't error on sizeof VLAs and variably-modified types

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -5828,7 +5828,9 @@ fn unExpr(p: *Parser) Error!Result {
                 res.val = .{ .tag = .int, .data = .{ .int = size } };
             } else {
                 res.val.tag = .unavailable;
-                try p.errStr(.invalid_sizeof, expected_paren - 1, try p.typeStr(res.ty));
+                if (res.ty.hasIncompleteSize()) {
+                    try p.errStr(.invalid_sizeof, expected_paren - 1, try p.typeStr(res.ty));
+                }
             }
             res.ty = p.comp.types.size;
             try res.un(p, .sizeof_expr);

--- a/test/cases/sizeof variably modified types.c
+++ b/test/cases/sizeof variably modified types.c
@@ -1,0 +1,12 @@
+void foo(int x) {
+    int arr[x];
+    _Static_assert(sizeof(arr) > 0, "sizeof VLA");
+    int (*pointer)[x] = &arr;
+    _Static_assert(sizeof(pointer) == sizeof(int *), "pointer size");
+    _Static_assert(sizeof(*pointer) > 0, "sizeof variably-modified type");
+}
+
+#define EXPECTED_ERRORS \
+    "sizeof variably modified types.c:3:20: error: static_assert expression is not an integral constant expression" \
+    "sizeof variably modified types.c:6:20: error: static_assert expression is not an integral constant expression" \
+


### PR DESCRIPTION
Fixes #352