### PR TITLE
Layout fixes for avr/msp430

### DIFF
--- a/deps/zig/type.zig
+++ b/deps/zig/type.zig
@@ -301,10 +301,7 @@ pub const CType = enum {
 
         // Overrides for unusual alignments
         switch (target.cpu.arch) {
-            .avr => switch (self) {
-                .short, .ushort => return 2,
-                else => return 1,
-            },
+            .avr => return 1,
             .i386 => switch (target.os.tag) {
                 .windows, .uefi => switch (self) {
                     .longlong, .ulonglong, .double => return 8,

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -538,8 +538,8 @@ pub fn compare(a: Value, op: std.math.CompareOperator, b: Value, ty: Type, comp:
             8 => return S.doICompare(u64, a, op, b),
             else => unreachable,
         } else switch (size) {
-            1 => return S.doICompare(u8, a, op, b),
-            2 => return S.doICompare(u16, a, op, b),
+            1 => return S.doICompare(i8, a, op, b),
+            2 => return S.doICompare(i16, a, op, b),
             4 => return S.doICompare(i32, a, op, b),
             8 => return S.doICompare(i64, a, op, b),
             else => unreachable,

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -510,18 +510,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "avr-avr2-other-eabi:Gcc|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "avr-avr2-other-eabi:Gcc|0027",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "avr-avr2-other-eabi:Gcc|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "avr-avr2-other-eabi:Gcc|0062",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -510,10 +510,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "avr-avr2-other-eabi:Gcc|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "hexagon-generic-linux-musl:Clang|0016",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
@@ -1319,10 +1315,6 @@ const compErr = blk: {
         },
         .{
             "mipsel-mips32-other-eabi:Clang|0052",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "msp430-msp430-other-eabi:Clang|0062",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{


### PR DESCRIPTION
Fixes signed integer compare, and layout on avr/msp430 (clang and gcc disagree on `short` alignment on avr; GCC seems to be the compiler of record since clang's support is experimental https://llvm.org/doxygen/md_lib_Target_AVR_README.html) - should we try to emulate clang? 

https://godbolt.org/z/45Ezjzh8T

