### PR TITLE
Small fixes for #pragma pack and _Alignof

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -722,6 +722,11 @@ const messages = struct {
         const kind = .warning;
         const suppress_gnu = true;
     };
+    const invalid_alignof = struct {
+        const msg = "invalid application of 'alignof' to an incomplete type '{s}'";
+        const extra = .str;
+        const kind = .@"error";
+    };
     const invalid_sizeof = struct {
         const msg = "invalid application of 'sizeof' to an incomplete type '{s}'";
         const extra = .str;

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -859,9 +859,12 @@ pub fn bitSizeof(ty: Type, comp: *const Compilation) ?u64 {
     };
 }
 
+pub fn alignable(ty: Type) bool {
+    return ty.isArray() or !ty.hasIncompleteSize();
+}
+
 /// Get the alignment of a type
 pub fn alignof(ty: Type, comp: *const Compilation) u29 {
-
     // don't return the attribute for records
     // layout has already accounted for requested alignment
     if (!ty.isRecord()) {

--- a/test/cases/#pragma pack clang.c
+++ b/test/cases/#pragma pack clang.c
@@ -1,0 +1,30 @@
+//aro-args --emulate=clang
+
+struct A {
+    char c;
+    int x;
+};
+
+struct B {
+#pragma pack(1)
+    char c;
+    int x;
+};
+
+#pragma pack()
+struct C {
+    char c;
+#pragma pack(1)
+    int x;
+};
+
+#pragma pack()
+struct D {
+    char c;
+    int x;
+#pragma pack(1)
+};
+
+_Static_assert(sizeof(struct A) == sizeof(struct B), "");
+_Static_assert(sizeof(struct A) == sizeof(struct C), "");
+_Static_assert(sizeof(struct A) == sizeof(struct D), "");

--- a/test/cases/#pragma pack gcc.c
+++ b/test/cases/#pragma pack gcc.c
@@ -1,0 +1,31 @@
+//aro-args --emulate=gcc
+
+struct A {
+    char c;
+    int x;
+};
+
+struct B {
+#pragma pack(1)
+    char c;
+    int x;
+};
+
+#pragma pack()
+struct C {
+    char c;
+#pragma pack(1)
+    int x;
+};
+
+#pragma pack()
+struct D {
+    char c;
+    int x;
+#pragma pack(1)
+};
+
+_Static_assert(sizeof(struct A) > sizeof(struct B), "");
+_Static_assert(sizeof(struct B) == sizeof(char) + sizeof(int), "");
+_Static_assert(sizeof(struct C) == sizeof(char) + sizeof(int), "");
+_Static_assert(sizeof(struct D) == sizeof(char) + sizeof(int), "");

--- a/test/cases/#pragma pack msvc.c
+++ b/test/cases/#pragma pack msvc.c
@@ -1,0 +1,33 @@
+//aro-args --emulate=msvc
+
+struct A {
+    char c;
+    int x;
+};
+
+struct B {
+#pragma pack(1)
+    char c;
+    int x;
+};
+
+#pragma pack()
+struct C {
+    char c;
+#pragma pack(1)
+    int x;
+};
+
+#pragma pack()
+struct D {
+    char c;
+    int x;
+#pragma pack(1)
+};
+
+_Static_assert(sizeof(struct A) > sizeof(struct B), "");
+_Static_assert(sizeof(struct B) == sizeof(struct C), "");
+_Static_assert(sizeof(struct B) == sizeof(char) + sizeof(int), "");
+// _Static_assert(sizeof(struct A) == sizeof(struct D), "");
+
+#define TESTS_SKIPPED 1

--- a/test/cases/sizeof alignof.c
+++ b/test/cases/sizeof alignof.c
@@ -21,7 +21,10 @@ int quuux(void) {
 
 _Static_assert(sizeof((void)1, (int*)0) == sizeof(int*), "sizeof");
 
+_Static_assert(_Alignof(struct does_not_exist) == 0, "");
+
 #define EXPECTED_ERRORS "sizeof alignof.c:10:19: error: expected parentheses around type name" \
     "sizeof alignof.c:10:37: error: expected parentheses around type name" \
     "sizeof alignof.c:14:32: warning: '_Alignof' applied to an expression is a GNU extension [-Wgnu-alignof-expression]" \
-    "sizeof alignof.c:19:20: warning: '_Alignof' applied to an expression is a GNU extension [-Wgnu-alignof-expression]"
+    "sizeof alignof.c:19:20: warning: '_Alignof' applied to an expression is a GNU extension [-Wgnu-alignof-expression]" \
+    "sizeof alignof.c:24:24: error: invalid application of 'alignof' to an incomplete type 'struct does_not_exist'" \


### PR DESCRIPTION
Disallow _Alignof (and _Alignas) for incomplete records and enums

Handle differences in `#pragma pack` behavior when it changes mid-record.