### PR TITLE
Attribute: handle typedef decreasing record alignment

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1440,7 +1440,7 @@ fn initDeclarator(p: *Parser, decl_spec: *DeclSpec, attr_buf_top: usize) Error!?
     try p.attributeSpecifierExtra(init_d.d.name);
 
     if (decl_spec.storage_class == .typedef) {
-        init_d.d.ty = try Attribute.applyTypeAttributes(p, init_d.d.ty, attr_buf_top, null);
+        init_d.d.ty = try Attribute.applyTypedefAttributes(p, init_d.d.ty, attr_buf_top);
     } else if (init_d.d.ty.isFunc()) {
         init_d.d.ty = try Attribute.applyFunctionAttributes(p, init_d.d.ty, attr_buf_top);
     } else {

--- a/test/cases/typedef record alignment.c
+++ b/test/cases/typedef record alignment.c
@@ -1,0 +1,40 @@
+//aro-args --target=x86_64-linux-gnu -Wno-gnu-alignof-expression
+
+__attribute__((aligned(2))) typedef struct {
+	int a;
+} A;
+_Static_assert(_Alignof(A) == 2, "");
+
+typedef __attribute__((aligned(2))) struct {
+	int a;
+} B;
+_Static_assert(_Alignof(B) == 2, "");
+
+typedef struct __attribute__((aligned(2))) {
+	int a;
+} C;
+_Static_assert(_Alignof(C) == 4, "");
+
+typedef struct {
+	int a;
+} __attribute__((aligned(2))) D;
+_Static_assert(_Alignof(D) == 4, "");
+_Static_assert(_Alignof(typeof(D)) == 4, "");
+typeof(D) d;
+_Static_assert(_Alignof(d)== 4, "");
+
+typedef struct {
+	int a;
+}  E __attribute__((aligned(2)));
+_Static_assert(_Alignof(E) == 2, "");
+_Static_assert(_Alignof(typeof(E)) == 2, "");
+typeof(E) e;
+_Static_assert(_Alignof(e)== 2, "");
+
+struct __attribute__((aligned(2))) F {
+	int a;
+};
+_Static_assert(_Alignof(struct F) == 4, "");
+
+typedef __attribute__((aligned(2))) struct F G;
+_Static_assert(_Alignof(G) == 2, "");


### PR DESCRIPTION
This addresses the GCC/clang side of #367. It's also a pretty ugly hack so feel free to close it if you'd prefer to handle it some other way.  Short of reworking the entire Type system, another way I think it could be handled would be adding a `?u29` alignment field to `Type.Attributed` to store typedef alignments

The fundamental problem is that after parse time there's no way to distinguish "struct with attributes" from "typedef which adds attributes to a struct" . It's relevant because attributes directly on a struct have a different effect on alignment than attributes on a typedef.

```c
struct A {
    int x;
};
struct __attribute__((aligned(2))) B {
    int x;
};
typedef __attribute__((aligned(2))) struct A Aligned_A;

_Static_assert(_Alignof(struct A) == 4, "");
_Static_assert(_Alignof(struct B) == 4, "");
_Static_assert(_Alignof(Aligned_A) == 2, "");
```

Both `struct B` and `Aligned_A` are represented as "attributed record", where the record has a single int field, but they have different alignment because the alignment on a typedef is allowed to be lower than the natural alignment.