### PR TITLE
Layout: aligned attribute can increase record alignment beyond computed value

### DIFF
--- a/src/Type.zig
+++ b/src/Type.zig
@@ -864,16 +864,18 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
 
     // don't return the attribute for records
     // layout has already accounted for requested alignment
-    if (!ty.isRecord()) {
-        if (ty.requestedAlignment(comp)) |requested| {
-            // gcc does not respect alignment on enums
-            if (ty.get(.@"enum")) |ty_enum| {
-                if (comp.langopts.emulate == .gcc) {
-                    return ty_enum.alignof(comp);
-                }
+    if (ty.requestedAlignment(comp)) |requested| {
+        // gcc does not respect alignment on enums
+        if (ty.get(.@"enum")) |ty_enum| {
+            if (comp.langopts.emulate == .gcc) {
+                return ty_enum.alignof(comp);
             }
-            return requested;
+        } else if (ty.getRecord()) |rec| {
+            if (ty.hasIncompleteSize()) return 0;
+            const computed = @intCast(u29, @divExact(rec.type_layout.field_alignment_bits, 8));
+            return std.math.max(requested, computed);
         }
+        return requested;
     }
 
     // TODO get target from compilation

--- a/src/record_layout.zig
+++ b/src/record_layout.zig
@@ -622,7 +622,13 @@ pub fn compute(ty: *Type, comp: *const Compilation, pragma_pack: ?u8) void {
 
 pub fn computeLayout(ty: Type, comp: *const Compilation, type_layout: *TypeLayout) void {
     if (ty.getRecord()) |rec| {
-        type_layout.* = rec.type_layout;
+        const requested = BITS_PER_BYTE * (ty.requestedAlignment(comp) orelse 0);
+        type_layout.* = .{
+            .size_bits = rec.type_layout.size_bits,
+            .pointer_alignment_bits = std.math.max(requested, rec.type_layout.pointer_alignment_bits),
+            .field_alignment_bits = std.math.max(requested, rec.type_layout.field_alignment_bits),
+            .required_alignment_bits = rec.type_layout.required_alignment_bits,
+        };
     } else {
         type_layout.size_bits = ty.bitSizeof(comp) orelse 0;
         type_layout.pointer_alignment_bits = ty.alignof(comp) * BITS_PER_BYTE;

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -5,7 +5,9 @@ const aro = @import("aro");
 /// These tests don't work for any platform due to Aro bugs.
 /// Skip entirely.
 const global_test_exclude = std.ComptimeStringMap(void, .{
-    .{"0044"},
+    // ComptimeStringMap can't be empty so the entry below is a placeholder
+    // To skip a test entirely just put the test name e.g. .{"0044"}
+    .{"NONE"},
 });
 
 /// Set true to debug specific targets w/ specific tests.
@@ -452,6 +454,10 @@ const compErr = blk: {
             .{ .parse = true, .layout = true, .extra = true, .offset = false },
         },
         .{
+            "aarch64-generic-windows-msvc:Msvc|0044",
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+        },
+        .{
             "aarch64-generic-windows-msvc:Msvc|0045",
             .{ .parse = true, .layout = true, .extra = true, .offset = true },
         },
@@ -596,6 +602,10 @@ const compErr = blk: {
             .{ .parse = true, .layout = true, .extra = true, .offset = false },
         },
         .{
+            "x86-i586-windows-msvc:Msvc|0044",
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+        },
+        .{
             "x86-i586-windows-msvc:Msvc|0045",
             .{ .parse = true, .layout = true, .extra = true, .offset = true },
         },
@@ -733,6 +743,10 @@ const compErr = blk: {
         },
         .{
             "x86-i686-uefi-msvc:Msvc|0043",
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+        },
+        .{
+            "x86-i686-uefi-msvc:Msvc|0044",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
@@ -874,6 +888,10 @@ const compErr = blk: {
         .{
             "x86-i686-windows-msvc:Msvc|0043",
             .{ .parse = true, .layout = true, .extra = true, .offset = false },
+        },
+        .{
+            "x86-i686-windows-msvc:Msvc|0044",
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
             "x86-i686-windows-msvc:Msvc|0045",
@@ -1020,6 +1038,10 @@ const compErr = blk: {
             .{ .parse = true, .layout = true, .extra = true, .offset = false },
         },
         .{
+            "thumb-baseline-windows-msvc:Msvc|0044",
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+        },
+        .{
             "thumb-baseline-windows-msvc:Msvc|0045",
             .{ .parse = true, .layout = true, .extra = true, .offset = true },
         },
@@ -1157,6 +1179,10 @@ const compErr = blk: {
         },
         .{
             "x86_64-x86_64-uefi-msvc:Msvc|0043",
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+        },
+        .{
+            "x86_64-x86_64-uefi-msvc:Msvc|0044",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
@@ -1298,6 +1324,10 @@ const compErr = blk: {
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0043",
             .{ .parse = true, .layout = true, .extra = true, .offset = false },
+        },
+        .{
+            "x86_64-x86_64-windows-msvc:Msvc|0044",
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0045",


### PR DESCRIPTION
Previously we were ignoring the aligned attribute on the record if it was applied after the layout computation (such as via a typedef)