### PR TITLE
Preprocessor: track nonreplaced function-like macros

### DIFF
--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -11,6 +11,10 @@ const Tree = @This();
 
 pub const Token = struct {
     id: Id,
+    flags: packed struct {
+        expansion_disabled: bool = false,
+        is_macro_arg: bool = false,
+    } = .{},
     /// This location contains the actual token slice which might be generated.
     /// If it is generated then there is guaranteed to be at least one
     /// expansion location.

--- a/test/cases/expanded/macro expansion disabled.c
+++ b/test/cases/expanded/macro expansion disabled.c
@@ -1,0 +1,6 @@
+
+
+1 LOOP_INDIRECTION () (1)
+
+
+123

--- a/test/cases/macro expansion disabled.c
+++ b/test/cases/macro expansion disabled.c
@@ -1,0 +1,12 @@
+//aro-args -E
+
+#define EMPTY()
+#define LOOP_INDIRECTION() LOOP
+#define LOOP(x) x LOOP_INDIRECTION EMPTY()() (x)
+LOOP(1)
+
+#define DEFER(id) id EMPTY()
+#define EXPAND(...) __VA_ARGS__
+
+#define A() 123
+EXPAND(DEFER(A)())


### PR DESCRIPTION
The text of 6.10.3.4.2 is somewhat ambiguous:

    These nonreplaced macro name preprocessing tokens are no longer available
    for further replacement even if they are later (re)examined in contexts in
    which that macro name preprocessing token would otherwise have been
    replaced.

The immediately preceding text is describing the rule for not recursively
replacing a macro with itself if it appears in its own replacement list,
but a token is also "nonreplaced" if it is a function-like macro that is
not followed by a left parenthesis. GCC and clang both do not expand
a macro in this case during a rescan.

This rule only applies if a macro is nonexpanded in a replacement list;
it does not apply to argument pre-expansion.

Closes #339