### PR TITLE
Layout tests: Disable `implicitly-unsigned-literal` warning

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -960,6 +960,13 @@ pub fn ignoreNonZeroSizedBitfieldTypeAlignment(comp: *const Compilation) bool {
     return false;
 }
 
+pub fn ignoreZeroSizedBitfieldTypeAlignment(comp: *const Compilation) bool {
+    switch (comp.target.cpu.arch) {
+        .avr => return true,
+        else => return false,
+    }
+}
+
 pub fn minZeroWidthBitfieldAlignment(comp: *const Compilation) ?u29 {
     switch (comp.target.cpu.arch) {
         .avr => return 8,

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -896,6 +896,10 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
                 .windows, .uefi => 8,
                 else => 4,
             },
+            .arm => switch (comp.target.os.tag) {
+                .ios => 4,
+                else => 8,
+            },
             else => 8,
         },
         .long_double => switch (comp.target.cpu.arch) {
@@ -903,6 +907,10 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
             .i386 => switch (comp.target.os.tag) {
                 .windows, .uefi => 8,
                 else => 4,
+            },
+            .arm => switch (comp.target.os.tag) {
+                .ios => 4,
+                else => 8,
             },
             else => 16,
         },

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -366,26 +366,6 @@ const compErr = blk: {
     @setEvalBranchQuota(100_000);
     break :blk std.ComptimeStringMap(ExpectedFailure, .{
         .{
-            "aarch64-generic-fuchsia-gnu:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-ios-macabi:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-ios-none:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-other-eabi:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-tvos-none:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "aarch64-generic-windows-msvc:Msvc|0003",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
@@ -698,14 +678,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "i386-i586-linux-gnu:Gcc|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "i386-i586-windows-msvc:Msvc|0003",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
@@ -847,34 +819,6 @@ const compErr = blk: {
         },
         .{
             "i386-i586-windows-msvc:Msvc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0062",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1514,10 +1458,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "riscv64-baseline_rv64-other-eabi:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "s390x-generic-linux-gnu:Gcc|0050",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
@@ -1706,22 +1646,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-fuchsia-gnu:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-haiku-gnu:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-ios-macabi:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-ios-none:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86_64-x86_64-linux-gnux32:Gcc|0001",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
@@ -1756,18 +1680,6 @@ const compErr = blk: {
         .{
             "x86_64-x86_64-linux-gnux32:Gcc|0083",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86_64-x86_64-other-eabi:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-solaris-eabi:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-tvos-none:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-uefi-msvc:Msvc|0005",

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -510,10 +510,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "arm-baseline-ios-none:Clang|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "arm-baseline-ios-none:Clang|0068",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
@@ -524,10 +520,6 @@ const compErr = blk: {
         .{
             "arm-baseline-ios-none:Clang|0082",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "arm-cortex_r4-ios-none:Clang|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "arm-cortex_r4-ios-none:Clang|0068",

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -510,30 +510,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "arm-baseline-ios-none:Clang|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "arm-baseline-ios-none:Clang|0073",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "arm-baseline-ios-none:Clang|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "arm-cortex_r4-ios-none:Clang|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "arm-cortex_r4-ios-none:Clang|0073",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "arm-cortex_r4-ios-none:Clang|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
             "avr-avr2-other-eabi:Gcc|0001",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },

--- a/test/records/0062_test.c
+++ b/test/records/0062_test.c
@@ -1606,7 +1606,7 @@ struct A075_extra_size {
 struct A075_extra_size var320;
 
 typedef enum {
-    F321 = 9223372036854775808,
+    F321 = 9223372036854775808ULL,
 } __attribute__((packed)) A076;
 A076 var322;
 struct A076_extra_alignment {
@@ -3206,7 +3206,7 @@ struct A155_extra_size {
 struct A155_extra_size var640;
 
 typedef enum {
-    F641 = -9223372036854775808,
+    F641 = -9223372036854775808ULL,
 } __attribute__((packed)) A156;
 A156 var642;
 struct A156_extra_alignment {
@@ -4831,7 +4831,7 @@ struct B075_extra_size {
 struct B075_extra_size var965;
 
 typedef enum {
-    F966 = 9223372036854775808,
+    F966 = 9223372036854775808ULL,
 } B076;
 B076 var967;
 struct B076_extra_alignment {
@@ -6431,7 +6431,7 @@ struct B155_extra_size {
 struct B155_extra_size var1285;
 
 typedef enum {
-    F1286 = -9223372036854775808,
+    F1286 = -9223372036854775808ULL,
 } B156;
 B156 var1287;
 struct B156_extra_alignment {


### PR DESCRIPTION
This was causing passing tests to show up as failed.