### PR TITLE
add support for c23 true/false keywords

### DIFF
--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -2,14 +2,12 @@
 
 #pragma once
 
-/* Todo: Set to 202311L once header is compliant with C23 */
-#define __STDC_VERSION_BOOL_H__ 0
-
 #if __STDC_VERSION__ < 202311L
 #define bool _Bool
-#endif
 
 #define true 1
 #define false 0
 
 #define __bool_true_false_are_defined 1
+
+#endif

--- a/src/CodeGen.zig
+++ b/src/CodeGen.zig
@@ -519,6 +519,7 @@ fn genExpr(c: *CodeGen, node: NodeIndex) Error!Ir.Ref {
     const data = c.node_data[@enumToInt(node)];
     switch (c.node_tag[@enumToInt(node)]) {
         .enumeration_ref,
+        .bool_literal,
         .int_literal,
         .char_literal,
         .float_literal,

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -352,16 +352,16 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
 
     // various int types
     const mapper = comp.string_interner.getSlowTypeMapper();
-    try generateTypeMacro(w, mapper, "__PTRDIFF_TYPE__", comp.types.ptrdiff);
-    try generateTypeMacro(w, mapper, "__SIZE_TYPE__", comp.types.size);
-    try generateTypeMacro(w, mapper, "__WCHAR_TYPE__", comp.types.wchar);
+    try generateTypeMacro(w, mapper, "__PTRDIFF_TYPE__", comp.types.ptrdiff, comp.langopts);
+    try generateTypeMacro(w, mapper, "__SIZE_TYPE__", comp.types.size, comp.langopts);
+    try generateTypeMacro(w, mapper, "__WCHAR_TYPE__", comp.types.wchar, comp.langopts);
 
     return comp.addSourceFromBuffer("<builtin>", buf.items);
 }
 
-fn generateTypeMacro(w: anytype, mapper: StringInterner.TypeMapper, name: []const u8, ty: Type) !void {
+fn generateTypeMacro(w: anytype, mapper: StringInterner.TypeMapper, name: []const u8, ty: Type, langopts: LangOpts) !void {
     try w.print("#define {s} ", .{name});
-    try ty.print(mapper, w);
+    try ty.print(mapper, langopts, w);
     try w.writeByte('\n');
 }
 

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -349,12 +349,12 @@ pub fn todo(p: *Parser, msg: []const u8) Error {
 }
 
 pub fn typeStr(p: *Parser, ty: Type) ![]const u8 {
-    if (Type.Builder.fromType(ty).str()) |str| return str;
+    if (Type.Builder.fromType(ty).str(p.comp.langopts)) |str| return str;
     const strings_top = p.strings.items.len;
     defer p.strings.items.len = strings_top;
 
     const mapper = p.comp.string_interner.getSlowTypeMapper();
-    try ty.print(mapper, p.strings.writer());
+    try ty.print(mapper, p.comp.langopts, p.strings.writer());
     return try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
 }
 
@@ -368,11 +368,11 @@ pub fn typePairStrExtra(p: *Parser, a: Type, msg: []const u8, b: Type) ![]const 
 
     try p.strings.append('\'');
     const mapper = p.comp.string_interner.getSlowTypeMapper();
-    try a.print(mapper, p.strings.writer());
+    try a.print(mapper, p.comp.langopts, p.strings.writer());
     try p.strings.append('\'');
     try p.strings.appendSlice(msg);
     try p.strings.append('\'');
-    try b.print(mapper, p.strings.writer());
+    try b.print(mapper, p.comp.langopts, p.strings.writer());
     try p.strings.append('\'');
     return try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
 }
@@ -6186,7 +6186,7 @@ fn validateFieldAccess(p: *Parser, record_ty: Type, expr_ty: Type, field_name_to
 
     try p.strings.writer().print("'{s}' in '", .{p.tokSlice(field_name_tok)});
     const mapper = p.comp.string_interner.getSlowTypeMapper();
-    try expr_ty.print(mapper, p.strings.writer());
+    try expr_ty.print(mapper, p.comp.langopts, p.strings.writer());
     try p.strings.append('\'');
 
     const duped = try p.comp.diag.arena.allocator().dupe(u8, p.strings.items);
@@ -6545,7 +6545,7 @@ fn primaryExpr(p: *Parser) Error!Result {
             } else if (p.func.ty) |func_ty| {
                 const mapper = p.comp.string_interner.getSlowTypeMapper();
                 p.strings.items.len = 0;
-                try Type.printNamed(func_ty, p.tokSlice(p.func.name), mapper, p.strings.writer());
+                try Type.printNamed(func_ty, p.tokSlice(p.func.name), mapper, p.comp.langopts, p.strings.writer());
                 try p.strings.append(0);
                 const predef = try p.makePredefinedIdentifier();
                 ty = predef.ty;

--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -658,6 +658,8 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
                 return false;
             },
             .macro_ws, .whitespace => continue,
+            .keyword_false => tok.id = .zero,
+            .keyword_true => tok.id = .one,
             else => if (tok.id.isMacroIdentifier()) {
                 if (tok.id == .keyword_defined) {
                     const tokens_consumed = try pp.handleKeywordDefined(&tok, items[i + 1 ..], eof);

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -699,7 +699,7 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, mapper: StringInterner.Type
     }
     if (color) util.setColor(TYPE, w);
     try w.writeByte('\'');
-    try ty.dump(mapper, w);
+    try ty.dump(mapper, tree.comp.langopts, w);
     try w.writeByte('\'');
 
     if (isLval(tree.nodes, tree.data, tree.value_map, node)) {

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -460,6 +460,8 @@ pub const Tag = enum(u8) {
     decl_ref_expr,
     /// decl_ref
     enumeration_ref,
+    /// C23 bool literal `true` / `false`
+    bool_literal,
     /// integer literal, always unsigned
     int_literal,
     /// Same as int_literal, but originates from a char literal
@@ -1141,6 +1143,7 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, mapper: StringInterner.Type
             try w.print("{s}\n", .{tree.tokSlice(data.decl_ref)});
             if (color) util.setColor(.reset, w);
         },
+        .bool_literal,
         .int_literal,
         .char_literal,
         .float_literal,

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -565,9 +565,11 @@ pub fn hash(v: Value) u64 {
 pub fn dump(v: Value, ty: Type, comp: *Compilation, w: anytype) !void {
     switch (v.tag) {
         .unavailable => try w.writeAll("unavailable"),
-        .int => if (ty.isUnsignedInt(comp))
-            try w.print("{d}", .{v.data.int})
-        else {
+        .int => if (ty.is(.bool) and comp.langopts.standard.atLeast(.c2x)) {
+            try w.print("{s}", .{if (v.isZero()) "false" else "true"});
+        } else if (ty.isUnsignedInt(comp)) {
+            try w.print("{d}", .{v.data.int});
+        } else {
             try w.print("{d}", .{v.signExtend(ty, comp)});
         },
         .bytes => try w.print("\"{s}\"", .{v.data.bytes}),

--- a/test/cases/ast/c23 true false ast.c
+++ b/test/cases/ast/c23 true false ast.c
@@ -1,0 +1,44 @@
+var: 'bool'
+ name: a
+ init:
+  bool_literal: 'bool' (value: true)
+
+var: 'bool'
+ name: b
+ init:
+  bool_literal: 'bool' (value: false)
+
+var: 'bool'
+ name: c
+ init:
+  implicit_cast: (int_to_bool) 'bool'
+    int_literal: 'int' (value: 0)
+
+var: 'bool'
+ name: d
+ init:
+  implicit_cast: (int_to_bool) 'bool'
+    int_literal: 'int' (value: 1)
+
+var: 'int'
+ name: e
+ init:
+  implicit_cast: (bool_to_int) 'int'
+    bool_literal: 'bool' (value: true)
+
+var: 'int'
+ name: f
+ init:
+  implicit_cast: (bool_to_int) 'int'
+    bool_literal: 'bool' (value: false)
+
+var: 'int'
+ name: g
+ init:
+  add_expr: 'int'
+   lhs:
+    implicit_cast: (bool_to_int) 'int'
+      bool_literal: 'bool' (value: true)
+   rhs:
+    int_literal: 'int' (value: 1)
+

--- a/test/cases/c23 keywords.c
+++ b/test/cases/c23 keywords.c
@@ -1,5 +1,5 @@
-//aro-args -std=c2x -pedantic
-
+//aro-args -std=c2x -pedantic -Wundef
+#include <stdbool.h>
 static_assert(1 == 1);
 static_assert(alignof(char) == 1);
 thread_local int x;
@@ -14,8 +14,28 @@ int alignas(16) y;
 
 typedef typeof(int) MyInt;
 
-// TODO: true / false keywords
-#define TESTS_SKIPPED 2
+#if false
+#error false should expand to 0
+#endif
+
+#if true
+#else
+#error true should expand to 1
+#endif
+
+#define FOO true
+#if FOO
+#else
+#error true should expand to 1
+#endif
+
+#if true + 1 != 2
+#error true should expand to 1 in preprocessor arithmetic
+#endif
+
+#if defined(true) || defined(false)
+#error true and false should not be defined
+#endif
 
 #define EXPECTED_ERRORS \
     "c23 keywords.c:9:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]" \

--- a/test/cases/c23 true false ast.c
+++ b/test/cases/c23 true false ast.c
@@ -1,0 +1,10 @@
+//aro-args -std=c2x
+bool a = true;
+bool b = false;
+bool c = 0;
+bool d = 1;
+
+int e = true;
+int f = false;
+
+int g = true + 1;

--- a/test/cases/constexpr.c
+++ b/test/cases/constexpr.c
@@ -15,6 +15,12 @@ constexpr _BitInt(b) bit = 4;
 int non_const = 4;
 constexpr int invalid = non_const; // TODO
 
+constexpr bool const_bool_true = true;
+static_assert(const_bool_true);
+constexpr bool const_bool_false = false;
+static_assert(!const_bool_false);
+
+
 #define TESTS_SKIPPED 1
 
 #define EXPECTED_ERRORS "constexpr.c:5:14: error: cannot combine with previous 'thread_local' specifier" \

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -540,7 +540,7 @@ const StmtTypeDumper = struct {
         const tag = tree.nodes.items(.tag)[@enumToInt(node)];
         if (tag == .implicit_return) return;
         const ty = tree.nodes.items(.ty)[@enumToInt(node)];
-        ty.dump(mapper, m.buf.writer()) catch {};
+        ty.dump(mapper, tree.comp.langopts, m.buf.writer()) catch {};
         const owned = m.buf.toOwnedSlice();
         errdefer m.buf.allocator.free(owned);
         try self.types.append(owned);


### PR DESCRIPTION
I removed `__STDC_VERSION_BOOL_H__` because it looks like it's not defined in the latest draft I was able to find. I also removed `__bool_true_false_are_defined` for C23 because in C23 stdbool.h "provides no content".