### PR TITLE
Preprocessor: correctly handle parenthesis around `defined`

### DIFF
--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -628,7 +628,7 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
             else => if (tok.id.isMacroIdentifier()) {
                 if (tok.id == .keyword_defined) {
                     const tokens_consumed = try pp.handleKeywordDefined(&tok, items[i + 1 ..], eof);
-                    i += tokens_consumed + 1; // + 1 for keyword_defined
+                    i += tokens_consumed;
                 } else {
                     try pp.comp.diag.add(.{
                         .tag = .undefined_macro,

--- a/test/cases/macro expansion to defined.c
+++ b/test/cases/macro expansion to defined.c
@@ -44,6 +44,12 @@
 #error Foo should be defined
 #endif
 
+#if defined(NOT_DEFINED)
+#error NOT_DEFINED should not be defined
+#elif !DEFINED ( FOO )
+#error FOO should be defined
+#endif
+
 #define EXPECTED_ERRORS \
 	"macro expansion to defined.c:5:5: warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]" \
 	"macro expansion to defined.c:3:24: note: expanded from here" \


### PR DESCRIPTION
We do not need to consume an extra token after handling `defined`
since the loop continue expression will do that for us.

Closes #383