### PR TITLE
Parser: better support for flexible array members

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1765,7 +1765,7 @@ fn recordSpec(p: *Parser) Error!Type {
     }
 
     for (p.record_buf.items[record_buf_top..]) |field| {
-        if (field.ty.hasIncompleteSize()) break;
+        if (field.ty.hasIncompleteSize() and !field.ty.is(.incomplete_array)) break;
     } else {
         record_ty.fields = try p.arena.dupe(Type.Record.Field, p.record_buf.items[record_buf_top..]);
     }

--- a/test/cases/msvc zero size array.c
+++ b/test/cases/msvc zero size array.c
@@ -18,6 +18,16 @@ struct J_size {
 _Static_assert(sizeof(struct J_size) == 2, "incorrect size");
 _Static_assert(_Alignof(struct J_size) == 1, "incorrect alignment");
 
+struct J_extra_alignment {
+    char a;
+    J b;
+};
+struct J_extra_alignment var83;
+
+_Static_assert(sizeof(J) == 0, "");
+_Static_assert(_Alignof(J) == 4, "");
+
 #define EXPECTED_ERRORS "msvc zero size array.c:10:16: warning: sizeof returns 0" \
     "msvc zero size array.c:14:12: warning: sizeof returns 0" \
+    "msvc zero size array.c:27:16: warning: sizeof returns 0" \
 


### PR DESCRIPTION
Previously, creating a variable of a type that contains a FAM errored due to a record field having incomplete size.

Closes #404