### PR TITLE
Preprocessor: treat `defined` as a built-in function-like macro

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -145,6 +145,7 @@ pub const Options = packed struct {
     @"old-style-flexible-struct": Kind = .default,
     @"gnu-zero-variadic-macro-arguments": Kind = .default,
     @"main-return-type": Kind = .default,
+    @"expansion-to-defined": Kind = .default,
 };
 
 const messages = struct {
@@ -2010,6 +2011,15 @@ const messages = struct {
         const msg = "return type of 'main' is not 'int'";
         const kind = .warning;
         const opt = "main-return-type";
+    };
+    const expansion_to_defined = struct {
+        const msg = "macro expansion producing 'defined' has undefined behavior";
+        const kind = .warning;
+        const opt = "expansion-to-defined";
+    };
+    const missing_paren_after_defined = struct {
+        const msg = "missing ')' after 'defined'";
+        const kind = .@"error";
     };
 };
 

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -145,6 +145,9 @@ pub const Token = struct {
         macro_param_has_include,
         /// Special token for implementing __has_include_next
         macro_param_has_include_next,
+        /// Special token for implementing `defined` as a macro function,
+        /// which is a GCC extension also supported by clang
+        macro_param_defined,
         /// Special token for implementing __is_identifier
         macro_param_is_identifier,
         /// Special token for implementing __FILE__
@@ -461,6 +464,7 @@ pub const Token = struct {
                 .macro_param_has_builtin,
                 .macro_param_has_include,
                 .macro_param_has_include_next,
+                .macro_param_defined,
                 .macro_param_is_identifier,
                 .macro_file,
                 .macro_line,

--- a/test/cases/macro expansion to defined.c
+++ b/test/cases/macro expansion to defined.c
@@ -1,0 +1,42 @@
+#define FOO_IS_DEFINED defined( FOO)
+#define BAR_IS_DEFINED defined(BAR )
+
+#if FOO_IS_DEFINED
+#error FOO should not be defined
+#endif
+
+#pragma GCC diagnostic ignored "-Wexpansion-to-defined"
+
+#define FOO
+#if !FOO_IS_DEFINED
+#error FOO should be defined
+#endif
+
+#undef FOO
+#if FOO_IS_DEFINED
+#error FOO should not be defined
+#endif
+
+#define FOO 0
+#define BAR
+
+#if !FOO_IS_DEFINED || !BAR_IS_DEFINED
+#error FOO and BAR should be defined
+#endif
+
+#define TOO_MANY_TOKENS defined(A B)
+#define NOT_ENOUGH_TOKENS defined( )
+
+#if TOO_MANY_TOKENS
+#endif
+
+#if NOT_ENOUGH_TOKENS
+#endif
+
+#define EXPECTED_ERRORS "macro expansion to defined.c:4:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]" \
+	"macro expansion to defined.c:1:24: note: expanded from here" \
+	"macro expansion to defined.c:30:5: error: missing ')' after 'defined'" \
+	"macro expansion to defined.c:27:35: note: expanded from here" \
+	"macro expansion to defined.c:33:5: error: macro name must be an identifier" \
+	"macro expansion to defined.c:28:27: note: expanded from here" \
+


### PR DESCRIPTION
This allows macro expansions which produce `defined` (undefined behavior)
to behave the same as they do in GCC/clang

Closes #337