### PR TITLE
Langopts: Set __STDC_VERSION__ for c2x (C23)

### DIFF
--- a/include/stdarg.h
+++ b/include/stdarg.h
@@ -1,6 +1,8 @@
 /* <stdarg.h> for the Aro C compiler */
 
 #pragma once
+/* Todo: Set to 202311L once header is compliant with C23 */
+#define __STDC_VERSION_STDARG_H__ 0
 
 typedef __builtin_va_list va_list;
 #define va_start(ap, param) __builtin_va_start(ap, param)

--- a/include/stdatomic.h
+++ b/include/stdatomic.h
@@ -2,4 +2,6 @@
 
 #pragma once
 
+/* Todo: Set to 202311L once header is compliant with C23 */
+#define __STDC_VERSION_STDATOMIC_H__ 0
 // TODO atomics

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+/* Todo: Set to 202311L once header is compliant with C23 */
+#define __STDC_VERSION_BOOL_H__ 0
+
 #define bool _Bool
 
 #define true 1

--- a/include/stddef.h
+++ b/include/stddef.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+/* Todo: Set to 202311L once header is compliant with C23 */
+#define __STDC_VERSION_STDDEF_H__ 0
+
 typedef __PTRDIFF_TYPE__ ptrdiff_t;
 typedef __SIZE_TYPE__ size_t;
 typedef __WCHAR_TYPE__ wchar_t;

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -69,8 +69,8 @@ pub const Standard = enum {
             .c99, .gnu99 => "199901L",
             .c11, .gnu11 => "201112L",
             .default, .c17, .gnu17 => "201710L",
-            // todo: update once finalized; this currently matches clang
-            .c2x, .gnu2x => "201710L",
+            // todo: subject to change, verify once c23 finalized
+            .c2x, .gnu2x => "202311L",
         };
     }
 };

--- a/test/cases/c23 defines.c
+++ b/test/cases/c23 defines.c
@@ -1,0 +1,2 @@
+//aro-args -std=c2x
+_Static_assert(__STDC_VERSION__ == 202311L, "");

--- a/test/cases/stdarg.c
+++ b/test/cases/stdarg.c
@@ -20,13 +20,13 @@ int b = __builtin_va_end;
 int c = __builtin_foo();
 
 #define EXPECTED_ERRORS "stdarg.c:11:5: warning: second argument to 'va_start' is not the last named parameter [-Wvarargs]" \
-    "stdarg.h:6:52: note: expanded from here" \
+    "stdarg.h:8:52: note: expanded from here" \
     "stdarg.c:11:18: note: expanded from here" \
     "stdarg.c:15:5: error: 'va_start' used in a function with fixed args" \
-    "stdarg.h:6:29: note: expanded from here" \
+    "stdarg.h:8:29: note: expanded from here" \
     "stdarg.c:18:9: error: 'va_start' cannot be used outside a function" \
-    "stdarg.h:6:29: note: expanded from here" \
+    "stdarg.h:8:29: note: expanded from here" \
     "stdarg.c:18:9: error: initializing 'int' from incompatible type 'void'" \
-    "stdarg.h:6:29: note: expanded from here" \
+    "stdarg.h:8:29: note: expanded from here" \
     "stdarg.c:19:9: error: builtin function must be directly called" \
     "stdarg.c:20:9: error: use of unknown builtin '__builtin_foo' [-Wimplicit-function-declaration]" \


### PR DESCRIPTION
The final value is subject to change but this should let us start defining feature test macros as necessary for new c23 keywords and header changes