### PR TITLE
C23 keywords

### DIFF
--- a/include/stdalign.h
+++ b/include/stdalign.h
@@ -1,9 +1,11 @@
 /* <stdalign.h> for the Aro C compiler */
 
 #pragma once
+#if __STDC_VERSION__ < 202311L
 
 #define alignas _Alignas
 #define alignof _Alignof
 
 #define __alignas_is_defined 1
 #define __alignof_is_defined 1
+#endif

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -5,7 +5,9 @@
 /* Todo: Set to 202311L once header is compliant with C23 */
 #define __STDC_VERSION_BOOL_H__ 0
 
+#if __STDC_VERSION__ < 202311L
 #define bool _Bool
+#endif
 
 #define true 1
 #define false 0

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -148,6 +148,7 @@ pub const Options = packed struct {
     @"main-return-type": Kind = .default,
     @"expansion-to-defined": Kind = .default,
     @"bit-int-extension": Kind = .default,
+    @"keyword-macro": Kind = .default,
 };
 
 const messages = struct {
@@ -2109,6 +2110,12 @@ const messages = struct {
         const msg = "{s} of bit sizes greater than 128 not supported";
         const extra = .str;
         const kind = .@"error";
+    };
+    const keyword_macro = struct {
+        const msg = "keyword is hidden by macro definition";
+        const kind = .off;
+        const pedantic = true;
+        const opt = "keyword-macro";
     };
 };
 

--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -1901,6 +1901,14 @@ fn define(pp: *Preprocessor, tokenizer: *Tokenizer) Error!void {
         try pp.err(macro_name, .macro_name_must_be_identifier);
         return skipToNl(tokenizer);
     }
+    var macro_name_token_id = macro_name.id;
+    macro_name_token_id.simplifyMacroKeyword();
+    switch (macro_name_token_id) {
+        .identifier, .extended_identifier => {},
+        else => if (macro_name_token_id.isMacroIdentifier()) {
+            try pp.err(macro_name, .keyword_macro);
+        },
+    }
 
     // Check for function macros and empty defines.
     var first = tokenizer.next();

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -190,6 +190,11 @@ pub const Token = struct {
 
         // ISO C23
         keyword_bit_int,
+        keyword_c23_alignas,
+        keyword_c23_alignof,
+        keyword_c23_bool,
+        keyword_c23_static_assert,
+        keyword_c23_thread_local,
 
         // Preprocessor directives
         keyword_include,
@@ -370,6 +375,11 @@ pub const Token = struct {
                 .keyword_int16_2,
                 .keyword_int8,
                 .keyword_int8_2,
+                .keyword_c23_alignas,
+                .keyword_c23_alignof,
+                .keyword_c23_bool,
+                .keyword_c23_static_assert,
+                .keyword_c23_thread_local,
                 => return true,
                 else => return false,
             }
@@ -549,6 +559,11 @@ pub const Token = struct {
                 .keyword_static_assert => "_Static_assert",
                 .keyword_thread_local => "_Thread_local",
                 .keyword_bit_int => "_BitInt",
+                .keyword_c23_alignas => "alignas",
+                .keyword_c23_alignof => "alignof",
+                .keyword_c23_bool => "bool",
+                .keyword_c23_static_assert => "static_assert",
+                .keyword_c23_thread_local => "thread_local",
                 .keyword_include => "include",
                 .keyword_include_next => "include_next",
                 .keyword_define => "define",
@@ -694,6 +709,14 @@ pub const Token = struct {
             .keyword_typeof => if (standard.isGNU()) kw else .identifier,
             .keyword_asm => if (standard.isGNU()) kw else .identifier,
             .keyword_declspec => if (comp.langopts.declspec_attrs) kw else .identifier,
+
+            .keyword_c23_alignas,
+            .keyword_c23_alignof,
+            .keyword_c23_bool,
+            .keyword_c23_static_assert,
+            .keyword_c23_thread_local,
+            => if (standard.atLeast(.c2x)) kw else .identifier,
+
             .keyword_int64,
             .keyword_int64_2,
             .keyword_int32,
@@ -782,6 +805,11 @@ pub const Token = struct {
 
         // ISO C23
         .{ "_BitInt", .keyword_bit_int },
+        .{ "alignas", .keyword_c23_alignas },
+        .{ "alignof", .keyword_c23_alignof },
+        .{ "bool", .keyword_c23_bool },
+        .{ "static_assert", .keyword_c23_static_assert },
+        .{ "thread_local", .keyword_c23_thread_local },
 
         // Preprocessor directives
         .{ "include", .keyword_include },

--- a/test/cases/c23 keywords.c
+++ b/test/cases/c23 keywords.c
@@ -1,0 +1,24 @@
+//aro-args -std=c2x -pedantic
+
+static_assert(1 == 1);
+static_assert(alignof(char) == 1);
+thread_local int x;
+bool b = 1;
+int alignas(16) y;
+
+#define static_assert no
+#define alignof no
+#define thread_local no
+#define bool no
+#define alignas no
+
+// TODO: true / false keywords
+#define TESTS_SKIPPED 2
+
+#define EXPECTED_ERRORS \
+    "c23 keywords.c:9:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]" \
+    "c23 keywords.c:10:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]" \
+    "c23 keywords.c:11:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]" \
+    "c23 keywords.c:12:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]" \
+    "c23 keywords.c:13:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]" \
+

--- a/test/cases/keyword hidden by macro.c
+++ b/test/cases/keyword hidden by macro.c
@@ -1,0 +1,12 @@
+//aro-args -pedantic
+#define int foo
+#define include hello
+#include <stdbool.h>
+#define if then
+#define alignof _Alignof
+
+unsigned x; // only here to suppress -Wempty-translation-unit
+
+#define EXPECTED_ERRORS "keyword hidden by macro.c:2:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]" \
+    "keyword hidden by macro.c:5:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]" \
+


### PR DESCRIPTION
Note: this is based on #431, I can rebase or edit as necessary 

Add `alignas`, `alignof`, `bool`, `static_assert`, and `thread_local` as keywords. `true` and `false` will be done separately because they add a new syntax term `predefined constant` that can also be used to implement `nullptr`; plus they'll need a bit more preprocessor support to ensure `true` works as intended.