### PR TITLE
Preprocessor: handle macros which expand to `defined`

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -145,6 +145,7 @@ pub const Options = packed struct {
     @"old-style-flexible-struct": Kind = .default,
     @"gnu-zero-variadic-macro-arguments": Kind = .default,
     @"main-return-type": Kind = .default,
+    @"expansion-to-defined": Kind = .default,
 };
 
 const messages = struct {
@@ -2010,6 +2011,12 @@ const messages = struct {
         const msg = "return type of 'main' is not 'int'";
         const kind = .warning;
         const opt = "main-return-type";
+    };
+    const expansion_to_defined = struct {
+        const msg = "macro expansion producing 'defined' has undefined behavior";
+        const kind = .off;
+        const pedantic = true;
+        const opt = "expansion-to-defined";
     };
 };
 

--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -538,19 +538,6 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
         var tok = tokenizer.next();
         switch (tok.id) {
             .nl, .eof => break tok,
-            .keyword_defined => {
-                const first = tokenizer.nextNoWS();
-                const macro_tok = if (first.id == .l_paren) tokenizer.nextNoWS() else first;
-                if (!macro_tok.id.isMacroIdentifier()) try pp.err(macro_tok, .macro_name_missing);
-                if (first.id == .l_paren) {
-                    const r_paren = tokenizer.nextNoWS();
-                    if (r_paren.id != .r_paren) {
-                        try pp.err(r_paren, .closing_paren);
-                        try pp.err(first, .to_match_paren);
-                    }
-                }
-                tok.id = if (pp.defines.get(pp.tokSlice(macro_tok)) != null) .one else .zero;
-            },
             .whitespace => if (pp.top_expansion_buf.items.len == 0) continue,
             else => {},
         }
@@ -558,7 +545,7 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
     } else unreachable;
     if (pp.top_expansion_buf.items.len != 0) {
         pp.expansion_source_loc = pp.top_expansion_buf.items[0].loc;
-        try pp.expandMacroExhaustive(tokenizer, &pp.top_expansion_buf, 0, pp.top_expansion_buf.items.len, false);
+        try pp.expandMacroExhaustive(tokenizer, &pp.top_expansion_buf, 0, pp.top_expansion_buf.items.len, false, .expr);
     }
     for (pp.top_expansion_buf.items) |tok| {
         if (tok.id == .macro_ws) continue;
@@ -577,8 +564,10 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
 
     // validate the tokens in the expression
     try pp.tokens.ensureUnusedCapacity(pp.gpa, pp.top_expansion_buf.items.len);
-    for (pp.top_expansion_buf.items) |_, i| {
-        var tok = pp.top_expansion_buf.items[i];
+    var i: usize = 0;
+    const items = pp.top_expansion_buf.items;
+    while (i < items.len) : (i += 1) {
+        var tok = items[i];
         switch (tok.id) {
             .string_literal,
             .string_literal_utf_16,
@@ -637,24 +626,29 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
             },
             .macro_ws, .whitespace => continue,
             else => if (tok.id.isMacroIdentifier()) {
-                try pp.comp.diag.add(.{
-                    .tag = .undefined_macro,
-                    .loc = tok.loc,
-                    .extra = .{ .str = pp.expandedSlice(tok) },
-                }, tok.expansionSlice());
-
-                if (i + 1 < pp.top_expansion_buf.items.len and
-                    pp.top_expansion_buf.items[i + 1].id == .l_paren)
-                {
+                if (tok.id == .keyword_defined) {
+                    const tokens_consumed = try pp.handleKeywordDefined(&tok, items[i + 1 ..], eof);
+                    i += tokens_consumed + 1; // + 1 for keyword_defined
+                } else {
                     try pp.comp.diag.add(.{
-                        .tag = .fn_macro_undefined,
+                        .tag = .undefined_macro,
                         .loc = tok.loc,
                         .extra = .{ .str = pp.expandedSlice(tok) },
                     }, tok.expansionSlice());
-                    return false;
-                }
 
-                tok.id = .zero; // undefined macro
+                    if (i + 1 < pp.top_expansion_buf.items.len and
+                        pp.top_expansion_buf.items[i + 1].id == .l_paren)
+                    {
+                        try pp.comp.diag.add(.{
+                            .tag = .fn_macro_undefined,
+                            .loc = tok.loc,
+                            .extra = .{ .str = pp.expandedSlice(tok) },
+                        }, tok.expansionSlice());
+                        return false;
+                    }
+
+                    tok.id = .zero; // undefined macro
+                }
             },
         }
         pp.tokens.appendAssumeCapacity(tok);
@@ -687,6 +681,59 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
         .string_ids = undefined,
     };
     return parser.macroExpr();
+}
+
+/// Turns macro_tok from .keyword_defined into .zero or .one depending on whether the argument is defined
+/// Returns the number of tokens consumed
+fn handleKeywordDefined(pp: *Preprocessor, macro_tok: *Token, tokens: []const Token, eof: RawToken) !usize {
+    std.debug.assert(macro_tok.id == .keyword_defined);
+    var it = TokenIterator.init(tokens);
+    const first = it.nextNoWS() orelse {
+        try pp.err(eof, .macro_name_missing);
+        return it.i;
+    };
+    switch (first.id) {
+        .identifier, .extended_identifier => {
+            macro_tok.id = if (pp.defines.contains(pp.expandedSlice(first))) .one else .zero;
+            return it.i;
+        },
+        .l_paren => {},
+        else => {
+            try pp.comp.diag.add(.{
+                .tag = .macro_name_must_be_identifier,
+                .loc = first.loc,
+                .extra = .{ .str = pp.expandedSlice(first) },
+            }, first.expansionSlice());
+            return it.i;
+        },
+    }
+    const second = it.nextNoWS() orelse {
+        try pp.err(eof, .macro_name_missing);
+        return it.i;
+    };
+    switch (second.id) {
+        .identifier, .extended_identifier => {
+            macro_tok.id = if (pp.defines.contains(pp.expandedSlice(second))) .one else .zero;
+        },
+        else => {
+            try pp.err(eof, .macro_name_missing);
+            return it.i;
+        },
+    }
+    const last = it.nextNoWS();
+    if (last == null or last.?.id != .r_paren) {
+        const tok = last orelse tokFromRaw(eof);
+        try pp.comp.diag.add(.{
+            .tag = .closing_paren,
+            .loc = tok.loc,
+        }, tok.expansionSlice());
+        try pp.comp.diag.add(.{
+            .tag = .to_match_paren,
+            .loc = first.loc,
+        }, first.expansionSlice());
+    }
+
+    return it.i;
 }
 
 /// Skip until #else #elif #endif, return last directive token id.
@@ -1443,6 +1490,36 @@ fn removeExpandedTokens(pp: *Preprocessor, buf: *ExpandBuf, start: usize, len: u
     moving_end_idx.* -|= len;
 }
 
+/// The behavior of `defined` depends on whether we are in a preprocessor
+/// expression context (#if or #elif) or not.
+/// In a non-expression context it's just an identifier. Within a preprocessor
+/// expression it is a unary operator or one-argument function.
+const EvalContext = enum {
+    expr,
+    non_expr,
+};
+
+/// Helper for safely iterating over a slice of tokens while skipping whitespace
+const TokenIterator = struct {
+    toks: []const Token,
+    i: usize,
+
+    fn init(toks: []const Token) TokenIterator {
+        return .{ .toks = toks, .i = 0 };
+    }
+
+    fn nextNoWS(self: *TokenIterator) ?Token {
+        while (self.i < self.toks.len) : (self.i += 1) {
+            const tok = self.toks[self.i];
+            if (tok.id == .whitespace or tok.id == .macro_ws) continue;
+
+            self.i += 1;
+            return tok;
+        }
+        return null;
+    }
+};
+
 fn expandMacroExhaustive(
     pp: *Preprocessor,
     tokenizer: *Tokenizer,
@@ -1450,6 +1527,7 @@ fn expandMacroExhaustive(
     start_idx: usize,
     end_idx: usize,
     extend_buf: bool,
+    eval_ctx: EvalContext,
 ) MacroError!void {
     var moving_end_idx = end_idx;
     var advance_index: usize = 0;
@@ -1461,6 +1539,22 @@ fn expandMacroExhaustive(
         var idx: usize = start_idx + advance_index;
         while (idx < moving_end_idx) {
             const macro_tok = buf.items[idx];
+            if (macro_tok.id == .keyword_defined and eval_ctx == .expr) {
+                idx += 1;
+                var it = TokenIterator.init(buf.items[idx..moving_end_idx]);
+                if (it.nextNoWS()) |tok| {
+                    switch (tok.id) {
+                        .l_paren => {
+                            _ = it.nextNoWS(); // eat (what should be) identifier
+                            _ = it.nextNoWS(); // eat (what should be) r paren
+                        },
+                        .identifier, .extended_identifier => {},
+                        else => {},
+                    }
+                }
+                idx += it.i;
+                continue;
+            }
             const macro_entry = pp.defines.getPtr(pp.expandedSlice(macro_tok));
             if (macro_entry == null or !shouldExpand(buf.items[idx], macro_entry.?)) {
                 idx += 1;
@@ -1538,7 +1632,7 @@ fn expandMacroExhaustive(
                         errdefer expand_buf.deinit();
                         try expand_buf.appendSlice(arg);
 
-                        try pp.expandMacroExhaustive(tokenizer, &expand_buf, 0, expand_buf.items.len, false);
+                        try pp.expandMacroExhaustive(tokenizer, &expand_buf, 0, expand_buf.items.len, false, eval_ctx);
 
                         expanded_args.appendAssumeCapacity(expand_buf.toOwnedSlice());
                     }
@@ -1572,7 +1666,14 @@ fn expandMacroExhaustive(
                     for (res.items) |*tok, i| {
                         try tok.addExpansionLocation(pp.gpa, &.{macro_tok.loc});
                         try tok.addExpansionLocation(pp.gpa, macro_expansion_locs);
-                        if (i < increment_idx_by and pp.defines.contains(pp.expandedSlice(tok.*))) {
+                        if (tok.id == .keyword_defined and eval_ctx == .expr) {
+                            try pp.comp.diag.add(.{
+                                .tag = .expansion_to_defined,
+                                .loc = tok.loc,
+                            }, tok.expansionSlice());
+                        }
+
+                        if (i < increment_idx_by and (tok.id == .keyword_defined or pp.defines.contains(pp.expandedSlice(tok.*)))) {
                             increment_idx_by = i;
                         }
                     }
@@ -1610,14 +1711,14 @@ fn expandMacro(pp: *Preprocessor, tokenizer: *Tokenizer, raw: RawToken) MacroErr
     try pp.top_expansion_buf.append(source_tok);
     pp.expansion_source_loc = source_tok.loc;
 
-    try pp.expandMacroExhaustive(tokenizer, &pp.top_expansion_buf, 0, 1, true);
+    try pp.expandMacroExhaustive(tokenizer, &pp.top_expansion_buf, 0, 1, true, .non_expr);
     try pp.tokens.ensureUnusedCapacity(pp.gpa, pp.top_expansion_buf.items.len);
     for (pp.top_expansion_buf.items) |*tok| {
         if (tok.id == .macro_ws and !pp.comp.only_preprocess) {
             Token.free(tok.expansion_locs, pp.gpa);
             continue;
         }
-        tok.id.simplifyMacroKeyword();
+        tok.id.simplifyMacroKeywordExtra(true);
         pp.tokens.appendAssumeCapacity(tok.*);
     }
     if (pp.comp.only_preprocess) {

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -388,12 +388,13 @@ pub const Token = struct {
         }
 
         /// Turn macro keywords into identifiers.
-        pub fn simplifyMacroKeyword(id: *Id) void {
+        /// `keyword_defined` is special since it should only turn into an identifier if
+        /// we are *not* in an #if or #elif expression
+        pub fn simplifyMacroKeywordExtra(id: *Id, defined_to_identifier: bool) void {
             switch (id.*) {
                 .keyword_include,
                 .keyword_include_next,
                 .keyword_define,
-                .keyword_defined,
                 .keyword_undef,
                 .keyword_ifdef,
                 .keyword_ifndef,
@@ -405,8 +406,15 @@ pub const Token = struct {
                 .keyword_line,
                 .keyword_va_args,
                 => id.* = .identifier,
+                .keyword_defined => if (defined_to_identifier) {
+                    id.* = .identifier;
+                },
                 else => {},
             }
+        }
+
+        pub fn simplifyMacroKeyword(id: *Id) void {
+            simplifyMacroKeywordExtra(id, false);
         }
 
         pub fn lexeme(id: Id) ?[]const u8 {
@@ -717,6 +725,7 @@ pub const Token = struct {
                 .bang,
                 .identifier,
                 .extended_identifier,
+                .keyword_defined,
                 .one,
                 .zero,
                 => true,

--- a/test/cases/macro expansion to defined parsed.c
+++ b/test/cases/macro expansion to defined parsed.c
@@ -1,0 +1,7 @@
+//aro-args -Wexpansion-to-defined
+#define DEFINED defined
+
+void foo(void) {
+	int DEFINED = 0;
+	defined = 1;
+}

--- a/test/cases/macro expansion to defined.c
+++ b/test/cases/macro expansion to defined.c
@@ -1,0 +1,53 @@
+//aro-args -Wexpansion-to-defined
+
+#define FOO_IS_DEFINED defined(FOO)
+
+#if FOO_IS_DEFINED
+#error FOO should not be defined
+#endif
+
+#pragma GCC diagnostic ignored "-Wexpansion-to-defined"
+
+#define FOO
+#if !FOO_IS_DEFINED
+#error FOO should be defined
+#endif
+
+#define DEFINED defined
+#if !DEFINED(FOO)
+#error FOO should be defined
+#endif
+
+#undef FOO
+#if DEFINED(FOO)
+#error FOO should not be defined
+#endif
+
+#define PASTED_DEFINED def ## ined
+
+#if PASTED_DEFINED BAR
+#error BAR should not be defined
+#endif
+
+#define BAR
+#if !PASTED_DEFINED BAR
+#error BAR should be defined
+#endif
+
+#define DEFINED_MACRO(X) defined(X)
+#if DEFINED_MACRO(FOO)
+#error FOO should not be defined
+#endif
+
+#define FOO
+#if !DEFINED_MACRO(FOO)
+#error Foo should be defined
+#endif
+
+#define EXPECTED_ERRORS \
+	"macro expansion to defined.c:5:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]" \
+	"macro expansion to defined.c:3:24: note: expanded from here" \
+	"macro expansion to defined.c:44:24: error: macro name missing" \
+	"macro expansion to defined.c:43:6: error: expected expression" \
+	"macro expansion to defined.c:37:26: note: expanded from here"
+

--- a/test/cases/macro expansion to defined.c
+++ b/test/cases/macro expansion to defined.c
@@ -47,7 +47,8 @@
 #define EXPECTED_ERRORS \
 	"macro expansion to defined.c:5:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]" \
 	"macro expansion to defined.c:3:24: note: expanded from here" \
-	"macro expansion to defined.c:44:24: error: macro name missing" \
+	"macro expansion to defined.c:43:6: error: macro name must be an identifier" \
+	"macro expansion to defined.c:37:35: note: expanded from here" \
 	"macro expansion to defined.c:43:6: error: expected expression" \
 	"macro expansion to defined.c:37:26: note: expanded from here"
 


### PR DESCRIPTION
Since `defined` needs to look at its argument before expansion
happens, it needs to be special cased in expandMacroExhaustive.

It can't be a special function-like macro because that will cause
incorrect expansion outside of preprocessor expression contexts.
It can't be handled solely in `Preprocessor.expr` because the
argument will have been expanded by that point.

Closes #337