### PR TITLE
MSVC layout and runner fixes.

### DIFF
--- a/src/Type.zig
+++ b/src/Type.zig
@@ -863,6 +863,9 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
             if (ty.hasIncompleteSize()) return 0;
             const computed = @intCast(u29, @divExact(rec.type_layout.field_alignment_bits, 8));
             return std.math.max(requested, computed);
+        } else if (comp.langopts.emulate == .msvc) {
+            const type_align = ty.data.attributed.base.alignof(comp);
+            return std.math.max(requested, type_align);
         }
         return requested;
     }

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -363,32 +363,20 @@ const compErr = blk: {
     @setEvalBranchQuota(100_000);
     break :blk std.ComptimeStringMap(ExpectedFailure, .{
         .{
-            "aarch64-generic-windows-msvc:Msvc|0003",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0005",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0007",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0009",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "aarch64-generic-windows-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0012",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "aarch64-generic-windows-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
+        },
+        .{
+            "aarch64-generic-windows-msvc:Msvc|0018",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
+        },
+        .{
+            "aarch64-generic-windows-msvc:Msvc|0020",
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
             "aarch64-generic-windows-msvc:Msvc|0020",
@@ -403,36 +391,16 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "aarch64-generic-windows-msvc:Msvc|0024",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
             "aarch64-generic-windows-msvc:Msvc|0025",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0026",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0027",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "aarch64-generic-windows-msvc:Msvc|0028",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "aarch64-generic-windows-msvc:Msvc|0026",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "aarch64-generic-windows-msvc:Msvc|0029",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0030",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0031",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
             "aarch64-generic-windows-msvc:Msvc|0037",
@@ -444,42 +412,26 @@ const compErr = blk: {
         },
         .{
             "aarch64-generic-windows-msvc:Msvc|0042",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0043",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0044",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
+            "aarch64-generic-windows-msvc:Msvc|0044",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
+        },
+        .{
             "aarch64-generic-windows-msvc:Msvc|0045",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "aarch64-generic-windows-msvc:Msvc|0046",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "aarch64-generic-windows-msvc:Msvc|0047",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0057",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0058",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "aarch64-generic-windows-msvc:Msvc|0053",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "aarch64-generic-windows-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0064",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -495,35 +447,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "aarch64-generic-windows-msvc:Msvc|0077",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "aarch64-generic-windows-msvc:Msvc|0080",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0081",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0003",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0005",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0007",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0009",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -531,103 +455,51 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0012",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i586-windows-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0020",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0021",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
+            "x86-i586-windows-msvc:Msvc|0018",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86-i586-windows-msvc:Msvc|0023",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0024",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
             "x86-i586-windows-msvc:Msvc|0025",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0026",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0027",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0028",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86-i586-windows-msvc:Msvc|0026",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86-i586-windows-msvc:Msvc|0029",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0030",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0031",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0037",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0039",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i586-windows-msvc:Msvc|0042",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0043",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
             "x86-i586-windows-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86-i586-windows-msvc:Msvc|0045",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86-i586-windows-msvc:Msvc|0046",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0047",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0057",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0058",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86-i586-windows-msvc:Msvc|0053",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86-i586-windows-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0064",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -639,47 +511,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0072",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0077",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0080",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0081",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0003",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0005",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0007",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0009",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i686-uefi-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0012",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -687,12 +519,8 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-uefi-msvc:Msvc|0020",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0021",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
+            "x86-i686-uefi-msvc:Msvc|0018",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86-i686-uefi-msvc:Msvc|0023",
@@ -707,31 +535,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-uefi-msvc:Msvc|0027",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0028",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
             "x86-i686-uefi-msvc:Msvc|0029",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0030",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0031",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0037",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0039",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -739,35 +543,23 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "x86-i686-uefi-msvc:Msvc|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86-i686-uefi-msvc:Msvc|0044",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-uefi-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86-i686-uefi-msvc:Msvc|0045",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86-i686-uefi-msvc:Msvc|0046",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-uefi-msvc:Msvc|0047",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0057",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0058",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86-i686-uefi-msvc:Msvc|0053",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86-i686-uefi-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0064",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -779,47 +571,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-uefi-msvc:Msvc|0072",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0077",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0080",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0081",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0003",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0005",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0007",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0009",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i686-windows-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0012",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -827,95 +579,47 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-windows-msvc:Msvc|0020",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0021",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
+            "x86-i686-windows-msvc:Msvc|0018",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86-i686-windows-msvc:Msvc|0023",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-windows-msvc:Msvc|0024",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
             "x86-i686-windows-msvc:Msvc|0025",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0026",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0027",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-windows-msvc:Msvc|0028",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86-i686-windows-msvc:Msvc|0026",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86-i686-windows-msvc:Msvc|0029",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-windows-msvc:Msvc|0030",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0031",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0037",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0039",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i686-windows-msvc:Msvc|0042",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0043",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
             "x86-i686-windows-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86-i686-windows-msvc:Msvc|0045",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86-i686-windows-msvc:Msvc|0046",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-windows-msvc:Msvc|0047",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0057",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0058",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86-i686-windows-msvc:Msvc|0053",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86-i686-windows-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0064",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -927,52 +631,16 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-windows-msvc:Msvc|0072",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0077",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0080",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0081",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0003",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0005",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0007",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0009",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "thumb-baseline-windows-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0012",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
+        },
+        .{
+            "thumb-baseline-windows-msvc:Msvc|0018",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0020",
@@ -987,36 +655,16 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "thumb-baseline-windows-msvc:Msvc|0024",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
             "thumb-baseline-windows-msvc:Msvc|0025",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0026",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0027",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "thumb-baseline-windows-msvc:Msvc|0028",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "thumb-baseline-windows-msvc:Msvc|0026",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0029",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0030",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0031",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0037",
@@ -1028,42 +676,26 @@ const compErr = blk: {
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0042",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0043",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0044",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
+            "thumb-baseline-windows-msvc:Msvc|0044",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
+        },
+        .{
             "thumb-baseline-windows-msvc:Msvc|0045",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0046",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "thumb-baseline-windows-msvc:Msvc|0047",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0057",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0058",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "thumb-baseline-windows-msvc:Msvc|0053",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0064",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1079,35 +711,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "thumb-baseline-windows-msvc:Msvc|0077",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "thumb-baseline-windows-msvc:Msvc|0080",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0081",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0003",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0005",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0007",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0009",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1115,20 +719,12 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0012",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86_64-x86_64-uefi-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0020",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0021",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
+            "x86_64-x86_64-uefi-msvc:Msvc|0018",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-uefi-msvc:Msvc|0023",
@@ -1143,31 +739,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0027",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0028",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
             "x86_64-x86_64-uefi-msvc:Msvc|0029",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0030",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0031",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0037",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0039",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1175,35 +747,23 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86_64-x86_64-uefi-msvc:Msvc|0044",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86_64-x86_64-uefi-msvc:Msvc|0045",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-uefi-msvc:Msvc|0046",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0047",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0057",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0058",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86_64-x86_64-uefi-msvc:Msvc|0053",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-uefi-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0064",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1215,47 +775,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0072",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0077",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0080",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0081",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0003",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0005",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0007",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0009",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86_64-x86_64-windows-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0012",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1263,95 +783,47 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-windows-msvc:Msvc|0020",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0021",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
+            "x86_64-x86_64-windows-msvc:Msvc|0018",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0023",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-windows-msvc:Msvc|0024",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
             "x86_64-x86_64-windows-msvc:Msvc|0025",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0026",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0027",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-windows-msvc:Msvc|0028",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86_64-x86_64-windows-msvc:Msvc|0026",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0029",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-windows-msvc:Msvc|0030",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0031",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0037",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0039",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86_64-x86_64-windows-msvc:Msvc|0042",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0043",
-            .{ .parse = true, .layout = true, .extra = true, .offset = false },
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0045",
-            .{ .parse = true, .layout = true, .extra = true, .offset = true },
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0046",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-windows-msvc:Msvc|0047",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0057",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0058",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "x86_64-x86_64-windows-msvc:Msvc|0053",
+            .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0064",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1360,26 +832,6 @@ const compErr = blk: {
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0066",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0072",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0077",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0080",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0081",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0088",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
     });

--- a/test/records/0001_test.c
+++ b/test/records/0001_test.c
@@ -12,28 +12,22 @@ typedef struct {
 } X;
 X var1;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var2;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var3;
 struct X_extra_size {

--- a/test/records/0002_test.c
+++ b/test/records/0002_test.c
@@ -18,28 +18,22 @@ typedef struct {
 #endif
 X var1;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var2;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var3;
 struct X_extra_size {
@@ -55,28 +49,22 @@ typedef struct {
 Y var5;
 #pragma pack()
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var6;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var7;
 struct Y_extra_size {

--- a/test/records/0003_test.c
+++ b/test/records/0003_test.c
@@ -18,28 +18,22 @@ typedef struct {
 #endif
 X var1;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var2;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var3;
 struct X_extra_size {
@@ -55,28 +49,22 @@ typedef struct {
 Y var5;
 #pragma pack()
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var6;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var7;
 struct Y_extra_size {

--- a/test/records/0004_test.c
+++ b/test/records/0004_test.c
@@ -14,28 +14,22 @@ typedef struct {
 } X;
 X var1;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var2;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var3;
 struct X_extra_size {
@@ -51,28 +45,22 @@ typedef struct {
 Y var5;
 #pragma pack()
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var6;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var7;
 struct Y_extra_size {

--- a/test/records/0005_test.c
+++ b/test/records/0005_test.c
@@ -12,28 +12,22 @@ typedef int Int __attribute__((aligned(8)));
 #endif
 Int var1;
 struct Int_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Int)];
-    char b;
-#else
     char a;
     Int b;
-#endif
 };
 struct Int_extra_alignment var2;
 #pragma pack(1)
 struct Int_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Int)];
+#else
     Int a;
+#endif
 };
 #pragma pack()
 struct Int_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Int_extra_packed)];
-    char b;
-#else
     char a;
     struct Int_extra_packed b;
-#endif
 };
 struct Int_extra_required_alignment var3;
 struct Int_extra_size {
@@ -47,28 +41,22 @@ typedef struct {
 } X;
 X var5;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var6;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var7;
 struct X_extra_size {
@@ -84,28 +72,22 @@ typedef struct {
 Y var9;
 #pragma pack()
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var10;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var11;
 struct Y_extra_size {

--- a/test/records/0006_test.c
+++ b/test/records/0006_test.c
@@ -12,28 +12,22 @@ typedef int Int __attribute__((aligned(8)));
 #endif
 Int var1;
 struct Int_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Int)];
-    char b;
-#else
     char a;
     Int b;
-#endif
 };
 struct Int_extra_alignment var2;
 #pragma pack(1)
 struct Int_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Int)];
+#else
     Int a;
+#endif
 };
 #pragma pack()
 struct Int_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Int_extra_packed)];
-    char b;
-#else
     char a;
     struct Int_extra_packed b;
-#endif
 };
 struct Int_extra_required_alignment var3;
 struct Int_extra_size {
@@ -48,28 +42,22 @@ typedef struct {
 } X;
 X var5;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var6;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var7;
 struct X_extra_size {

--- a/test/records/0007_test.c
+++ b/test/records/0007_test.c
@@ -12,28 +12,22 @@ typedef short a __attribute__((aligned(8)));
 #endif
 a var1;
 struct a_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(a)];
-    char b;
-#else
     char a;
     a b;
-#endif
 };
 struct a_extra_alignment var2;
 #pragma pack(1)
 struct a_extra_packed {
+#ifdef MSVC
+    char a[sizeof(a)];
+#else
     a a;
+#endif
 };
 #pragma pack()
 struct a_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct a_extra_packed)];
-    char b;
-#else
     char a;
     struct a_extra_packed b;
-#endif
 };
 struct a_extra_required_alignment var3;
 struct a_extra_size {
@@ -49,28 +43,22 @@ typedef struct {
 A var5;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var6;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var7;
 struct A_extra_size {
@@ -86,28 +74,22 @@ typedef short b __attribute__((aligned(4)));
 #endif
 b var9;
 struct b_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(b)];
-    char b;
-#else
     char a;
     b b;
-#endif
 };
 struct b_extra_alignment var10;
 #pragma pack(1)
 struct b_extra_packed {
+#ifdef MSVC
+    char a[sizeof(b)];
+#else
     b a;
+#endif
 };
 #pragma pack()
 struct b_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct b_extra_packed)];
-    char b;
-#else
     char a;
     struct b_extra_packed b;
-#endif
 };
 struct b_extra_required_alignment var11;
 struct b_extra_size {
@@ -123,28 +105,22 @@ typedef struct {
 B var13;
 #pragma pack()
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var14;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var15;
 struct B_extra_size {
@@ -160,28 +136,22 @@ typedef int c __attribute__((aligned(8)));
 #endif
 c var17;
 struct c_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(c)];
-    char b;
-#else
     char a;
     c b;
-#endif
 };
 struct c_extra_alignment var18;
 #pragma pack(1)
 struct c_extra_packed {
+#ifdef MSVC
+    char a[sizeof(c)];
+#else
     c a;
+#endif
 };
 #pragma pack()
 struct c_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct c_extra_packed)];
-    char b;
-#else
     char a;
     struct c_extra_packed b;
-#endif
 };
 struct c_extra_required_alignment var19;
 struct c_extra_size {
@@ -197,28 +167,22 @@ typedef struct {
 C var21;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var22;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var23;
 struct C_extra_size {
@@ -234,28 +198,22 @@ typedef long long d __attribute__((aligned(4)));
 #endif
 d var25;
 struct d_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(d)];
-    char b;
-#else
     char a;
     d b;
-#endif
 };
 struct d_extra_alignment var26;
 #pragma pack(1)
 struct d_extra_packed {
+#ifdef MSVC
+    char a[sizeof(d)];
+#else
     d a;
+#endif
 };
 #pragma pack()
 struct d_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct d_extra_packed)];
-    char b;
-#else
     char a;
     struct d_extra_packed b;
-#endif
 };
 struct d_extra_required_alignment var27;
 struct d_extra_size {
@@ -271,28 +229,22 @@ typedef struct {
 D var29;
 #pragma pack()
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var30;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var31;
 struct D_extra_size {
@@ -308,28 +260,22 @@ typedef int e __attribute__((aligned(2)));
 #endif
 e var33;
 struct e_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(e)];
-    char b;
-#else
     char a;
     e b;
-#endif
 };
 struct e_extra_alignment var34;
 #pragma pack(1)
 struct e_extra_packed {
+#ifdef MSVC
+    char a[sizeof(e)];
+#else
     e a;
+#endif
 };
 #pragma pack()
 struct e_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct e_extra_packed)];
-    char b;
-#else
     char a;
     struct e_extra_packed b;
-#endif
 };
 struct e_extra_required_alignment var35;
 struct e_extra_size {
@@ -345,28 +291,22 @@ typedef struct {
 E var37;
 #pragma pack()
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var38;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var39;
 struct E_extra_size {
@@ -382,28 +322,22 @@ typedef long long f __attribute__((aligned(2)));
 #endif
 f var41;
 struct f_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(f)];
-    char b;
-#else
     char a;
     f b;
-#endif
 };
 struct f_extra_alignment var42;
 #pragma pack(1)
 struct f_extra_packed {
+#ifdef MSVC
+    char a[sizeof(f)];
+#else
     f a;
+#endif
 };
 #pragma pack()
 struct f_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct f_extra_packed)];
-    char b;
-#else
     char a;
     struct f_extra_packed b;
-#endif
 };
 struct f_extra_required_alignment var43;
 struct f_extra_size {
@@ -419,28 +353,22 @@ typedef struct {
 F var45;
 #pragma pack()
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var46;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var47;
 struct F_extra_size {

--- a/test/records/0008_test.c
+++ b/test/records/0008_test.c
@@ -8,28 +8,22 @@
 typedef int unnamed_type_1[3];
 unnamed_type_1 var2;
 struct unnamed_type_1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_1)];
-    char b;
-#else
     char a;
     unnamed_type_1 b;
-#endif
 };
 struct unnamed_type_1_extra_alignment var3;
 #pragma pack(1)
 struct unnamed_type_1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_1)];
+#else
     unnamed_type_1 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_1_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_1_extra_packed b;
-#endif
 };
 struct unnamed_type_1_extra_required_alignment var4;
 struct unnamed_type_1_extra_size {
@@ -45,28 +39,22 @@ typedef unnamed_type_1 Int __attribute__((aligned(8)));
 #endif
 Int var6;
 struct Int_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Int)];
-    char b;
-#else
     char a;
     Int b;
-#endif
 };
 struct Int_extra_alignment var7;
 #pragma pack(1)
 struct Int_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Int)];
+#else
     Int a;
+#endif
 };
 #pragma pack()
 struct Int_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Int_extra_packed)];
-    char b;
-#else
     char a;
     struct Int_extra_packed b;
-#endif
 };
 struct Int_extra_required_alignment var8;
 struct Int_extra_size {
@@ -78,28 +66,22 @@ struct Int_extra_size var9;
 typedef Int unnamed_type_10[3];
 unnamed_type_10 var11;
 struct unnamed_type_10_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_10)];
-    char b;
-#else
     char a;
     unnamed_type_10 b;
-#endif
 };
 struct unnamed_type_10_extra_alignment var12;
 #pragma pack(1)
 struct unnamed_type_10_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_10)];
+#else
     unnamed_type_10 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_10_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_10_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_10_extra_packed b;
-#endif
 };
 struct unnamed_type_10_extra_required_alignment var13;
 struct unnamed_type_10_extra_size {
@@ -111,28 +93,22 @@ struct unnamed_type_10_extra_size var14;
 typedef unnamed_type_10 Y;
 Y var15;
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var16;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var17;
 struct Y_extra_size {
@@ -147,28 +123,22 @@ typedef struct {
 } Z;
 Z var19;
 struct Z_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Z)];
-    char b;
-#else
     char a;
     Z b;
-#endif
 };
 struct Z_extra_alignment var20;
 #pragma pack(1)
 struct Z_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Z)];
+#else
     Z a;
+#endif
 };
 #pragma pack()
 struct Z_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Z_extra_packed)];
-    char b;
-#else
     char a;
     struct Z_extra_packed b;
-#endif
 };
 struct Z_extra_required_alignment var21;
 struct Z_extra_size {

--- a/test/records/0009_test.c
+++ b/test/records/0009_test.c
@@ -16,28 +16,22 @@ typedef struct {
 A var1;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -57,28 +51,22 @@ typedef struct {
 B var5;
 #pragma pack()
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -98,28 +86,22 @@ typedef struct {
 C var9;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -139,28 +121,22 @@ typedef struct {
 D var13;
 #pragma pack()
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {
@@ -180,28 +156,22 @@ typedef struct {
 E var17;
 #pragma pack()
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var18;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var19;
 struct E_extra_size {
@@ -221,28 +191,22 @@ typedef struct {
 F var21;
 #pragma pack()
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var22;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var23;
 struct F_extra_size {

--- a/test/records/0010_test.c
+++ b/test/records/0010_test.c
@@ -8,28 +8,22 @@
 typedef int unnamed_type_1[3];
 unnamed_type_1 var2;
 struct unnamed_type_1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_1)];
-    char b;
-#else
     char a;
     unnamed_type_1 b;
-#endif
 };
 struct unnamed_type_1_extra_alignment var3;
 #pragma pack(1)
 struct unnamed_type_1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_1)];
+#else
     unnamed_type_1 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_1_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_1_extra_packed b;
-#endif
 };
 struct unnamed_type_1_extra_required_alignment var4;
 struct unnamed_type_1_extra_size {
@@ -45,28 +39,22 @@ typedef unnamed_type_1 Int __attribute__((aligned(8)));
 #endif
 Int var6;
 struct Int_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Int)];
-    char b;
-#else
     char a;
     Int b;
-#endif
 };
 struct Int_extra_alignment var7;
 #pragma pack(1)
 struct Int_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Int)];
+#else
     Int a;
+#endif
 };
 #pragma pack()
 struct Int_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Int_extra_packed)];
-    char b;
-#else
     char a;
     struct Int_extra_packed b;
-#endif
 };
 struct Int_extra_required_alignment var8;
 struct Int_extra_size {
@@ -78,28 +66,22 @@ struct Int_extra_size var9;
 typedef Int unnamed_type_10[3];
 unnamed_type_10 var11;
 struct unnamed_type_10_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_10)];
-    char b;
-#else
     char a;
     unnamed_type_10 b;
-#endif
 };
 struct unnamed_type_10_extra_alignment var12;
 #pragma pack(1)
 struct unnamed_type_10_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_10)];
+#else
     unnamed_type_10 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_10_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_10_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_10_extra_packed b;
-#endif
 };
 struct unnamed_type_10_extra_required_alignment var13;
 struct unnamed_type_10_extra_size {
@@ -114,28 +96,22 @@ typedef struct {
 } Y;
 Y var15;
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var16;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var17;
 struct Y_extra_size {

--- a/test/records/0011_test.c
+++ b/test/records/0011_test.c
@@ -12,28 +12,22 @@ typedef int I1 __attribute__((aligned(8)));
 #endif
 I1 var1;
 struct I1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(I1)];
-    char b;
-#else
     char a;
     I1 b;
-#endif
 };
 struct I1_extra_alignment var2;
 #pragma pack(1)
 struct I1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(I1)];
+#else
     I1 a;
+#endif
 };
 #pragma pack()
 struct I1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct I1_extra_packed)];
-    char b;
-#else
     char a;
     struct I1_extra_packed b;
-#endif
 };
 struct I1_extra_required_alignment var3;
 struct I1_extra_size {
@@ -49,28 +43,22 @@ typedef I1 I2 __attribute__((aligned(1)));
 #endif
 I2 var5;
 struct I2_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(I2)];
-    char b;
-#else
     char a;
     I2 b;
-#endif
 };
 struct I2_extra_alignment var6;
 #pragma pack(1)
 struct I2_extra_packed {
+#ifdef MSVC
+    char a[sizeof(I2)];
+#else
     I2 a;
+#endif
 };
 #pragma pack()
 struct I2_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct I2_extra_packed)];
-    char b;
-#else
     char a;
     struct I2_extra_packed b;
-#endif
 };
 struct I2_extra_required_alignment var7;
 struct I2_extra_size {
@@ -84,28 +72,22 @@ typedef struct {
 } X;
 X var9;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var10;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var11;
 struct X_extra_size {

--- a/test/records/0012_test.c
+++ b/test/records/0012_test.c
@@ -18,28 +18,22 @@ typedef struct {
 #endif
 X var1;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var2;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var3;
 struct X_extra_size {
@@ -55,28 +49,22 @@ typedef struct {
 Y var5;
 #pragma pack()
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var6;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var7;
 struct Y_extra_size {

--- a/test/records/0013_test.c
+++ b/test/records/0013_test.c
@@ -8,28 +8,22 @@
 typedef char A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -41,28 +35,22 @@ struct A_extra_size var4;
 typedef unsigned char B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -74,28 +62,22 @@ struct B_extra_size var8;
 typedef signed char C;
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -107,28 +89,22 @@ struct C_extra_size var12;
 typedef unsigned short D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {
@@ -140,28 +116,22 @@ struct D_extra_size var16;
 typedef short E;
 E var17;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var18;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var19;
 struct E_extra_size {
@@ -173,28 +143,22 @@ struct E_extra_size var20;
 typedef unsigned int F;
 F var21;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var22;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var23;
 struct F_extra_size {
@@ -206,28 +170,22 @@ struct F_extra_size var24;
 typedef int G;
 G var25;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var26;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var27;
 struct G_extra_size {
@@ -239,28 +197,22 @@ struct G_extra_size var28;
 typedef unsigned long H;
 H var29;
 struct H_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(H)];
-    char b;
-#else
     char a;
     H b;
-#endif
 };
 struct H_extra_alignment var30;
 #pragma pack(1)
 struct H_extra_packed {
+#ifdef MSVC
+    char a[sizeof(H)];
+#else
     H a;
+#endif
 };
 #pragma pack()
 struct H_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct H_extra_packed)];
-    char b;
-#else
     char a;
     struct H_extra_packed b;
-#endif
 };
 struct H_extra_required_alignment var31;
 struct H_extra_size {
@@ -272,28 +224,22 @@ struct H_extra_size var32;
 typedef long I;
 I var33;
 struct I_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(I)];
-    char b;
-#else
     char a;
     I b;
-#endif
 };
 struct I_extra_alignment var34;
 #pragma pack(1)
 struct I_extra_packed {
+#ifdef MSVC
+    char a[sizeof(I)];
+#else
     I a;
+#endif
 };
 #pragma pack()
 struct I_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct I_extra_packed)];
-    char b;
-#else
     char a;
     struct I_extra_packed b;
-#endif
 };
 struct I_extra_required_alignment var35;
 struct I_extra_size {
@@ -305,28 +251,22 @@ struct I_extra_size var36;
 typedef unsigned long long J;
 J var37;
 struct J_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(J)];
-    char b;
-#else
     char a;
     J b;
-#endif
 };
 struct J_extra_alignment var38;
 #pragma pack(1)
 struct J_extra_packed {
+#ifdef MSVC
+    char a[sizeof(J)];
+#else
     J a;
+#endif
 };
 #pragma pack()
 struct J_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct J_extra_packed)];
-    char b;
-#else
     char a;
     struct J_extra_packed b;
-#endif
 };
 struct J_extra_required_alignment var39;
 struct J_extra_size {
@@ -338,28 +278,22 @@ struct J_extra_size var40;
 typedef long long K;
 K var41;
 struct K_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(K)];
-    char b;
-#else
     char a;
     K b;
-#endif
 };
 struct K_extra_alignment var42;
 #pragma pack(1)
 struct K_extra_packed {
+#ifdef MSVC
+    char a[sizeof(K)];
+#else
     K a;
+#endif
 };
 #pragma pack()
 struct K_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct K_extra_packed)];
-    char b;
-#else
     char a;
     struct K_extra_packed b;
-#endif
 };
 struct K_extra_required_alignment var43;
 struct K_extra_size {
@@ -371,28 +305,22 @@ struct K_extra_size var44;
 typedef void* L;
 L var45;
 struct L_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(L)];
-    char b;
-#else
     char a;
     L b;
-#endif
 };
 struct L_extra_alignment var46;
 #pragma pack(1)
 struct L_extra_packed {
+#ifdef MSVC
+    char a[sizeof(L)];
+#else
     L a;
+#endif
 };
 #pragma pack()
 struct L_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct L_extra_packed)];
-    char b;
-#else
     char a;
     struct L_extra_packed b;
-#endif
 };
 struct L_extra_required_alignment var47;
 struct L_extra_size {
@@ -404,28 +332,22 @@ struct L_extra_size var48;
 typedef float M;
 M var49;
 struct M_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(M)];
-    char b;
-#else
     char a;
     M b;
-#endif
 };
 struct M_extra_alignment var50;
 #pragma pack(1)
 struct M_extra_packed {
+#ifdef MSVC
+    char a[sizeof(M)];
+#else
     M a;
+#endif
 };
 #pragma pack()
 struct M_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct M_extra_packed)];
-    char b;
-#else
     char a;
     struct M_extra_packed b;
-#endif
 };
 struct M_extra_required_alignment var51;
 struct M_extra_size {
@@ -437,28 +359,22 @@ struct M_extra_size var52;
 typedef double N;
 N var53;
 struct N_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(N)];
-    char b;
-#else
     char a;
     N b;
-#endif
 };
 struct N_extra_alignment var54;
 #pragma pack(1)
 struct N_extra_packed {
+#ifdef MSVC
+    char a[sizeof(N)];
+#else
     N a;
+#endif
 };
 #pragma pack()
 struct N_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct N_extra_packed)];
-    char b;
-#else
     char a;
     struct N_extra_packed b;
-#endif
 };
 struct N_extra_required_alignment var55;
 struct N_extra_size {

--- a/test/records/0014_test.c
+++ b/test/records/0014_test.c
@@ -12,28 +12,22 @@ typedef int A __attribute__((aligned(1)));
 #endif
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef int B __attribute__((aligned(2)));
 #endif
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -86,28 +74,22 @@ typedef int C __attribute__((aligned(4)));
 #endif
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -123,28 +105,22 @@ typedef int D __attribute__((aligned(8)));
 #endif
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {
@@ -160,28 +136,22 @@ typedef int E __attribute__((aligned(16)));
 #endif
 E var17;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var18;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var19;
 struct E_extra_size {
@@ -197,28 +167,22 @@ typedef int F __attribute__((aligned(32)));
 #endif
 F var21;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var22;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var23;
 struct F_extra_size {
@@ -234,28 +198,22 @@ typedef int G __attribute__((aligned(64)));
 #endif
 G var25;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var26;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var27;
 struct G_extra_size {
@@ -271,28 +229,22 @@ typedef int H __attribute__((aligned(128)));
 #endif
 H var29;
 struct H_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(H)];
-    char b;
-#else
     char a;
     H b;
-#endif
 };
 struct H_extra_alignment var30;
 #pragma pack(1)
 struct H_extra_packed {
+#ifdef MSVC
+    char a[sizeof(H)];
+#else
     H a;
+#endif
 };
 #pragma pack()
 struct H_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct H_extra_packed)];
-    char b;
-#else
     char a;
     struct H_extra_packed b;
-#endif
 };
 struct H_extra_required_alignment var31;
 struct H_extra_size {
@@ -308,28 +260,22 @@ typedef A AA __attribute__((aligned(1)));
 #endif
 AA var33;
 struct AA_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AA)];
-    char b;
-#else
     char a;
     AA b;
-#endif
 };
 struct AA_extra_alignment var34;
 #pragma pack(1)
 struct AA_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AA)];
+#else
     AA a;
+#endif
 };
 #pragma pack()
 struct AA_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AA_extra_packed)];
-    char b;
-#else
     char a;
     struct AA_extra_packed b;
-#endif
 };
 struct AA_extra_required_alignment var35;
 struct AA_extra_size {
@@ -345,28 +291,22 @@ typedef A AB __attribute__((aligned(2)));
 #endif
 AB var37;
 struct AB_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AB)];
-    char b;
-#else
     char a;
     AB b;
-#endif
 };
 struct AB_extra_alignment var38;
 #pragma pack(1)
 struct AB_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AB)];
+#else
     AB a;
+#endif
 };
 #pragma pack()
 struct AB_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AB_extra_packed)];
-    char b;
-#else
     char a;
     struct AB_extra_packed b;
-#endif
 };
 struct AB_extra_required_alignment var39;
 struct AB_extra_size {
@@ -382,28 +322,22 @@ typedef A AC __attribute__((aligned(4)));
 #endif
 AC var41;
 struct AC_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AC)];
-    char b;
-#else
     char a;
     AC b;
-#endif
 };
 struct AC_extra_alignment var42;
 #pragma pack(1)
 struct AC_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AC)];
+#else
     AC a;
+#endif
 };
 #pragma pack()
 struct AC_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AC_extra_packed)];
-    char b;
-#else
     char a;
     struct AC_extra_packed b;
-#endif
 };
 struct AC_extra_required_alignment var43;
 struct AC_extra_size {
@@ -419,28 +353,22 @@ typedef A AD __attribute__((aligned(8)));
 #endif
 AD var45;
 struct AD_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AD)];
-    char b;
-#else
     char a;
     AD b;
-#endif
 };
 struct AD_extra_alignment var46;
 #pragma pack(1)
 struct AD_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AD)];
+#else
     AD a;
+#endif
 };
 #pragma pack()
 struct AD_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AD_extra_packed)];
-    char b;
-#else
     char a;
     struct AD_extra_packed b;
-#endif
 };
 struct AD_extra_required_alignment var47;
 struct AD_extra_size {
@@ -456,28 +384,22 @@ typedef A AE __attribute__((aligned(16)));
 #endif
 AE var49;
 struct AE_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AE)];
-    char b;
-#else
     char a;
     AE b;
-#endif
 };
 struct AE_extra_alignment var50;
 #pragma pack(1)
 struct AE_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AE)];
+#else
     AE a;
+#endif
 };
 #pragma pack()
 struct AE_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AE_extra_packed)];
-    char b;
-#else
     char a;
     struct AE_extra_packed b;
-#endif
 };
 struct AE_extra_required_alignment var51;
 struct AE_extra_size {
@@ -493,28 +415,22 @@ typedef A AF __attribute__((aligned(32)));
 #endif
 AF var53;
 struct AF_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AF)];
-    char b;
-#else
     char a;
     AF b;
-#endif
 };
 struct AF_extra_alignment var54;
 #pragma pack(1)
 struct AF_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AF)];
+#else
     AF a;
+#endif
 };
 #pragma pack()
 struct AF_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AF_extra_packed)];
-    char b;
-#else
     char a;
     struct AF_extra_packed b;
-#endif
 };
 struct AF_extra_required_alignment var55;
 struct AF_extra_size {
@@ -530,28 +446,22 @@ typedef A AG __attribute__((aligned(64)));
 #endif
 AG var57;
 struct AG_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AG)];
-    char b;
-#else
     char a;
     AG b;
-#endif
 };
 struct AG_extra_alignment var58;
 #pragma pack(1)
 struct AG_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AG)];
+#else
     AG a;
+#endif
 };
 #pragma pack()
 struct AG_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AG_extra_packed)];
-    char b;
-#else
     char a;
     struct AG_extra_packed b;
-#endif
 };
 struct AG_extra_required_alignment var59;
 struct AG_extra_size {
@@ -567,28 +477,22 @@ typedef A AH __attribute__((aligned(128)));
 #endif
 AH var61;
 struct AH_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AH)];
-    char b;
-#else
     char a;
     AH b;
-#endif
 };
 struct AH_extra_alignment var62;
 #pragma pack(1)
 struct AH_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AH)];
+#else
     AH a;
+#endif
 };
 #pragma pack()
 struct AH_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AH_extra_packed)];
-    char b;
-#else
     char a;
     struct AH_extra_packed b;
-#endif
 };
 struct AH_extra_required_alignment var63;
 struct AH_extra_size {
@@ -604,28 +508,22 @@ typedef B BA __attribute__((aligned(1)));
 #endif
 BA var65;
 struct BA_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BA)];
-    char b;
-#else
     char a;
     BA b;
-#endif
 };
 struct BA_extra_alignment var66;
 #pragma pack(1)
 struct BA_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BA)];
+#else
     BA a;
+#endif
 };
 #pragma pack()
 struct BA_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BA_extra_packed)];
-    char b;
-#else
     char a;
     struct BA_extra_packed b;
-#endif
 };
 struct BA_extra_required_alignment var67;
 struct BA_extra_size {
@@ -641,28 +539,22 @@ typedef B BB __attribute__((aligned(2)));
 #endif
 BB var69;
 struct BB_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BB)];
-    char b;
-#else
     char a;
     BB b;
-#endif
 };
 struct BB_extra_alignment var70;
 #pragma pack(1)
 struct BB_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BB)];
+#else
     BB a;
+#endif
 };
 #pragma pack()
 struct BB_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BB_extra_packed)];
-    char b;
-#else
     char a;
     struct BB_extra_packed b;
-#endif
 };
 struct BB_extra_required_alignment var71;
 struct BB_extra_size {
@@ -678,28 +570,22 @@ typedef B BC __attribute__((aligned(4)));
 #endif
 BC var73;
 struct BC_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BC)];
-    char b;
-#else
     char a;
     BC b;
-#endif
 };
 struct BC_extra_alignment var74;
 #pragma pack(1)
 struct BC_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BC)];
+#else
     BC a;
+#endif
 };
 #pragma pack()
 struct BC_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BC_extra_packed)];
-    char b;
-#else
     char a;
     struct BC_extra_packed b;
-#endif
 };
 struct BC_extra_required_alignment var75;
 struct BC_extra_size {
@@ -715,28 +601,22 @@ typedef B BD __attribute__((aligned(8)));
 #endif
 BD var77;
 struct BD_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BD)];
-    char b;
-#else
     char a;
     BD b;
-#endif
 };
 struct BD_extra_alignment var78;
 #pragma pack(1)
 struct BD_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BD)];
+#else
     BD a;
+#endif
 };
 #pragma pack()
 struct BD_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BD_extra_packed)];
-    char b;
-#else
     char a;
     struct BD_extra_packed b;
-#endif
 };
 struct BD_extra_required_alignment var79;
 struct BD_extra_size {
@@ -752,28 +632,22 @@ typedef B BE __attribute__((aligned(16)));
 #endif
 BE var81;
 struct BE_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BE)];
-    char b;
-#else
     char a;
     BE b;
-#endif
 };
 struct BE_extra_alignment var82;
 #pragma pack(1)
 struct BE_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BE)];
+#else
     BE a;
+#endif
 };
 #pragma pack()
 struct BE_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BE_extra_packed)];
-    char b;
-#else
     char a;
     struct BE_extra_packed b;
-#endif
 };
 struct BE_extra_required_alignment var83;
 struct BE_extra_size {
@@ -789,28 +663,22 @@ typedef B BF __attribute__((aligned(32)));
 #endif
 BF var85;
 struct BF_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BF)];
-    char b;
-#else
     char a;
     BF b;
-#endif
 };
 struct BF_extra_alignment var86;
 #pragma pack(1)
 struct BF_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BF)];
+#else
     BF a;
+#endif
 };
 #pragma pack()
 struct BF_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BF_extra_packed)];
-    char b;
-#else
     char a;
     struct BF_extra_packed b;
-#endif
 };
 struct BF_extra_required_alignment var87;
 struct BF_extra_size {
@@ -826,28 +694,22 @@ typedef B BG __attribute__((aligned(64)));
 #endif
 BG var89;
 struct BG_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BG)];
-    char b;
-#else
     char a;
     BG b;
-#endif
 };
 struct BG_extra_alignment var90;
 #pragma pack(1)
 struct BG_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BG)];
+#else
     BG a;
+#endif
 };
 #pragma pack()
 struct BG_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BG_extra_packed)];
-    char b;
-#else
     char a;
     struct BG_extra_packed b;
-#endif
 };
 struct BG_extra_required_alignment var91;
 struct BG_extra_size {
@@ -863,28 +725,22 @@ typedef B BH __attribute__((aligned(128)));
 #endif
 BH var93;
 struct BH_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BH)];
-    char b;
-#else
     char a;
     BH b;
-#endif
 };
 struct BH_extra_alignment var94;
 #pragma pack(1)
 struct BH_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BH)];
+#else
     BH a;
+#endif
 };
 #pragma pack()
 struct BH_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BH_extra_packed)];
-    char b;
-#else
     char a;
     struct BH_extra_packed b;
-#endif
 };
 struct BH_extra_required_alignment var95;
 struct BH_extra_size {
@@ -900,28 +756,22 @@ typedef D DA __attribute__((aligned(1)));
 #endif
 DA var97;
 struct DA_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(DA)];
-    char b;
-#else
     char a;
     DA b;
-#endif
 };
 struct DA_extra_alignment var98;
 #pragma pack(1)
 struct DA_extra_packed {
+#ifdef MSVC
+    char a[sizeof(DA)];
+#else
     DA a;
+#endif
 };
 #pragma pack()
 struct DA_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct DA_extra_packed)];
-    char b;
-#else
     char a;
     struct DA_extra_packed b;
-#endif
 };
 struct DA_extra_required_alignment var99;
 struct DA_extra_size {
@@ -937,28 +787,22 @@ typedef D DB __attribute__((aligned(2)));
 #endif
 DB var101;
 struct DB_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(DB)];
-    char b;
-#else
     char a;
     DB b;
-#endif
 };
 struct DB_extra_alignment var102;
 #pragma pack(1)
 struct DB_extra_packed {
+#ifdef MSVC
+    char a[sizeof(DB)];
+#else
     DB a;
+#endif
 };
 #pragma pack()
 struct DB_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct DB_extra_packed)];
-    char b;
-#else
     char a;
     struct DB_extra_packed b;
-#endif
 };
 struct DB_extra_required_alignment var103;
 struct DB_extra_size {
@@ -974,28 +818,22 @@ typedef D DC __attribute__((aligned(4)));
 #endif
 DC var105;
 struct DC_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(DC)];
-    char b;
-#else
     char a;
     DC b;
-#endif
 };
 struct DC_extra_alignment var106;
 #pragma pack(1)
 struct DC_extra_packed {
+#ifdef MSVC
+    char a[sizeof(DC)];
+#else
     DC a;
+#endif
 };
 #pragma pack()
 struct DC_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct DC_extra_packed)];
-    char b;
-#else
     char a;
     struct DC_extra_packed b;
-#endif
 };
 struct DC_extra_required_alignment var107;
 struct DC_extra_size {
@@ -1011,28 +849,22 @@ typedef D DD __attribute__((aligned(8)));
 #endif
 DD var109;
 struct DD_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(DD)];
-    char b;
-#else
     char a;
     DD b;
-#endif
 };
 struct DD_extra_alignment var110;
 #pragma pack(1)
 struct DD_extra_packed {
+#ifdef MSVC
+    char a[sizeof(DD)];
+#else
     DD a;
+#endif
 };
 #pragma pack()
 struct DD_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct DD_extra_packed)];
-    char b;
-#else
     char a;
     struct DD_extra_packed b;
-#endif
 };
 struct DD_extra_required_alignment var111;
 struct DD_extra_size {
@@ -1048,28 +880,22 @@ typedef D DE __attribute__((aligned(16)));
 #endif
 DE var113;
 struct DE_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(DE)];
-    char b;
-#else
     char a;
     DE b;
-#endif
 };
 struct DE_extra_alignment var114;
 #pragma pack(1)
 struct DE_extra_packed {
+#ifdef MSVC
+    char a[sizeof(DE)];
+#else
     DE a;
+#endif
 };
 #pragma pack()
 struct DE_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct DE_extra_packed)];
-    char b;
-#else
     char a;
     struct DE_extra_packed b;
-#endif
 };
 struct DE_extra_required_alignment var115;
 struct DE_extra_size {
@@ -1085,28 +911,22 @@ typedef D DF __attribute__((aligned(32)));
 #endif
 DF var117;
 struct DF_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(DF)];
-    char b;
-#else
     char a;
     DF b;
-#endif
 };
 struct DF_extra_alignment var118;
 #pragma pack(1)
 struct DF_extra_packed {
+#ifdef MSVC
+    char a[sizeof(DF)];
+#else
     DF a;
+#endif
 };
 #pragma pack()
 struct DF_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct DF_extra_packed)];
-    char b;
-#else
     char a;
     struct DF_extra_packed b;
-#endif
 };
 struct DF_extra_required_alignment var119;
 struct DF_extra_size {
@@ -1122,28 +942,22 @@ typedef D DG __attribute__((aligned(64)));
 #endif
 DG var121;
 struct DG_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(DG)];
-    char b;
-#else
     char a;
     DG b;
-#endif
 };
 struct DG_extra_alignment var122;
 #pragma pack(1)
 struct DG_extra_packed {
+#ifdef MSVC
+    char a[sizeof(DG)];
+#else
     DG a;
+#endif
 };
 #pragma pack()
 struct DG_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct DG_extra_packed)];
-    char b;
-#else
     char a;
     struct DG_extra_packed b;
-#endif
 };
 struct DG_extra_required_alignment var123;
 struct DG_extra_size {
@@ -1159,28 +973,22 @@ typedef D DH __attribute__((aligned(128)));
 #endif
 DH var125;
 struct DH_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(DH)];
-    char b;
-#else
     char a;
     DH b;
-#endif
 };
 struct DH_extra_alignment var126;
 #pragma pack(1)
 struct DH_extra_packed {
+#ifdef MSVC
+    char a[sizeof(DH)];
+#else
     DH a;
+#endif
 };
 #pragma pack()
 struct DH_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct DH_extra_packed)];
-    char b;
-#else
     char a;
     struct DH_extra_packed b;
-#endif
 };
 struct DH_extra_required_alignment var127;
 struct DH_extra_size {

--- a/test/records/0015_test.c
+++ b/test/records/0015_test.c
@@ -11,28 +11,22 @@ typedef union {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -47,28 +41,22 @@ typedef union {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {

--- a/test/records/0016_test.c
+++ b/test/records/0016_test.c
@@ -22,28 +22,22 @@ typedef enum {
 A var4;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var5;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var6;
 struct A_extra_size {

--- a/test/records/0017_test.c
+++ b/test/records/0017_test.c
@@ -12,28 +12,22 @@ typedef char A __attribute__((aligned(4)));
 #endif
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -45,28 +39,22 @@ struct A_extra_size var4;
 typedef A B[3];
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {

--- a/test/records/0018_test.c
+++ b/test/records/0018_test.c
@@ -8,28 +8,22 @@
 typedef char A[3];
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -45,28 +39,22 @@ typedef char unnamed_type_5 __attribute__((aligned(4)));
 #endif
 unnamed_type_5 var6;
 struct unnamed_type_5_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_5)];
-    char b;
-#else
     char a;
     unnamed_type_5 b;
-#endif
 };
 struct unnamed_type_5_extra_alignment var7;
 #pragma pack(1)
 struct unnamed_type_5_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_5)];
+#else
     unnamed_type_5 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_5_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_5_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_5_extra_packed b;
-#endif
 };
 struct unnamed_type_5_extra_required_alignment var8;
 struct unnamed_type_5_extra_size {
@@ -78,28 +66,22 @@ struct unnamed_type_5_extra_size var9;
 typedef unnamed_type_5 B[3];
 B var10;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var11;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var12;
 struct B_extra_size {
@@ -115,28 +97,22 @@ typedef char unnamed_type_15 __attribute__((aligned(4)));
 #endif
 unnamed_type_15 var16;
 struct unnamed_type_15_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_15)];
-    char b;
-#else
     char a;
     unnamed_type_15 b;
-#endif
 };
 struct unnamed_type_15_extra_alignment var17;
 #pragma pack(1)
 struct unnamed_type_15_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_15)];
+#else
     unnamed_type_15 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_15_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_15_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_15_extra_packed b;
-#endif
 };
 struct unnamed_type_15_extra_required_alignment var18;
 struct unnamed_type_15_extra_size {
@@ -148,28 +124,22 @@ struct unnamed_type_15_extra_size var19;
 typedef unnamed_type_15 unnamed_type_14[3];
 unnamed_type_14 var20;
 struct unnamed_type_14_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_14)];
-    char b;
-#else
     char a;
     unnamed_type_14 b;
-#endif
 };
 struct unnamed_type_14_extra_alignment var21;
 #pragma pack(1)
 struct unnamed_type_14_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_14)];
+#else
     unnamed_type_14 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_14_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_14_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_14_extra_packed b;
-#endif
 };
 struct unnamed_type_14_extra_required_alignment var22;
 struct unnamed_type_14_extra_size {
@@ -181,28 +151,22 @@ struct unnamed_type_14_extra_size var23;
 typedef unnamed_type_14 C[3];
 C var24;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var25;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var26;
 struct C_extra_size {
@@ -214,28 +178,22 @@ struct C_extra_size var27;
 typedef short D[3];
 D var28;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var29;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var30;
 struct D_extra_size {
@@ -251,28 +209,22 @@ typedef short unnamed_type_32 __attribute__((aligned(4)));
 #endif
 unnamed_type_32 var33;
 struct unnamed_type_32_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_32)];
-    char b;
-#else
     char a;
     unnamed_type_32 b;
-#endif
 };
 struct unnamed_type_32_extra_alignment var34;
 #pragma pack(1)
 struct unnamed_type_32_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_32)];
+#else
     unnamed_type_32 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_32_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_32_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_32_extra_packed b;
-#endif
 };
 struct unnamed_type_32_extra_required_alignment var35;
 struct unnamed_type_32_extra_size {
@@ -284,28 +236,22 @@ struct unnamed_type_32_extra_size var36;
 typedef unnamed_type_32 E[3];
 E var37;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var38;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var39;
 struct E_extra_size {
@@ -321,28 +267,22 @@ typedef short unnamed_type_42 __attribute__((aligned(4)));
 #endif
 unnamed_type_42 var43;
 struct unnamed_type_42_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_42)];
-    char b;
-#else
     char a;
     unnamed_type_42 b;
-#endif
 };
 struct unnamed_type_42_extra_alignment var44;
 #pragma pack(1)
 struct unnamed_type_42_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_42)];
+#else
     unnamed_type_42 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_42_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_42_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_42_extra_packed b;
-#endif
 };
 struct unnamed_type_42_extra_required_alignment var45;
 struct unnamed_type_42_extra_size {
@@ -354,28 +294,22 @@ struct unnamed_type_42_extra_size var46;
 typedef unnamed_type_42 unnamed_type_41[3];
 unnamed_type_41 var47;
 struct unnamed_type_41_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_41)];
-    char b;
-#else
     char a;
     unnamed_type_41 b;
-#endif
 };
 struct unnamed_type_41_extra_alignment var48;
 #pragma pack(1)
 struct unnamed_type_41_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_41)];
+#else
     unnamed_type_41 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_41_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_41_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_41_extra_packed b;
-#endif
 };
 struct unnamed_type_41_extra_required_alignment var49;
 struct unnamed_type_41_extra_size {
@@ -387,28 +321,22 @@ struct unnamed_type_41_extra_size var50;
 typedef unnamed_type_41 F[3];
 F var51;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var52;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var53;
 struct F_extra_size {
@@ -420,28 +348,22 @@ struct F_extra_size var54;
 typedef long long G[3];
 G var55;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var56;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var57;
 struct G_extra_size {
@@ -457,28 +379,22 @@ typedef long long unnamed_type_59 __attribute__((aligned(128)));
 #endif
 unnamed_type_59 var60;
 struct unnamed_type_59_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_59)];
-    char b;
-#else
     char a;
     unnamed_type_59 b;
-#endif
 };
 struct unnamed_type_59_extra_alignment var61;
 #pragma pack(1)
 struct unnamed_type_59_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_59)];
+#else
     unnamed_type_59 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_59_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_59_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_59_extra_packed b;
-#endif
 };
 struct unnamed_type_59_extra_required_alignment var62;
 struct unnamed_type_59_extra_size {
@@ -490,28 +406,22 @@ struct unnamed_type_59_extra_size var63;
 typedef unnamed_type_59 H[3];
 H var64;
 struct H_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(H)];
-    char b;
-#else
     char a;
     H b;
-#endif
 };
 struct H_extra_alignment var65;
 #pragma pack(1)
 struct H_extra_packed {
+#ifdef MSVC
+    char a[sizeof(H)];
+#else
     H a;
+#endif
 };
 #pragma pack()
 struct H_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct H_extra_packed)];
-    char b;
-#else
     char a;
     struct H_extra_packed b;
-#endif
 };
 struct H_extra_required_alignment var66;
 struct H_extra_size {
@@ -527,28 +437,22 @@ typedef long long unnamed_type_69 __attribute__((aligned(128)));
 #endif
 unnamed_type_69 var70;
 struct unnamed_type_69_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_69)];
-    char b;
-#else
     char a;
     unnamed_type_69 b;
-#endif
 };
 struct unnamed_type_69_extra_alignment var71;
 #pragma pack(1)
 struct unnamed_type_69_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_69)];
+#else
     unnamed_type_69 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_69_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_69_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_69_extra_packed b;
-#endif
 };
 struct unnamed_type_69_extra_required_alignment var72;
 struct unnamed_type_69_extra_size {
@@ -560,28 +464,22 @@ struct unnamed_type_69_extra_size var73;
 typedef unnamed_type_69 unnamed_type_68[3];
 unnamed_type_68 var74;
 struct unnamed_type_68_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_68)];
-    char b;
-#else
     char a;
     unnamed_type_68 b;
-#endif
 };
 struct unnamed_type_68_extra_alignment var75;
 #pragma pack(1)
 struct unnamed_type_68_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_68)];
+#else
     unnamed_type_68 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_68_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_68_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_68_extra_packed b;
-#endif
 };
 struct unnamed_type_68_extra_required_alignment var76;
 struct unnamed_type_68_extra_size {
@@ -593,28 +491,22 @@ struct unnamed_type_68_extra_size var77;
 typedef unnamed_type_68 I[3];
 I var78;
 struct I_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(I)];
-    char b;
-#else
     char a;
     I b;
-#endif
 };
 struct I_extra_alignment var79;
 #pragma pack(1)
 struct I_extra_packed {
+#ifdef MSVC
+    char a[sizeof(I)];
+#else
     I a;
+#endif
 };
 #pragma pack()
 struct I_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct I_extra_packed)];
-    char b;
-#else
     char a;
     struct I_extra_packed b;
-#endif
 };
 struct I_extra_required_alignment var80;
 struct I_extra_size {
@@ -630,28 +522,22 @@ typedef int J[0];
 #endif
 J var82;
 struct J_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(J)];
-    char b;
-#else
     char a;
     J b;
-#endif
 };
 struct J_extra_alignment var83;
 #pragma pack(1)
 struct J_extra_packed {
+#ifdef MSVC
+    char a[sizeof(J)];
+#else
     J a;
+#endif
 };
 #pragma pack()
 struct J_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct J_extra_packed)];
-    char b;
-#else
     char a;
     struct J_extra_packed b;
-#endif
 };
 struct J_extra_required_alignment var84;
 struct J_extra_size {

--- a/test/records/0019_test.c
+++ b/test/records/0019_test.c
@@ -10,28 +10,22 @@ typedef enum {
 } A;
 A var2;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var3;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var4;
 struct A_extra_size {
@@ -54,28 +48,22 @@ typedef enum {
 #endif
 E var8;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var9;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var10;
 struct E_extra_size {

--- a/test/records/0020_test.c
+++ b/test/records/0020_test.c
@@ -14,28 +14,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -50,28 +44,22 @@ typedef struct {
 } A_;
 A_ var5;
 struct A__extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A_)];
-    char b;
-#else
     char a;
     A_ b;
-#endif
 };
 struct A__extra_alignment var6;
 #pragma pack(1)
 struct A__extra_packed {
+#ifdef MSVC
+    char a[sizeof(A_)];
+#else
     A_ a;
+#endif
 };
 #pragma pack()
 struct A__extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A__extra_packed)];
-    char b;
-#else
     char a;
     struct A__extra_packed b;
-#endif
 };
 struct A__extra_required_alignment var7;
 struct A__extra_size {
@@ -85,28 +73,22 @@ typedef struct {
 } B;
 B var9;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var10;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var11;
 struct B_extra_size {
@@ -122,28 +104,22 @@ typedef struct {
 C var13;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var14;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var15;
 struct C_extra_size {
@@ -159,28 +135,22 @@ typedef struct {
 D var17;
 #pragma pack()
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var18;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var19;
 struct D_extra_size {
@@ -196,28 +166,22 @@ typedef struct {
 E var21;
 #pragma pack()
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var22;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var23;
 struct E_extra_size {
@@ -233,28 +197,22 @@ typedef struct {
 F var25;
 #pragma pack()
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var26;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var27;
 struct F_extra_size {
@@ -268,28 +226,22 @@ typedef union {
 } G;
 G var29;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var30;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var31;
 struct G_extra_size {
@@ -305,28 +257,22 @@ typedef union {
 H var33;
 #pragma pack()
 struct H_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(H)];
-    char b;
-#else
     char a;
     H b;
-#endif
 };
 struct H_extra_alignment var34;
 #pragma pack(1)
 struct H_extra_packed {
+#ifdef MSVC
+    char a[sizeof(H)];
+#else
     H a;
+#endif
 };
 #pragma pack()
 struct H_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct H_extra_packed)];
-    char b;
-#else
     char a;
     struct H_extra_packed b;
-#endif
 };
 struct H_extra_required_alignment var35;
 struct H_extra_size {
@@ -342,28 +288,22 @@ typedef union {
 I var37;
 #pragma pack()
 struct I_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(I)];
-    char b;
-#else
     char a;
     I b;
-#endif
 };
 struct I_extra_alignment var38;
 #pragma pack(1)
 struct I_extra_packed {
+#ifdef MSVC
+    char a[sizeof(I)];
+#else
     I a;
+#endif
 };
 #pragma pack()
 struct I_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct I_extra_packed)];
-    char b;
-#else
     char a;
     struct I_extra_packed b;
-#endif
 };
 struct I_extra_required_alignment var39;
 struct I_extra_size {
@@ -379,28 +319,22 @@ typedef union {
 J var41;
 #pragma pack()
 struct J_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(J)];
-    char b;
-#else
     char a;
     J b;
-#endif
 };
 struct J_extra_alignment var42;
 #pragma pack(1)
 struct J_extra_packed {
+#ifdef MSVC
+    char a[sizeof(J)];
+#else
     J a;
+#endif
 };
 #pragma pack()
 struct J_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct J_extra_packed)];
-    char b;
-#else
     char a;
     struct J_extra_packed b;
-#endif
 };
 struct J_extra_required_alignment var43;
 struct J_extra_size {
@@ -416,28 +350,22 @@ typedef union {
 K var45;
 #pragma pack()
 struct K_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(K)];
-    char b;
-#else
     char a;
     K b;
-#endif
 };
 struct K_extra_alignment var46;
 #pragma pack(1)
 struct K_extra_packed {
+#ifdef MSVC
+    char a[sizeof(K)];
+#else
     K a;
+#endif
 };
 #pragma pack()
 struct K_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct K_extra_packed)];
-    char b;
-#else
     char a;
     struct K_extra_packed b;
-#endif
 };
 struct K_extra_required_alignment var47;
 struct K_extra_size {

--- a/test/records/0021_test.c
+++ b/test/records/0021_test.c
@@ -14,28 +14,22 @@ typedef struct {
 } Y;
 Y var1;
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var2;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var3;
 struct Y_extra_size {
@@ -50,28 +44,22 @@ typedef struct {
 } Z;
 Z var5;
 struct Z_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Z)];
-    char b;
-#else
     char a;
     Z b;
-#endif
 };
 struct Z_extra_alignment var6;
 #pragma pack(1)
 struct Z_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Z)];
+#else
     Z a;
+#endif
 };
 #pragma pack()
 struct Z_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Z_extra_packed)];
-    char b;
-#else
     char a;
     struct Z_extra_packed b;
-#endif
 };
 struct Z_extra_required_alignment var7;
 struct Z_extra_size {

--- a/test/records/0022_test.c
+++ b/test/records/0022_test.c
@@ -16,28 +16,22 @@ typedef struct {
 S2 var1;
 #pragma pack()
 struct S2_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(S2)];
-    char b;
-#else
     char a;
     S2 b;
-#endif
 };
 struct S2_extra_alignment var2;
 #pragma pack(1)
 struct S2_extra_packed {
+#ifdef MSVC
+    char a[sizeof(S2)];
+#else
     S2 a;
+#endif
 };
 #pragma pack()
 struct S2_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct S2_extra_packed)];
-    char b;
-#else
     char a;
     struct S2_extra_packed b;
-#endif
 };
 struct S2_extra_required_alignment var3;
 struct S2_extra_size {
@@ -57,28 +51,22 @@ typedef struct {
 S4 var5;
 #pragma pack()
 struct S4_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(S4)];
-    char b;
-#else
     char a;
     S4 b;
-#endif
 };
 struct S4_extra_alignment var6;
 #pragma pack(1)
 struct S4_extra_packed {
+#ifdef MSVC
+    char a[sizeof(S4)];
+#else
     S4 a;
+#endif
 };
 #pragma pack()
 struct S4_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct S4_extra_packed)];
-    char b;
-#else
     char a;
     struct S4_extra_packed b;
-#endif
 };
 struct S4_extra_required_alignment var7;
 struct S4_extra_size {
@@ -98,28 +86,22 @@ typedef struct {
 S8 var9;
 #pragma pack()
 struct S8_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(S8)];
-    char b;
-#else
     char a;
     S8 b;
-#endif
 };
 struct S8_extra_alignment var10;
 #pragma pack(1)
 struct S8_extra_packed {
+#ifdef MSVC
+    char a[sizeof(S8)];
+#else
     S8 a;
+#endif
 };
 #pragma pack()
 struct S8_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct S8_extra_packed)];
-    char b;
-#else
     char a;
     struct S8_extra_packed b;
-#endif
 };
 struct S8_extra_required_alignment var11;
 struct S8_extra_size {
@@ -139,28 +121,22 @@ typedef struct {
 S16 var13;
 #pragma pack()
 struct S16_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(S16)];
-    char b;
-#else
     char a;
     S16 b;
-#endif
 };
 struct S16_extra_alignment var14;
 #pragma pack(1)
 struct S16_extra_packed {
+#ifdef MSVC
+    char a[sizeof(S16)];
+#else
     S16 a;
+#endif
 };
 #pragma pack()
 struct S16_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct S16_extra_packed)];
-    char b;
-#else
     char a;
     struct S16_extra_packed b;
-#endif
 };
 struct S16_extra_required_alignment var15;
 struct S16_extra_size {
@@ -180,28 +156,22 @@ typedef struct {
 S32 var17;
 #pragma pack()
 struct S32_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(S32)];
-    char b;
-#else
     char a;
     S32 b;
-#endif
 };
 struct S32_extra_alignment var18;
 #pragma pack(1)
 struct S32_extra_packed {
+#ifdef MSVC
+    char a[sizeof(S32)];
+#else
     S32 a;
+#endif
 };
 #pragma pack()
 struct S32_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct S32_extra_packed)];
-    char b;
-#else
     char a;
     struct S32_extra_packed b;
-#endif
 };
 struct S32_extra_required_alignment var19;
 struct S32_extra_size {

--- a/test/records/0023_test.c
+++ b/test/records/0023_test.c
@@ -18,28 +18,22 @@ typedef struct {
 #endif
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -63,28 +57,22 @@ typedef struct {
 B var5;
 #pragma pack()
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {

--- a/test/records/0024_test.c
+++ b/test/records/0024_test.c
@@ -12,28 +12,22 @@ typedef long long unnamed_type_1[0];
 #endif
 unnamed_type_1 var2;
 struct unnamed_type_1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_1)];
-    char b;
-#else
     char a;
     unnamed_type_1 b;
-#endif
 };
 struct unnamed_type_1_extra_alignment var3;
 #pragma pack(1)
 struct unnamed_type_1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_1)];
+#else
     unnamed_type_1 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_1_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_1_extra_packed b;
-#endif
 };
 struct unnamed_type_1_extra_required_alignment var4;
 struct unnamed_type_1_extra_size {
@@ -47,28 +41,22 @@ typedef union {
 } X;
 X var6;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var7;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var8;
 struct X_extra_size {
@@ -84,28 +72,22 @@ typedef char unnamed_type_10[0];
 #endif
 unnamed_type_10 var11;
 struct unnamed_type_10_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_10)];
-    char b;
-#else
     char a;
     unnamed_type_10 b;
-#endif
 };
 struct unnamed_type_10_extra_alignment var12;
 #pragma pack(1)
 struct unnamed_type_10_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_10)];
+#else
     unnamed_type_10 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_10_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_10_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_10_extra_packed b;
-#endif
 };
 struct unnamed_type_10_extra_required_alignment var13;
 struct unnamed_type_10_extra_size {
@@ -120,28 +102,22 @@ typedef union {
 } Y;
 Y var15;
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var16;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var17;
 struct Y_extra_size {

--- a/test/records/0025_test.c
+++ b/test/records/0025_test.c
@@ -16,28 +16,22 @@ typedef struct {
 A var1;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -53,28 +47,22 @@ typedef A unnamed_type_5[0];
 #endif
 unnamed_type_5 var6;
 struct unnamed_type_5_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_5)];
-    char b;
-#else
     char a;
     unnamed_type_5 b;
-#endif
 };
 struct unnamed_type_5_extra_alignment var7;
 #pragma pack(1)
 struct unnamed_type_5_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_5)];
+#else
     unnamed_type_5 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_5_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_5_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_5_extra_packed b;
-#endif
 };
 struct unnamed_type_5_extra_required_alignment var8;
 struct unnamed_type_5_extra_size {
@@ -88,28 +76,22 @@ typedef union {
 } BA;
 BA var10;
 struct BA_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BA)];
-    char b;
-#else
     char a;
     BA b;
-#endif
 };
 struct BA_extra_alignment var11;
 #pragma pack(1)
 struct BA_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BA)];
+#else
     BA a;
+#endif
 };
 #pragma pack()
 struct BA_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BA_extra_packed)];
-    char b;
-#else
     char a;
     struct BA_extra_packed b;
-#endif
 };
 struct BA_extra_required_alignment var12;
 struct BA_extra_size {
@@ -125,28 +107,22 @@ typedef A unnamed_type_14[0];
 #endif
 unnamed_type_14 var15;
 struct unnamed_type_14_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_14)];
-    char b;
-#else
     char a;
     unnamed_type_14 b;
-#endif
 };
 struct unnamed_type_14_extra_alignment var16;
 #pragma pack(1)
 struct unnamed_type_14_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_14)];
+#else
     unnamed_type_14 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_14_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_14_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_14_extra_packed b;
-#endif
 };
 struct unnamed_type_14_extra_required_alignment var17;
 struct unnamed_type_14_extra_size {
@@ -165,28 +141,22 @@ typedef union {
 } BB;
 BB var19;
 struct BB_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BB)];
-    char b;
-#else
     char a;
     BB b;
-#endif
 };
 struct BB_extra_alignment var20;
 #pragma pack(1)
 struct BB_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BB)];
+#else
     BB a;
+#endif
 };
 #pragma pack()
 struct BB_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BB_extra_packed)];
-    char b;
-#else
     char a;
     struct BB_extra_packed b;
-#endif
 };
 struct BB_extra_required_alignment var21;
 struct BB_extra_size {
@@ -202,28 +172,22 @@ typedef A unnamed_type_23[0];
 #endif
 unnamed_type_23 var24;
 struct unnamed_type_23_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_23)];
-    char b;
-#else
     char a;
     unnamed_type_23 b;
-#endif
 };
 struct unnamed_type_23_extra_alignment var25;
 #pragma pack(1)
 struct unnamed_type_23_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_23)];
+#else
     unnamed_type_23 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_23_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_23_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_23_extra_packed b;
-#endif
 };
 struct unnamed_type_23_extra_required_alignment var26;
 struct unnamed_type_23_extra_size {
@@ -242,28 +206,22 @@ typedef union {
 } BC;
 BC var28;
 struct BC_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BC)];
-    char b;
-#else
     char a;
     BC b;
-#endif
 };
 struct BC_extra_alignment var29;
 #pragma pack(1)
 struct BC_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BC)];
+#else
     BC a;
+#endif
 };
 #pragma pack()
 struct BC_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BC_extra_packed)];
-    char b;
-#else
     char a;
     struct BC_extra_packed b;
-#endif
 };
 struct BC_extra_required_alignment var30;
 struct BC_extra_size {
@@ -279,28 +237,22 @@ typedef A unnamed_type_32[0];
 #endif
 unnamed_type_32 var33;
 struct unnamed_type_32_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_32)];
-    char b;
-#else
     char a;
     unnamed_type_32 b;
-#endif
 };
 struct unnamed_type_32_extra_alignment var34;
 #pragma pack(1)
 struct unnamed_type_32_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_32)];
+#else
     unnamed_type_32 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_32_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_32_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_32_extra_packed b;
-#endif
 };
 struct unnamed_type_32_extra_required_alignment var35;
 struct unnamed_type_32_extra_size {
@@ -322,28 +274,22 @@ typedef union {
 #endif
 BD var37;
 struct BD_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BD)];
-    char b;
-#else
     char a;
     BD b;
-#endif
 };
 struct BD_extra_alignment var38;
 #pragma pack(1)
 struct BD_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BD)];
+#else
     BD a;
+#endif
 };
 #pragma pack()
 struct BD_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BD_extra_packed)];
-    char b;
-#else
     char a;
     struct BD_extra_packed b;
-#endif
 };
 struct BD_extra_required_alignment var39;
 struct BD_extra_size {
@@ -359,28 +305,22 @@ typedef A unnamed_type_41[0];
 #endif
 unnamed_type_41 var42;
 struct unnamed_type_41_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_41)];
-    char b;
-#else
     char a;
     unnamed_type_41 b;
-#endif
 };
 struct unnamed_type_41_extra_alignment var43;
 #pragma pack(1)
 struct unnamed_type_41_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_41)];
+#else
     unnamed_type_41 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_41_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_41_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_41_extra_packed b;
-#endif
 };
 struct unnamed_type_41_extra_required_alignment var44;
 struct unnamed_type_41_extra_size {
@@ -402,28 +342,22 @@ typedef union {
 #endif
 BE var46;
 struct BE_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(BE)];
-    char b;
-#else
     char a;
     BE b;
-#endif
 };
 struct BE_extra_alignment var47;
 #pragma pack(1)
 struct BE_extra_packed {
+#ifdef MSVC
+    char a[sizeof(BE)];
+#else
     BE a;
+#endif
 };
 #pragma pack()
 struct BE_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct BE_extra_packed)];
-    char b;
-#else
     char a;
     struct BE_extra_packed b;
-#endif
 };
 struct BE_extra_required_alignment var48;
 struct BE_extra_size {
@@ -439,28 +373,22 @@ typedef char C __attribute__((aligned(8)));
 #endif
 C var50;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var51;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var52;
 struct C_extra_size {
@@ -476,28 +404,22 @@ typedef C unnamed_type_54[0];
 #endif
 unnamed_type_54 var55;
 struct unnamed_type_54_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_54)];
-    char b;
-#else
     char a;
     unnamed_type_54 b;
-#endif
 };
 struct unnamed_type_54_extra_alignment var56;
 #pragma pack(1)
 struct unnamed_type_54_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_54)];
+#else
     unnamed_type_54 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_54_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_54_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_54_extra_packed b;
-#endif
 };
 struct unnamed_type_54_extra_required_alignment var57;
 struct unnamed_type_54_extra_size {
@@ -511,28 +433,22 @@ typedef union {
 } D;
 D var59;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var60;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var61;
 struct D_extra_size {
@@ -546,28 +462,22 @@ typedef union {
 } E;
 E var63;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var64;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var65;
 struct E_extra_size {
@@ -581,28 +491,22 @@ typedef union {
 } F;
 F var67;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var68;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var69;
 struct F_extra_size {
@@ -616,28 +520,22 @@ typedef union {
 } G;
 G var71;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var72;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var73;
 struct G_extra_size {
@@ -652,28 +550,22 @@ typedef union {
 } H;
 H var75;
 struct H_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(H)];
-    char b;
-#else
     char a;
     H b;
-#endif
 };
 struct H_extra_alignment var76;
 #pragma pack(1)
 struct H_extra_packed {
+#ifdef MSVC
+    char a[sizeof(H)];
+#else
     H a;
+#endif
 };
 #pragma pack()
 struct H_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct H_extra_packed)];
-    char b;
-#else
     char a;
     struct H_extra_packed b;
-#endif
 };
 struct H_extra_required_alignment var77;
 struct H_extra_size {
@@ -689,28 +581,22 @@ typedef char unnamed_type_79[0];
 #endif
 unnamed_type_79 var80;
 struct unnamed_type_79_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_79)];
-    char b;
-#else
     char a;
     unnamed_type_79 b;
-#endif
 };
 struct unnamed_type_79_extra_alignment var81;
 #pragma pack(1)
 struct unnamed_type_79_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_79)];
+#else
     unnamed_type_79 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_79_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_79_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_79_extra_packed b;
-#endif
 };
 struct unnamed_type_79_extra_required_alignment var82;
 struct unnamed_type_79_extra_size {
@@ -724,28 +610,22 @@ typedef union {
 } I;
 I var84;
 struct I_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(I)];
-    char b;
-#else
     char a;
     I b;
-#endif
 };
 struct I_extra_alignment var85;
 #pragma pack(1)
 struct I_extra_packed {
+#ifdef MSVC
+    char a[sizeof(I)];
+#else
     I a;
+#endif
 };
 #pragma pack()
 struct I_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct I_extra_packed)];
-    char b;
-#else
     char a;
     struct I_extra_packed b;
-#endif
 };
 struct I_extra_required_alignment var86;
 struct I_extra_size {

--- a/test/records/0026_test.c
+++ b/test/records/0026_test.c
@@ -16,28 +16,22 @@ typedef struct {
 A var1;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -53,28 +47,22 @@ typedef A unnamed_type_5[0];
 #endif
 unnamed_type_5 var6;
 struct unnamed_type_5_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_5)];
-    char b;
-#else
     char a;
     unnamed_type_5 b;
-#endif
 };
 struct unnamed_type_5_extra_alignment var7;
 #pragma pack(1)
 struct unnamed_type_5_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_5)];
+#else
     unnamed_type_5 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_5_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_5_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_5_extra_packed b;
-#endif
 };
 struct unnamed_type_5_extra_required_alignment var8;
 struct unnamed_type_5_extra_size {
@@ -88,28 +76,22 @@ typedef struct {
 } B;
 B var10;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var11;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var12;
 struct B_extra_size {
@@ -125,28 +107,22 @@ typedef char C __attribute__((aligned(2)));
 #endif
 C var14;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var15;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var16;
 struct C_extra_size {
@@ -162,28 +138,22 @@ typedef C unnamed_type_18[0];
 #endif
 unnamed_type_18 var19;
 struct unnamed_type_18_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_18)];
-    char b;
-#else
     char a;
     unnamed_type_18 b;
-#endif
 };
 struct unnamed_type_18_extra_alignment var20;
 #pragma pack(1)
 struct unnamed_type_18_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_18)];
+#else
     unnamed_type_18 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_18_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_18_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_18_extra_packed b;
-#endif
 };
 struct unnamed_type_18_extra_required_alignment var21;
 struct unnamed_type_18_extra_size {
@@ -197,28 +167,22 @@ typedef struct {
 } D;
 D var23;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var24;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var25;
 struct D_extra_size {
@@ -240,28 +204,22 @@ typedef struct {
 E var27;
 #pragma pack()
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var28;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var29;
 struct E_extra_size {
@@ -277,28 +235,22 @@ typedef E unnamed_type_31[0];
 #endif
 unnamed_type_31 var32;
 struct unnamed_type_31_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_31)];
-    char b;
-#else
     char a;
     unnamed_type_31 b;
-#endif
 };
 struct unnamed_type_31_extra_alignment var33;
 #pragma pack(1)
 struct unnamed_type_31_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_31)];
+#else
     unnamed_type_31 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_31_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_31_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_31_extra_packed b;
-#endif
 };
 struct unnamed_type_31_extra_required_alignment var34;
 struct unnamed_type_31_extra_size {
@@ -312,28 +264,22 @@ typedef struct {
 } F;
 F var36;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var37;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var38;
 struct F_extra_size {
@@ -353,28 +299,22 @@ typedef struct {
 } G;
 G var40;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var41;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var42;
 struct G_extra_size {
@@ -390,28 +330,22 @@ typedef G unnamed_type_44[0];
 #endif
 unnamed_type_44 var45;
 struct unnamed_type_44_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_44)];
-    char b;
-#else
     char a;
     unnamed_type_44 b;
-#endif
 };
 struct unnamed_type_44_extra_alignment var46;
 #pragma pack(1)
 struct unnamed_type_44_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_44)];
+#else
     unnamed_type_44 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_44_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_44_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_44_extra_packed b;
-#endif
 };
 struct unnamed_type_44_extra_required_alignment var47;
 struct unnamed_type_44_extra_size {
@@ -425,28 +359,22 @@ typedef struct {
 } H;
 H var49;
 struct H_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(H)];
-    char b;
-#else
     char a;
     H b;
-#endif
 };
 struct H_extra_alignment var50;
 #pragma pack(1)
 struct H_extra_packed {
+#ifdef MSVC
+    char a[sizeof(H)];
+#else
     H a;
+#endif
 };
 #pragma pack()
 struct H_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct H_extra_packed)];
-    char b;
-#else
     char a;
     struct H_extra_packed b;
-#endif
 };
 struct H_extra_required_alignment var51;
 struct H_extra_size {
@@ -462,28 +390,22 @@ typedef char unnamed_type_53[0];
 #endif
 unnamed_type_53 var54;
 struct unnamed_type_53_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_53)];
-    char b;
-#else
     char a;
     unnamed_type_53 b;
-#endif
 };
 struct unnamed_type_53_extra_alignment var55;
 #pragma pack(1)
 struct unnamed_type_53_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_53)];
+#else
     unnamed_type_53 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_53_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_53_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_53_extra_packed b;
-#endif
 };
 struct unnamed_type_53_extra_required_alignment var56;
 struct unnamed_type_53_extra_size {
@@ -497,28 +419,22 @@ typedef struct {
 } I;
 I var58;
 struct I_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(I)];
-    char b;
-#else
     char a;
     I b;
-#endif
 };
 struct I_extra_alignment var59;
 #pragma pack(1)
 struct I_extra_packed {
+#ifdef MSVC
+    char a[sizeof(I)];
+#else
     I a;
+#endif
 };
 #pragma pack()
 struct I_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct I_extra_packed)];
-    char b;
-#else
     char a;
     struct I_extra_packed b;
-#endif
 };
 struct I_extra_required_alignment var60;
 struct I_extra_size {
@@ -534,28 +450,22 @@ typedef char unnamed_type_62[0];
 #endif
 unnamed_type_62 var63;
 struct unnamed_type_62_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_62)];
-    char b;
-#else
     char a;
     unnamed_type_62 b;
-#endif
 };
 struct unnamed_type_62_extra_alignment var64;
 #pragma pack(1)
 struct unnamed_type_62_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_62)];
+#else
     unnamed_type_62 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_62_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_62_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_62_extra_packed b;
-#endif
 };
 struct unnamed_type_62_extra_required_alignment var65;
 struct unnamed_type_62_extra_size {
@@ -573,28 +483,22 @@ typedef struct {
 } J;
 J var67;
 struct J_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(J)];
-    char b;
-#else
     char a;
     J b;
-#endif
 };
 struct J_extra_alignment var68;
 #pragma pack(1)
 struct J_extra_packed {
+#ifdef MSVC
+    char a[sizeof(J)];
+#else
     J a;
+#endif
 };
 #pragma pack()
 struct J_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct J_extra_packed)];
-    char b;
-#else
     char a;
     struct J_extra_packed b;
-#endif
 };
 struct J_extra_required_alignment var69;
 struct J_extra_size {
@@ -610,28 +514,22 @@ typedef char unnamed_type_71[0];
 #endif
 unnamed_type_71 var72;
 struct unnamed_type_71_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_71)];
-    char b;
-#else
     char a;
     unnamed_type_71 b;
-#endif
 };
 struct unnamed_type_71_extra_alignment var73;
 #pragma pack(1)
 struct unnamed_type_71_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_71)];
+#else
     unnamed_type_71 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_71_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_71_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_71_extra_packed b;
-#endif
 };
 struct unnamed_type_71_extra_required_alignment var74;
 struct unnamed_type_71_extra_size {
@@ -649,28 +547,22 @@ typedef struct {
 } K;
 K var76;
 struct K_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(K)];
-    char b;
-#else
     char a;
     K b;
-#endif
 };
 struct K_extra_alignment var77;
 #pragma pack(1)
 struct K_extra_packed {
+#ifdef MSVC
+    char a[sizeof(K)];
+#else
     K a;
+#endif
 };
 #pragma pack()
 struct K_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct K_extra_packed)];
-    char b;
-#else
     char a;
     struct K_extra_packed b;
-#endif
 };
 struct K_extra_required_alignment var78;
 struct K_extra_size {

--- a/test/records/0027_test.c
+++ b/test/records/0027_test.c
@@ -11,28 +11,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -48,28 +42,22 @@ typedef short B __attribute__((aligned(4)));
 #endif
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -84,28 +72,22 @@ typedef struct {
 } C;
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -123,28 +105,22 @@ typedef struct {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {
@@ -159,28 +135,22 @@ typedef struct {
 } E;
 E var17;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var18;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var19;
 struct E_extra_size {
@@ -200,28 +170,22 @@ typedef struct {
 F var21;
 #pragma pack()
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var22;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var23;
 struct F_extra_size {
@@ -236,28 +200,22 @@ typedef struct {
 } G;
 G var25;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var26;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var27;
 struct G_extra_size {

--- a/test/records/0028_test.c
+++ b/test/records/0028_test.c
@@ -12,28 +12,22 @@ typedef char Char __attribute__((aligned(4)));
 #endif
 Char var1;
 struct Char_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Char)];
-    char b;
-#else
     char a;
     Char b;
-#endif
 };
 struct Char_extra_alignment var2;
 #pragma pack(1)
 struct Char_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Char)];
+#else
     Char a;
+#endif
 };
 #pragma pack()
 struct Char_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Char_extra_packed)];
-    char b;
-#else
     char a;
     struct Char_extra_packed b;
-#endif
 };
 struct Char_extra_required_alignment var3;
 struct Char_extra_size {
@@ -50,28 +44,22 @@ typedef struct {
 A var5;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var6;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var7;
 struct A_extra_size {
@@ -90,28 +78,22 @@ typedef struct {
 } B;
 B var9;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var10;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var11;
 struct B_extra_size {
@@ -130,28 +112,22 @@ typedef struct {
 } C;
 C var13;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var14;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var15;
 struct C_extra_size {
@@ -170,28 +146,22 @@ typedef struct {
 } D;
 D var17;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var18;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var19;
 struct D_extra_size {
@@ -212,28 +182,22 @@ typedef struct {
 E var21;
 #pragma pack()
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var22;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var23;
 struct E_extra_size {
@@ -250,28 +214,22 @@ typedef struct {
 F var25;
 #pragma pack()
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var26;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var27;
 struct F_extra_size {
@@ -292,28 +250,22 @@ typedef struct {
 G var29;
 #pragma pack()
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var30;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var31;
 struct G_extra_size {

--- a/test/records/0029_test.c
+++ b/test/records/0029_test.c
@@ -12,28 +12,22 @@ typedef char Char __attribute__((aligned(4)));
 #endif
 Char var1;
 struct Char_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Char)];
-    char b;
-#else
     char a;
     Char b;
-#endif
 };
 struct Char_extra_alignment var2;
 #pragma pack(1)
 struct Char_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Char)];
+#else
     Char a;
+#endif
 };
 #pragma pack()
 struct Char_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Char_extra_packed)];
-    char b;
-#else
     char a;
     struct Char_extra_packed b;
-#endif
 };
 struct Char_extra_required_alignment var3;
 struct Char_extra_size {
@@ -47,28 +41,22 @@ typedef struct {
 } A;
 A var5;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var6;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var7;
 struct A_extra_size {
@@ -82,28 +70,22 @@ typedef struct {
 } B;
 B var9;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var10;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var11;
 struct B_extra_size {
@@ -119,28 +101,22 @@ typedef struct {
 C var13;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var14;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var15;
 struct C_extra_size {
@@ -156,28 +132,22 @@ typedef struct {
 D var17;
 #pragma pack()
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var18;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var19;
 struct D_extra_size {
@@ -195,28 +165,22 @@ typedef struct {
 } E;
 E var21;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var22;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var23;
 struct E_extra_size {
@@ -234,28 +198,22 @@ typedef struct {
 } F;
 F var25;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var26;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var27;
 struct F_extra_size {
@@ -273,28 +231,22 @@ typedef struct {
 } G;
 G var29;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var30;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var31;
 struct G_extra_size {
@@ -312,28 +264,22 @@ typedef struct {
 } H;
 H var33;
 struct H_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(H)];
-    char b;
-#else
     char a;
     H b;
-#endif
 };
 struct H_extra_alignment var34;
 #pragma pack(1)
 struct H_extra_packed {
+#ifdef MSVC
+    char a[sizeof(H)];
+#else
     H a;
+#endif
 };
 #pragma pack()
 struct H_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct H_extra_packed)];
-    char b;
-#else
     char a;
     struct H_extra_packed b;
-#endif
 };
 struct H_extra_required_alignment var35;
 struct H_extra_size {

--- a/test/records/0030_test.c
+++ b/test/records/0030_test.c
@@ -13,28 +13,22 @@ typedef struct {
 A var1;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -52,28 +46,22 @@ typedef struct {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -90,28 +78,22 @@ typedef struct {
 C var9;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {

--- a/test/records/0031_test.c
+++ b/test/records/0031_test.c
@@ -12,28 +12,22 @@ typedef char Char __attribute__((aligned(4)));
 #endif
 Char var1;
 struct Char_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Char)];
-    char b;
-#else
     char a;
     Char b;
-#endif
 };
 struct Char_extra_alignment var2;
 #pragma pack(1)
 struct Char_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Char)];
+#else
     Char a;
+#endif
 };
 #pragma pack()
 struct Char_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Char_extra_packed)];
-    char b;
-#else
     char a;
     struct Char_extra_packed b;
-#endif
 };
 struct Char_extra_required_alignment var3;
 struct Char_extra_size {
@@ -50,28 +44,22 @@ typedef struct {
 A var5;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var6;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var7;
 struct A_extra_size {
@@ -92,28 +80,22 @@ typedef struct {
 B var9;
 #pragma pack()
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var10;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var11;
 struct B_extra_size {

--- a/test/records/0032_test.c
+++ b/test/records/0032_test.c
@@ -10,28 +10,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -45,28 +39,22 @@ typedef union {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -84,28 +72,22 @@ typedef struct {
 } C;
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -123,28 +105,22 @@ typedef union {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {

--- a/test/records/0033_test.c
+++ b/test/records/0033_test.c
@@ -11,28 +11,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -53,28 +47,22 @@ typedef struct {
 B var5;
 #pragma pack()
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -91,28 +79,22 @@ typedef struct {
 C var9;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {

--- a/test/records/0034_test.c
+++ b/test/records/0034_test.c
@@ -11,28 +11,22 @@ typedef union {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -47,28 +41,22 @@ typedef struct {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {

--- a/test/records/0035_test.c
+++ b/test/records/0035_test.c
@@ -11,28 +11,22 @@ typedef union {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -47,28 +41,22 @@ typedef union {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -83,28 +71,22 @@ typedef struct {
 } C;
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -119,28 +101,22 @@ typedef struct {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {

--- a/test/records/0036_test.c
+++ b/test/records/0036_test.c
@@ -11,18 +11,18 @@ typedef struct {
 } S;
 S var1;
 struct S_extra_alignment {
-    char a[_Alignof(S)];
-    char b;
+    char a;
+    S b;
 };
 struct S_extra_alignment var2;
 #pragma pack(1)
 struct S_extra_packed {
-    S a;
+    char a[sizeof(S)];
 };
 #pragma pack()
 struct S_extra_required_alignment {
-    char a[_Alignof(struct S_extra_packed)];
-    char b;
+    char a;
+    struct S_extra_packed b;
 };
 struct S_extra_required_alignment var3;
 struct S_extra_size {

--- a/test/records/0037_test.c
+++ b/test/records/0037_test.c
@@ -15,28 +15,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -56,28 +50,22 @@ typedef struct {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -97,28 +85,22 @@ typedef struct {
 } C;
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -139,28 +121,22 @@ typedef struct {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {

--- a/test/records/0038_test.c
+++ b/test/records/0038_test.c
@@ -16,28 +16,22 @@ typedef struct {
 A var1;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {

--- a/test/records/0039_test.c
+++ b/test/records/0039_test.c
@@ -12,28 +12,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -48,28 +42,22 @@ typedef struct {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -89,28 +77,22 @@ typedef struct {
 } C;
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {

--- a/test/records/0040_test.c
+++ b/test/records/0040_test.c
@@ -11,28 +11,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef struct {
 B var5;
 #pragma pack()
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -91,28 +79,22 @@ typedef struct {
 C var9;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {

--- a/test/records/0041_test.c
+++ b/test/records/0041_test.c
@@ -10,28 +10,22 @@ typedef union {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef union {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -88,28 +76,22 @@ typedef union {
 } C;
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -128,28 +110,22 @@ typedef union {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {
@@ -170,28 +146,22 @@ typedef union {
 } E;
 E var17;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var18;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var19;
 struct E_extra_size {

--- a/test/records/0042_test.c
+++ b/test/records/0042_test.c
@@ -18,28 +18,22 @@ typedef struct {
 #endif
 AlignedStruct var1;
 struct AlignedStruct_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AlignedStruct)];
-    char b;
-#else
     char a;
     AlignedStruct b;
-#endif
 };
 struct AlignedStruct_extra_alignment var2;
 #pragma pack(1)
 struct AlignedStruct_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AlignedStruct)];
+#else
     AlignedStruct a;
+#endif
 };
 #pragma pack()
 struct AlignedStruct_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AlignedStruct_extra_packed)];
-    char b;
-#else
     char a;
     struct AlignedStruct_extra_packed b;
-#endif
 };
 struct AlignedStruct_extra_required_alignment var3;
 struct AlignedStruct_extra_size {
@@ -55,28 +49,22 @@ typedef int AlignedInt __attribute__((aligned(16)));
 #endif
 AlignedInt var5;
 struct AlignedInt_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(AlignedInt)];
-    char b;
-#else
     char a;
     AlignedInt b;
-#endif
 };
 struct AlignedInt_extra_alignment var6;
 #pragma pack(1)
 struct AlignedInt_extra_packed {
+#ifdef MSVC
+    char a[sizeof(AlignedInt)];
+#else
     AlignedInt a;
+#endif
 };
 #pragma pack()
 struct AlignedInt_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct AlignedInt_extra_packed)];
-    char b;
-#else
     char a;
     struct AlignedInt_extra_packed b;
-#endif
 };
 struct AlignedInt_extra_required_alignment var7;
 struct AlignedInt_extra_size {
@@ -88,28 +76,22 @@ struct AlignedInt_extra_size var8;
 typedef AlignedStruct unnamed_type_9[1];
 unnamed_type_9 var10;
 struct unnamed_type_9_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_9)];
-    char b;
-#else
     char a;
     unnamed_type_9 b;
-#endif
 };
 struct unnamed_type_9_extra_alignment var11;
 #pragma pack(1)
 struct unnamed_type_9_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_9)];
+#else
     unnamed_type_9 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_9_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_9_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_9_extra_packed b;
-#endif
 };
 struct unnamed_type_9_extra_required_alignment var12;
 struct unnamed_type_9_extra_size {
@@ -125,28 +107,22 @@ typedef struct {
 A var14;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var15;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var16;
 struct A_extra_size {
@@ -158,28 +134,22 @@ struct A_extra_size var17;
 typedef AlignedInt unnamed_type_18[1];
 unnamed_type_18 var19;
 struct unnamed_type_18_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_18)];
-    char b;
-#else
     char a;
     unnamed_type_18 b;
-#endif
 };
 struct unnamed_type_18_extra_alignment var20;
 #pragma pack(1)
 struct unnamed_type_18_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_18)];
+#else
     unnamed_type_18 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_18_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_18_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_18_extra_packed b;
-#endif
 };
 struct unnamed_type_18_extra_required_alignment var21;
 struct unnamed_type_18_extra_size {
@@ -196,28 +166,22 @@ typedef struct {
 B var23;
 #pragma pack()
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var24;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var25;
 struct B_extra_size {
@@ -233,28 +197,22 @@ typedef AlignedInt unnamed_type_27[0];
 #endif
 unnamed_type_27 var28;
 struct unnamed_type_27_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_27)];
-    char b;
-#else
     char a;
     unnamed_type_27 b;
-#endif
 };
 struct unnamed_type_27_extra_alignment var29;
 #pragma pack(1)
 struct unnamed_type_27_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_27)];
+#else
     unnamed_type_27 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_27_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_27_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_27_extra_packed b;
-#endif
 };
 struct unnamed_type_27_extra_required_alignment var30;
 struct unnamed_type_27_extra_size {
@@ -271,28 +229,22 @@ typedef struct {
 C var32;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var33;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var34;
 struct C_extra_size {

--- a/test/records/0043_test.c
+++ b/test/records/0043_test.c
@@ -12,28 +12,22 @@ typedef int unnamed_type_1[0];
 #endif
 unnamed_type_1 var2;
 struct unnamed_type_1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_1)];
-    char b;
-#else
     char a;
     unnamed_type_1 b;
-#endif
 };
 struct unnamed_type_1_extra_alignment var3;
 #pragma pack(1)
 struct unnamed_type_1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_1)];
+#else
     unnamed_type_1 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_1_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_1_extra_packed b;
-#endif
 };
 struct unnamed_type_1_extra_required_alignment var4;
 struct unnamed_type_1_extra_size {
@@ -47,28 +41,22 @@ typedef struct {
 } EmptyIntMemb;
 EmptyIntMemb var6;
 struct EmptyIntMemb_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(EmptyIntMemb)];
-    char b;
-#else
     char a;
     EmptyIntMemb b;
-#endif
 };
 struct EmptyIntMemb_extra_alignment var7;
 #pragma pack(1)
 struct EmptyIntMemb_extra_packed {
+#ifdef MSVC
+    char a[sizeof(EmptyIntMemb)];
+#else
     EmptyIntMemb a;
+#endif
 };
 #pragma pack()
 struct EmptyIntMemb_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct EmptyIntMemb_extra_packed)];
-    char b;
-#else
     char a;
     struct EmptyIntMemb_extra_packed b;
-#endif
 };
 struct EmptyIntMemb_extra_required_alignment var8;
 struct EmptyIntMemb_extra_size {
@@ -84,28 +72,22 @@ typedef long long unnamed_type_10[0];
 #endif
 unnamed_type_10 var11;
 struct unnamed_type_10_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_10)];
-    char b;
-#else
     char a;
     unnamed_type_10 b;
-#endif
 };
 struct unnamed_type_10_extra_alignment var12;
 #pragma pack(1)
 struct unnamed_type_10_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_10)];
+#else
     unnamed_type_10 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_10_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_10_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_10_extra_packed b;
-#endif
 };
 struct unnamed_type_10_extra_required_alignment var13;
 struct unnamed_type_10_extra_size {
@@ -119,28 +101,22 @@ typedef struct {
 } EmptyLongLongMemb;
 EmptyLongLongMemb var15;
 struct EmptyLongLongMemb_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(EmptyLongLongMemb)];
-    char b;
-#else
     char a;
     EmptyLongLongMemb b;
-#endif
 };
 struct EmptyLongLongMemb_extra_alignment var16;
 #pragma pack(1)
 struct EmptyLongLongMemb_extra_packed {
+#ifdef MSVC
+    char a[sizeof(EmptyLongLongMemb)];
+#else
     EmptyLongLongMemb a;
+#endif
 };
 #pragma pack()
 struct EmptyLongLongMemb_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct EmptyLongLongMemb_extra_packed)];
-    char b;
-#else
     char a;
     struct EmptyLongLongMemb_extra_packed b;
-#endif
 };
 struct EmptyLongLongMemb_extra_required_alignment var17;
 struct EmptyLongLongMemb_extra_size {
@@ -156,28 +132,22 @@ typedef long long unnamed_type_19[0];
 #endif
 unnamed_type_19 var20;
 struct unnamed_type_19_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_19)];
-    char b;
-#else
     char a;
     unnamed_type_19 b;
-#endif
 };
 struct unnamed_type_19_extra_alignment var21;
 #pragma pack(1)
 struct unnamed_type_19_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_19)];
+#else
     unnamed_type_19 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_19_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_19_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_19_extra_packed b;
-#endif
 };
 struct unnamed_type_19_extra_required_alignment var22;
 struct unnamed_type_19_extra_size {
@@ -195,28 +165,22 @@ typedef struct {
 } EmptyAligned2LongLongMemb;
 EmptyAligned2LongLongMemb var24;
 struct EmptyAligned2LongLongMemb_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(EmptyAligned2LongLongMemb)];
-    char b;
-#else
     char a;
     EmptyAligned2LongLongMemb b;
-#endif
 };
 struct EmptyAligned2LongLongMemb_extra_alignment var25;
 #pragma pack(1)
 struct EmptyAligned2LongLongMemb_extra_packed {
+#ifdef MSVC
+    char a[sizeof(EmptyAligned2LongLongMemb)];
+#else
     EmptyAligned2LongLongMemb a;
+#endif
 };
 #pragma pack()
 struct EmptyAligned2LongLongMemb_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct EmptyAligned2LongLongMemb_extra_packed)];
-    char b;
-#else
     char a;
     struct EmptyAligned2LongLongMemb_extra_packed b;
-#endif
 };
 struct EmptyAligned2LongLongMemb_extra_required_alignment var26;
 struct EmptyAligned2LongLongMemb_extra_size {
@@ -232,28 +196,22 @@ typedef long long unnamed_type_28[0];
 #endif
 unnamed_type_28 var29;
 struct unnamed_type_28_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_28)];
-    char b;
-#else
     char a;
     unnamed_type_28 b;
-#endif
 };
 struct unnamed_type_28_extra_alignment var30;
 #pragma pack(1)
 struct unnamed_type_28_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_28)];
+#else
     unnamed_type_28 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_28_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_28_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_28_extra_packed b;
-#endif
 };
 struct unnamed_type_28_extra_required_alignment var31;
 struct unnamed_type_28_extra_size {
@@ -271,28 +229,22 @@ typedef struct {
 } EmptyAligned8LongLongMemb;
 EmptyAligned8LongLongMemb var33;
 struct EmptyAligned8LongLongMemb_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(EmptyAligned8LongLongMemb)];
-    char b;
-#else
     char a;
     EmptyAligned8LongLongMemb b;
-#endif
 };
 struct EmptyAligned8LongLongMemb_extra_alignment var34;
 #pragma pack(1)
 struct EmptyAligned8LongLongMemb_extra_packed {
+#ifdef MSVC
+    char a[sizeof(EmptyAligned8LongLongMemb)];
+#else
     EmptyAligned8LongLongMemb a;
+#endif
 };
 #pragma pack()
 struct EmptyAligned8LongLongMemb_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct EmptyAligned8LongLongMemb_extra_packed)];
-    char b;
-#else
     char a;
     struct EmptyAligned8LongLongMemb_extra_packed b;
-#endif
 };
 struct EmptyAligned8LongLongMemb_extra_required_alignment var35;
 struct EmptyAligned8LongLongMemb_extra_size {
@@ -308,28 +260,22 @@ typedef long long unnamed_type_37[0];
 #endif
 unnamed_type_37 var38;
 struct unnamed_type_37_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_37)];
-    char b;
-#else
     char a;
     unnamed_type_37 b;
-#endif
 };
 struct unnamed_type_37_extra_alignment var39;
 #pragma pack(1)
 struct unnamed_type_37_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_37)];
+#else
     unnamed_type_37 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_37_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_37_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_37_extra_packed b;
-#endif
 };
 struct unnamed_type_37_extra_required_alignment var40;
 struct unnamed_type_37_extra_size {
@@ -353,28 +299,22 @@ typedef struct {
 EmptyPackedAligned4LongLongMemb var42;
 #pragma pack()
 struct EmptyPackedAligned4LongLongMemb_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(EmptyPackedAligned4LongLongMemb)];
-    char b;
-#else
     char a;
     EmptyPackedAligned4LongLongMemb b;
-#endif
 };
 struct EmptyPackedAligned4LongLongMemb_extra_alignment var43;
 #pragma pack(1)
 struct EmptyPackedAligned4LongLongMemb_extra_packed {
+#ifdef MSVC
+    char a[sizeof(EmptyPackedAligned4LongLongMemb)];
+#else
     EmptyPackedAligned4LongLongMemb a;
+#endif
 };
 #pragma pack()
 struct EmptyPackedAligned4LongLongMemb_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct EmptyPackedAligned4LongLongMemb_extra_packed)];
-    char b;
-#else
     char a;
     struct EmptyPackedAligned4LongLongMemb_extra_packed b;
-#endif
 };
 struct EmptyPackedAligned4LongLongMemb_extra_required_alignment var44;
 struct EmptyPackedAligned4LongLongMemb_extra_size {
@@ -390,28 +330,22 @@ typedef long long unnamed_type_46[0];
 #endif
 unnamed_type_46 var47;
 struct unnamed_type_46_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_46)];
-    char b;
-#else
     char a;
     unnamed_type_46 b;
-#endif
 };
 struct unnamed_type_46_extra_alignment var48;
 #pragma pack(1)
 struct unnamed_type_46_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_46)];
+#else
     unnamed_type_46 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_46_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_46_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_46_extra_packed b;
-#endif
 };
 struct unnamed_type_46_extra_required_alignment var49;
 struct unnamed_type_46_extra_size {
@@ -431,28 +365,22 @@ typedef struct {
 EmptyPackedAligned8LongLongMemb var51;
 #pragma pack()
 struct EmptyPackedAligned8LongLongMemb_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(EmptyPackedAligned8LongLongMemb)];
-    char b;
-#else
     char a;
     EmptyPackedAligned8LongLongMemb b;
-#endif
 };
 struct EmptyPackedAligned8LongLongMemb_extra_alignment var52;
 #pragma pack(1)
 struct EmptyPackedAligned8LongLongMemb_extra_packed {
+#ifdef MSVC
+    char a[sizeof(EmptyPackedAligned8LongLongMemb)];
+#else
     EmptyPackedAligned8LongLongMemb a;
+#endif
 };
 #pragma pack()
 struct EmptyPackedAligned8LongLongMemb_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct EmptyPackedAligned8LongLongMemb_extra_packed)];
-    char b;
-#else
     char a;
     struct EmptyPackedAligned8LongLongMemb_extra_packed b;
-#endif
 };
 struct EmptyPackedAligned8LongLongMemb_extra_required_alignment var53;
 struct EmptyPackedAligned8LongLongMemb_extra_size {

--- a/test/records/0044_test.c
+++ b/test/records/0044_test.c
@@ -10,28 +10,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef struct {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -88,28 +76,22 @@ typedef struct {
 X var9;
 #pragma pack()
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var10;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var11;
 struct X_extra_size {
@@ -129,28 +111,22 @@ typedef struct {
 YA var13;
 #pragma pack()
 struct YA_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(YA)];
-    char b;
-#else
     char a;
     YA b;
-#endif
 };
 struct YA_extra_alignment var14;
 #pragma pack(1)
 struct YA_extra_packed {
+#ifdef MSVC
+    char a[sizeof(YA)];
+#else
     YA a;
+#endif
 };
 #pragma pack()
 struct YA_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct YA_extra_packed)];
-    char b;
-#else
     char a;
     struct YA_extra_packed b;
-#endif
 };
 struct YA_extra_required_alignment var15;
 struct YA_extra_size {
@@ -167,28 +143,22 @@ typedef struct {
 YB var17;
 #pragma pack()
 struct YB_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(YB)];
-    char b;
-#else
     char a;
     YB b;
-#endif
 };
 struct YB_extra_alignment var18;
 #pragma pack(1)
 struct YB_extra_packed {
+#ifdef MSVC
+    char a[sizeof(YB)];
+#else
     YB a;
+#endif
 };
 #pragma pack()
 struct YB_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct YB_extra_packed)];
-    char b;
-#else
     char a;
     struct YB_extra_packed b;
-#endif
 };
 struct YB_extra_required_alignment var19;
 struct YB_extra_size {
@@ -208,28 +178,22 @@ typedef struct {
 YC var21;
 #pragma pack()
 struct YC_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(YC)];
-    char b;
-#else
     char a;
     YC b;
-#endif
 };
 struct YC_extra_alignment var22;
 #pragma pack(1)
 struct YC_extra_packed {
+#ifdef MSVC
+    char a[sizeof(YC)];
+#else
     YC a;
+#endif
 };
 #pragma pack()
 struct YC_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct YC_extra_packed)];
-    char b;
-#else
     char a;
     struct YC_extra_packed b;
-#endif
 };
 struct YC_extra_required_alignment var23;
 struct YC_extra_size {
@@ -246,28 +210,22 @@ typedef struct {
 YD var25;
 #pragma pack()
 struct YD_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(YD)];
-    char b;
-#else
     char a;
     YD b;
-#endif
 };
 struct YD_extra_alignment var26;
 #pragma pack(1)
 struct YD_extra_packed {
+#ifdef MSVC
+    char a[sizeof(YD)];
+#else
     YD a;
+#endif
 };
 #pragma pack()
 struct YD_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct YD_extra_packed)];
-    char b;
-#else
     char a;
     struct YD_extra_packed b;
-#endif
 };
 struct YD_extra_required_alignment var27;
 struct YD_extra_size {
@@ -287,28 +245,22 @@ typedef struct {
 YE var29;
 #pragma pack()
 struct YE_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(YE)];
-    char b;
-#else
     char a;
     YE b;
-#endif
 };
 struct YE_extra_alignment var30;
 #pragma pack(1)
 struct YE_extra_packed {
+#ifdef MSVC
+    char a[sizeof(YE)];
+#else
     YE a;
+#endif
 };
 #pragma pack()
 struct YE_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct YE_extra_packed)];
-    char b;
-#else
     char a;
     struct YE_extra_packed b;
-#endif
 };
 struct YE_extra_required_alignment var31;
 struct YE_extra_size {
@@ -325,28 +277,22 @@ typedef struct {
 YF var33;
 #pragma pack()
 struct YF_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(YF)];
-    char b;
-#else
     char a;
     YF b;
-#endif
 };
 struct YF_extra_alignment var34;
 #pragma pack(1)
 struct YF_extra_packed {
+#ifdef MSVC
+    char a[sizeof(YF)];
+#else
     YF a;
+#endif
 };
 #pragma pack()
 struct YF_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct YF_extra_packed)];
-    char b;
-#else
     char a;
     struct YF_extra_packed b;
-#endif
 };
 struct YF_extra_required_alignment var35;
 struct YF_extra_size {
@@ -370,28 +316,22 @@ typedef struct {
 D0 var37;
 #pragma pack()
 struct D0_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D0)];
-    char b;
-#else
     char a;
     D0 b;
-#endif
 };
 struct D0_extra_alignment var38;
 #pragma pack(1)
 struct D0_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D0)];
+#else
     D0 a;
+#endif
 };
 #pragma pack()
 struct D0_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D0_extra_packed)];
-    char b;
-#else
     char a;
     struct D0_extra_packed b;
-#endif
 };
 struct D0_extra_required_alignment var39;
 struct D0_extra_size {
@@ -413,28 +353,22 @@ typedef struct {
 RB0 var41;
 #pragma pack()
 struct RB0_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(RB0)];
-    char b;
-#else
     char a;
     RB0 b;
-#endif
 };
 struct RB0_extra_alignment var42;
 #pragma pack(1)
 struct RB0_extra_packed {
+#ifdef MSVC
+    char a[sizeof(RB0)];
+#else
     RB0 a;
+#endif
 };
 #pragma pack()
 struct RB0_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct RB0_extra_packed)];
-    char b;
-#else
     char a;
     struct RB0_extra_packed b;
-#endif
 };
 struct RB0_extra_required_alignment var43;
 struct RB0_extra_size {
@@ -455,28 +389,22 @@ typedef struct {
 RC var45;
 #pragma pack()
 struct RC_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(RC)];
-    char b;
-#else
     char a;
     RC b;
-#endif
 };
 struct RC_extra_alignment var46;
 #pragma pack(1)
 struct RC_extra_packed {
+#ifdef MSVC
+    char a[sizeof(RC)];
+#else
     RC a;
+#endif
 };
 #pragma pack()
 struct RC_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct RC_extra_packed)];
-    char b;
-#else
     char a;
     struct RC_extra_packed b;
-#endif
 };
 struct RC_extra_required_alignment var47;
 struct RC_extra_size {
@@ -493,28 +421,22 @@ typedef struct {
 RE var49;
 #pragma pack()
 struct RE_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(RE)];
-    char b;
-#else
     char a;
     RE b;
-#endif
 };
 struct RE_extra_alignment var50;
 #pragma pack(1)
 struct RE_extra_packed {
+#ifdef MSVC
+    char a[sizeof(RE)];
+#else
     RE a;
+#endif
 };
 #pragma pack()
 struct RE_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct RE_extra_packed)];
-    char b;
-#else
     char a;
     struct RE_extra_packed b;
-#endif
 };
 struct RE_extra_required_alignment var51;
 struct RE_extra_size {
@@ -536,28 +458,22 @@ typedef struct {
 #endif
 PA var53;
 struct PA_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(PA)];
-    char b;
-#else
     char a;
     PA b;
-#endif
 };
 struct PA_extra_alignment var54;
 #pragma pack(1)
 struct PA_extra_packed {
+#ifdef MSVC
+    char a[sizeof(PA)];
+#else
     PA a;
+#endif
 };
 #pragma pack()
 struct PA_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct PA_extra_packed)];
-    char b;
-#else
     char a;
     struct PA_extra_packed b;
-#endif
 };
 struct PA_extra_required_alignment var55;
 struct PA_extra_size {
@@ -573,28 +489,22 @@ typedef PA PB __attribute__((aligned(8)));
 #endif
 PB var57;
 struct PB_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(PB)];
-    char b;
-#else
     char a;
     PB b;
-#endif
 };
 struct PB_extra_alignment var58;
 #pragma pack(1)
 struct PB_extra_packed {
+#ifdef MSVC
+    char a[sizeof(PB)];
+#else
     PB a;
+#endif
 };
 #pragma pack()
 struct PB_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct PB_extra_packed)];
-    char b;
-#else
     char a;
     struct PB_extra_packed b;
-#endif
 };
 struct PB_extra_required_alignment var59;
 struct PB_extra_size {
@@ -611,28 +521,22 @@ typedef struct {
 PC var61;
 #pragma pack()
 struct PC_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(PC)];
-    char b;
-#else
     char a;
     PC b;
-#endif
 };
 struct PC_extra_alignment var62;
 #pragma pack(1)
 struct PC_extra_packed {
+#ifdef MSVC
+    char a[sizeof(PC)];
+#else
     PC a;
+#endif
 };
 #pragma pack()
 struct PC_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct PC_extra_packed)];
-    char b;
-#else
     char a;
     struct PC_extra_packed b;
-#endif
 };
 struct PC_extra_required_alignment var63;
 struct PC_extra_size {
@@ -644,28 +548,22 @@ struct PC_extra_size var64;
 typedef PB PD;
 PD var65;
 struct PD_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(PD)];
-    char b;
-#else
     char a;
     PD b;
-#endif
 };
 struct PD_extra_alignment var66;
 #pragma pack(1)
 struct PD_extra_packed {
+#ifdef MSVC
+    char a[sizeof(PD)];
+#else
     PD a;
+#endif
 };
 #pragma pack()
 struct PD_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct PD_extra_packed)];
-    char b;
-#else
     char a;
     struct PD_extra_packed b;
-#endif
 };
 struct PD_extra_required_alignment var67;
 struct PD_extra_size {
@@ -682,28 +580,22 @@ typedef struct {
 PE var69;
 #pragma pack()
 struct PE_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(PE)];
-    char b;
-#else
     char a;
     PE b;
-#endif
 };
 struct PE_extra_alignment var70;
 #pragma pack(1)
 struct PE_extra_packed {
+#ifdef MSVC
+    char a[sizeof(PE)];
+#else
     PE a;
+#endif
 };
 #pragma pack()
 struct PE_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct PE_extra_packed)];
-    char b;
-#else
     char a;
     struct PE_extra_packed b;
-#endif
 };
 struct PE_extra_required_alignment var71;
 struct PE_extra_size {
@@ -719,28 +611,22 @@ typedef int QA __attribute__((aligned(2)));
 #endif
 QA var73;
 struct QA_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(QA)];
-    char b;
-#else
     char a;
     QA b;
-#endif
 };
 struct QA_extra_alignment var74;
 #pragma pack(1)
 struct QA_extra_packed {
+#ifdef MSVC
+    char a[sizeof(QA)];
+#else
     QA a;
+#endif
 };
 #pragma pack()
 struct QA_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct QA_extra_packed)];
-    char b;
-#else
     char a;
     struct QA_extra_packed b;
-#endif
 };
 struct QA_extra_required_alignment var75;
 struct QA_extra_size {
@@ -757,28 +643,22 @@ typedef struct {
 QB var77;
 #pragma pack()
 struct QB_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(QB)];
-    char b;
-#else
     char a;
     QB b;
-#endif
 };
 struct QB_extra_alignment var78;
 #pragma pack(1)
 struct QB_extra_packed {
+#ifdef MSVC
+    char a[sizeof(QB)];
+#else
     QB a;
+#endif
 };
 #pragma pack()
 struct QB_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct QB_extra_packed)];
-    char b;
-#else
     char a;
     struct QB_extra_packed b;
-#endif
 };
 struct QB_extra_required_alignment var79;
 struct QB_extra_size {
@@ -793,28 +673,22 @@ typedef struct {
 } QC;
 QC var81;
 struct QC_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(QC)];
-    char b;
-#else
     char a;
     QC b;
-#endif
 };
 struct QC_extra_alignment var82;
 #pragma pack(1)
 struct QC_extra_packed {
+#ifdef MSVC
+    char a[sizeof(QC)];
+#else
     QC a;
+#endif
 };
 #pragma pack()
 struct QC_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct QC_extra_packed)];
-    char b;
-#else
     char a;
     struct QC_extra_packed b;
-#endif
 };
 struct QC_extra_required_alignment var83;
 struct QC_extra_size {
@@ -829,28 +703,22 @@ typedef struct {
 } QD;
 QD var85;
 struct QD_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(QD)];
-    char b;
-#else
     char a;
     QD b;
-#endif
 };
 struct QD_extra_alignment var86;
 #pragma pack(1)
 struct QD_extra_packed {
+#ifdef MSVC
+    char a[sizeof(QD)];
+#else
     QD a;
+#endif
 };
 #pragma pack()
 struct QD_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct QD_extra_packed)];
-    char b;
-#else
     char a;
     struct QD_extra_packed b;
-#endif
 };
 struct QD_extra_required_alignment var87;
 struct QD_extra_size {
@@ -866,28 +734,22 @@ typedef long long unnamed_type_89[0];
 #endif
 unnamed_type_89 var90;
 struct unnamed_type_89_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_89)];
-    char b;
-#else
     char a;
     unnamed_type_89 b;
-#endif
 };
 struct unnamed_type_89_extra_alignment var91;
 #pragma pack(1)
 struct unnamed_type_89_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_89)];
+#else
     unnamed_type_89 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_89_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_89_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_89_extra_packed b;
-#endif
 };
 struct unnamed_type_89_extra_required_alignment var92;
 struct unnamed_type_89_extra_size {
@@ -909,28 +771,22 @@ typedef struct {
 #endif
 EmptyAlignedLongLongMemb var94;
 struct EmptyAlignedLongLongMemb_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(EmptyAlignedLongLongMemb)];
-    char b;
-#else
     char a;
     EmptyAlignedLongLongMemb b;
-#endif
 };
 struct EmptyAlignedLongLongMemb_extra_alignment var95;
 #pragma pack(1)
 struct EmptyAlignedLongLongMemb_extra_packed {
+#ifdef MSVC
+    char a[sizeof(EmptyAlignedLongLongMemb)];
+#else
     EmptyAlignedLongLongMemb a;
+#endif
 };
 #pragma pack()
 struct EmptyAlignedLongLongMemb_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct EmptyAlignedLongLongMemb_extra_packed)];
-    char b;
-#else
     char a;
     struct EmptyAlignedLongLongMemb_extra_packed b;
-#endif
 };
 struct EmptyAlignedLongLongMemb_extra_required_alignment var96;
 struct EmptyAlignedLongLongMemb_extra_size {
@@ -946,28 +802,22 @@ typedef long long unnamed_type_98[0];
 #endif
 unnamed_type_98 var99;
 struct unnamed_type_98_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_98)];
-    char b;
-#else
     char a;
     unnamed_type_98 b;
-#endif
 };
 struct unnamed_type_98_extra_alignment var100;
 #pragma pack(1)
 struct unnamed_type_98_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_98)];
+#else
     unnamed_type_98 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_98_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_98_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_98_extra_packed b;
-#endif
 };
 struct unnamed_type_98_extra_required_alignment var101;
 struct unnamed_type_98_extra_size {
@@ -991,28 +841,22 @@ typedef struct {
 EmptyPackedAlignedLongLongMemb var103;
 #pragma pack()
 struct EmptyPackedAlignedLongLongMemb_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(EmptyPackedAlignedLongLongMemb)];
-    char b;
-#else
     char a;
     EmptyPackedAlignedLongLongMemb b;
-#endif
 };
 struct EmptyPackedAlignedLongLongMemb_extra_alignment var104;
 #pragma pack(1)
 struct EmptyPackedAlignedLongLongMemb_extra_packed {
+#ifdef MSVC
+    char a[sizeof(EmptyPackedAlignedLongLongMemb)];
+#else
     EmptyPackedAlignedLongLongMemb a;
+#endif
 };
 #pragma pack()
 struct EmptyPackedAlignedLongLongMemb_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct EmptyPackedAlignedLongLongMemb_extra_packed)];
-    char b;
-#else
     char a;
     struct EmptyPackedAlignedLongLongMemb_extra_packed b;
-#endif
 };
 struct EmptyPackedAlignedLongLongMemb_extra_required_alignment var105;
 struct EmptyPackedAlignedLongLongMemb_extra_size {

--- a/test/records/0045_test.c
+++ b/test/records/0045_test.c
@@ -8,28 +8,22 @@
 typedef char unnamed_type_1[3];
 unnamed_type_1 var2;
 struct unnamed_type_1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_1)];
-    char b;
-#else
     char a;
     unnamed_type_1 b;
-#endif
 };
 struct unnamed_type_1_extra_alignment var3;
 #pragma pack(1)
 struct unnamed_type_1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_1)];
+#else
     unnamed_type_1 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_1_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_1_extra_packed b;
-#endif
 };
 struct unnamed_type_1_extra_required_alignment var4;
 struct unnamed_type_1_extra_size {
@@ -45,28 +39,22 @@ typedef unnamed_type_1 A __attribute__((aligned(2)));
 #endif
 A var6;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var7;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var8;
 struct A_extra_size {
@@ -78,28 +66,22 @@ struct A_extra_size var9;
 typedef A B[3];
 B var10;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var11;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var12;
 struct B_extra_size {
@@ -111,28 +93,22 @@ struct B_extra_size var13;
 typedef char C[3];
 C var14;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var15;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var16;
 struct C_extra_size {
@@ -148,28 +124,22 @@ typedef B D[0];
 #endif
 D var18;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var19;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var20;
 struct D_extra_size {
@@ -184,28 +154,22 @@ typedef struct {
 } E;
 E var22;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var23;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var24;
 struct E_extra_size {
@@ -221,28 +185,22 @@ typedef B unnamed_type_26[0];
 #endif
 unnamed_type_26 var27;
 struct unnamed_type_26_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_26)];
-    char b;
-#else
     char a;
     unnamed_type_26 b;
-#endif
 };
 struct unnamed_type_26_extra_alignment var28;
 #pragma pack(1)
 struct unnamed_type_26_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_26)];
+#else
     unnamed_type_26 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_26_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_26_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_26_extra_packed b;
-#endif
 };
 struct unnamed_type_26_extra_required_alignment var29;
 struct unnamed_type_26_extra_size {
@@ -257,28 +215,22 @@ typedef struct {
 } F;
 F var31;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var32;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var33;
 struct F_extra_size {

--- a/test/records/0046_test.c
+++ b/test/records/0046_test.c
@@ -12,28 +12,22 @@ typedef int A __attribute__((aligned(1)));
 #endif
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef char B __attribute__((aligned(8)));
 #endif
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -86,28 +74,22 @@ typedef int C __attribute__((aligned(4)));
 #endif
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -123,28 +105,22 @@ typedef char unnamed_type_13 __attribute__((aligned(16)));
 #endif
 unnamed_type_13 var14;
 struct unnamed_type_13_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_13)];
-    char b;
-#else
     char a;
     unnamed_type_13 b;
-#endif
 };
 struct unnamed_type_13_extra_alignment var15;
 #pragma pack(1)
 struct unnamed_type_13_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_13)];
+#else
     unnamed_type_13 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_13_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_13_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_13_extra_packed b;
-#endif
 };
 struct unnamed_type_13_extra_required_alignment var16;
 struct unnamed_type_13_extra_size {
@@ -160,28 +136,22 @@ typedef unnamed_type_13 D __attribute__((aligned(4)));
 #endif
 D var18;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var19;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var20;
 struct D_extra_size {

--- a/test/records/0047_test.c
+++ b/test/records/0047_test.c
@@ -12,28 +12,22 @@ typedef struct {
 } X;
 X var1;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var2;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var3;
 struct X_extra_size {
@@ -49,28 +43,22 @@ typedef struct {
 } Y;
 Y var5;
 struct Y_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Y)];
-    char b;
-#else
     char a;
     Y b;
-#endif
 };
 struct Y_extra_alignment var6;
 #pragma pack(1)
 struct Y_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Y)];
+#else
     Y a;
+#endif
 };
 #pragma pack()
 struct Y_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Y_extra_packed)];
-    char b;
-#else
     char a;
     struct Y_extra_packed b;
-#endif
 };
 struct Y_extra_required_alignment var7;
 struct Y_extra_size {

--- a/test/records/0048_test.c
+++ b/test/records/0048_test.c
@@ -15,28 +15,22 @@ typedef struct {
 } X;
 X var1;
 struct X_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(X)];
-    char b;
-#else
     char a;
     X b;
-#endif
 };
 struct X_extra_alignment var2;
 #pragma pack(1)
 struct X_extra_packed {
+#ifdef MSVC
+    char a[sizeof(X)];
+#else
     X a;
+#endif
 };
 #pragma pack()
 struct X_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct X_extra_packed)];
-    char b;
-#else
     char a;
     struct X_extra_packed b;
-#endif
 };
 struct X_extra_required_alignment var3;
 struct X_extra_size {

--- a/test/records/0051_test.c
+++ b/test/records/0051_test.c
@@ -18,28 +18,22 @@ typedef enum {
 #endif
 A var2;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var3;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var4;
 struct A_extra_size {

--- a/test/records/0053_test.c
+++ b/test/records/0053_test.c
@@ -12,28 +12,22 @@ typedef int A[0];
 #endif
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {

--- a/test/records/0054_test.c
+++ b/test/records/0054_test.c
@@ -12,28 +12,22 @@ typedef enum {
 A var2;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var3;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var4;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef enum {
 B var7;
 #pragma pack()
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var8;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var9;
 struct B_extra_size {

--- a/test/records/0055_test.c
+++ b/test/records/0055_test.c
@@ -10,28 +10,22 @@ typedef enum {
 } __attribute__((packed)) A;
 A var2;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var3;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var4;
 struct A_extra_size {
@@ -45,28 +39,22 @@ typedef enum {
 } __attribute__((packed)) B;
 B var7;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var8;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var9;
 struct B_extra_size {

--- a/test/records/0056_test.c
+++ b/test/records/0056_test.c
@@ -10,28 +10,22 @@ typedef struct {
 } __attribute__((packed)) A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -45,28 +39,22 @@ typedef union {
 } __attribute__((packed)) B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {

--- a/test/records/0057_test.c
+++ b/test/records/0057_test.c
@@ -13,28 +13,22 @@ typedef struct {
 A var1;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -52,28 +46,22 @@ typedef struct {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -90,28 +78,22 @@ typedef struct {
 C var9;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -126,28 +108,22 @@ typedef struct {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {
@@ -165,28 +141,22 @@ typedef struct {
 } E;
 E var17;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var18;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var19;
 struct E_extra_size {
@@ -201,28 +171,22 @@ typedef struct {
 } F;
 F var21;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var22;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var23;
 struct F_extra_size {

--- a/test/records/0058_test.c
+++ b/test/records/0058_test.c
@@ -12,28 +12,22 @@ typedef char Char __attribute__((aligned(4)));
 #endif
 Char var1;
 struct Char_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(Char)];
-    char b;
-#else
     char a;
     Char b;
-#endif
 };
 struct Char_extra_alignment var2;
 #pragma pack(1)
 struct Char_extra_packed {
+#ifdef MSVC
+    char a[sizeof(Char)];
+#else
     Char a;
+#endif
 };
 #pragma pack()
 struct Char_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct Char_extra_packed)];
-    char b;
-#else
     char a;
     struct Char_extra_packed b;
-#endif
 };
 struct Char_extra_required_alignment var3;
 struct Char_extra_size {
@@ -48,28 +42,22 @@ typedef struct {
 } __attribute__((packed)) A;
 A var5;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var6;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var7;
 struct A_extra_size {
@@ -88,28 +76,22 @@ typedef struct {
 } __attribute__((packed)) B;
 B var9;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var10;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var11;
 struct B_extra_size {

--- a/test/records/0059_test.c
+++ b/test/records/0059_test.c
@@ -12,28 +12,22 @@ typedef struct {
 } __attribute__((packed)) A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -48,28 +42,22 @@ typedef struct {
 } __attribute__((packed)) B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {

--- a/test/records/0061_test.c
+++ b/test/records/0061_test.c
@@ -12,28 +12,22 @@ typedef enum {
 A var2;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var3;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var4;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef enum {
 B var7;
 #pragma pack()
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var8;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var9;
 struct B_extra_size {
@@ -86,28 +74,22 @@ typedef enum {
 C var12;
 #pragma pack()
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var13;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var14;
 struct C_extra_size {

--- a/test/records/0063_test.c
+++ b/test/records/0063_test.c
@@ -18,28 +18,22 @@ typedef enum {
 #endif
 A var2;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var3;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var4;
 struct A_extra_size {
@@ -61,28 +55,22 @@ typedef enum {
 #endif
 B var7;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var8;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var9;
 struct B_extra_size {

--- a/test/records/0064_test.c
+++ b/test/records/0064_test.c
@@ -16,28 +16,22 @@ typedef struct {
 A00 var1;
 #pragma pack()
 struct A00_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A00)];
-    char b;
-#else
     char a;
     A00 b;
-#endif
 };
 struct A00_extra_alignment var2;
 #pragma pack(1)
 struct A00_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A00)];
+#else
     A00 a;
+#endif
 };
 #pragma pack()
 struct A00_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A00_extra_packed)];
-    char b;
-#else
     char a;
     struct A00_extra_packed b;
-#endif
 };
 struct A00_extra_required_alignment var3;
 struct A00_extra_size {
@@ -57,28 +51,22 @@ typedef struct {
 A01 var5;
 #pragma pack()
 struct A01_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A01)];
-    char b;
-#else
     char a;
     A01 b;
-#endif
 };
 struct A01_extra_alignment var6;
 #pragma pack(1)
 struct A01_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A01)];
+#else
     A01 a;
+#endif
 };
 #pragma pack()
 struct A01_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A01_extra_packed)];
-    char b;
-#else
     char a;
     struct A01_extra_packed b;
-#endif
 };
 struct A01_extra_required_alignment var7;
 struct A01_extra_size {
@@ -98,28 +86,22 @@ typedef struct {
 A02 var9;
 #pragma pack()
 struct A02_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A02)];
-    char b;
-#else
     char a;
     A02 b;
-#endif
 };
 struct A02_extra_alignment var10;
 #pragma pack(1)
 struct A02_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A02)];
+#else
     A02 a;
+#endif
 };
 #pragma pack()
 struct A02_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A02_extra_packed)];
-    char b;
-#else
     char a;
     struct A02_extra_packed b;
-#endif
 };
 struct A02_extra_required_alignment var11;
 struct A02_extra_size {
@@ -139,28 +121,22 @@ typedef struct {
 A03 var13;
 #pragma pack()
 struct A03_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A03)];
-    char b;
-#else
     char a;
     A03 b;
-#endif
 };
 struct A03_extra_alignment var14;
 #pragma pack(1)
 struct A03_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A03)];
+#else
     A03 a;
+#endif
 };
 #pragma pack()
 struct A03_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A03_extra_packed)];
-    char b;
-#else
     char a;
     struct A03_extra_packed b;
-#endif
 };
 struct A03_extra_required_alignment var15;
 struct A03_extra_size {
@@ -180,28 +156,22 @@ typedef struct {
 A04 var17;
 #pragma pack()
 struct A04_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A04)];
-    char b;
-#else
     char a;
     A04 b;
-#endif
 };
 struct A04_extra_alignment var18;
 #pragma pack(1)
 struct A04_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A04)];
+#else
     A04 a;
+#endif
 };
 #pragma pack()
 struct A04_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A04_extra_packed)];
-    char b;
-#else
     char a;
     struct A04_extra_packed b;
-#endif
 };
 struct A04_extra_required_alignment var19;
 struct A04_extra_size {
@@ -221,28 +191,22 @@ typedef struct {
 A05 var21;
 #pragma pack()
 struct A05_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A05)];
-    char b;
-#else
     char a;
     A05 b;
-#endif
 };
 struct A05_extra_alignment var22;
 #pragma pack(1)
 struct A05_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A05)];
+#else
     A05 a;
+#endif
 };
 #pragma pack()
 struct A05_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A05_extra_packed)];
-    char b;
-#else
     char a;
     struct A05_extra_packed b;
-#endif
 };
 struct A05_extra_required_alignment var23;
 struct A05_extra_size {
@@ -262,28 +226,22 @@ typedef struct {
 A06 var25;
 #pragma pack()
 struct A06_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A06)];
-    char b;
-#else
     char a;
     A06 b;
-#endif
 };
 struct A06_extra_alignment var26;
 #pragma pack(1)
 struct A06_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A06)];
+#else
     A06 a;
+#endif
 };
 #pragma pack()
 struct A06_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A06_extra_packed)];
-    char b;
-#else
     char a;
     struct A06_extra_packed b;
-#endif
 };
 struct A06_extra_required_alignment var27;
 struct A06_extra_size {
@@ -303,28 +261,22 @@ typedef struct {
 A07 var29;
 #pragma pack()
 struct A07_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A07)];
-    char b;
-#else
     char a;
     A07 b;
-#endif
 };
 struct A07_extra_alignment var30;
 #pragma pack(1)
 struct A07_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A07)];
+#else
     A07 a;
+#endif
 };
 #pragma pack()
 struct A07_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A07_extra_packed)];
-    char b;
-#else
     char a;
     struct A07_extra_packed b;
-#endif
 };
 struct A07_extra_required_alignment var31;
 struct A07_extra_size {
@@ -344,28 +296,22 @@ typedef struct {
 A08 var33;
 #pragma pack()
 struct A08_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A08)];
-    char b;
-#else
     char a;
     A08 b;
-#endif
 };
 struct A08_extra_alignment var34;
 #pragma pack(1)
 struct A08_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A08)];
+#else
     A08 a;
+#endif
 };
 #pragma pack()
 struct A08_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A08_extra_packed)];
-    char b;
-#else
     char a;
     struct A08_extra_packed b;
-#endif
 };
 struct A08_extra_required_alignment var35;
 struct A08_extra_size {
@@ -385,28 +331,22 @@ typedef struct {
 A09 var37;
 #pragma pack()
 struct A09_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A09)];
-    char b;
-#else
     char a;
     A09 b;
-#endif
 };
 struct A09_extra_alignment var38;
 #pragma pack(1)
 struct A09_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A09)];
+#else
     A09 a;
+#endif
 };
 #pragma pack()
 struct A09_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A09_extra_packed)];
-    char b;
-#else
     char a;
     struct A09_extra_packed b;
-#endif
 };
 struct A09_extra_required_alignment var39;
 struct A09_extra_size {
@@ -426,28 +366,22 @@ typedef struct {
 A10 var41;
 #pragma pack()
 struct A10_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A10)];
-    char b;
-#else
     char a;
     A10 b;
-#endif
 };
 struct A10_extra_alignment var42;
 #pragma pack(1)
 struct A10_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A10)];
+#else
     A10 a;
+#endif
 };
 #pragma pack()
 struct A10_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A10_extra_packed)];
-    char b;
-#else
     char a;
     struct A10_extra_packed b;
-#endif
 };
 struct A10_extra_required_alignment var43;
 struct A10_extra_size {
@@ -467,28 +401,22 @@ typedef struct {
 A11 var45;
 #pragma pack()
 struct A11_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A11)];
-    char b;
-#else
     char a;
     A11 b;
-#endif
 };
 struct A11_extra_alignment var46;
 #pragma pack(1)
 struct A11_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A11)];
+#else
     A11 a;
+#endif
 };
 #pragma pack()
 struct A11_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A11_extra_packed)];
-    char b;
-#else
     char a;
     struct A11_extra_packed b;
-#endif
 };
 struct A11_extra_required_alignment var47;
 struct A11_extra_size {
@@ -508,28 +436,22 @@ typedef struct {
 A12 var49;
 #pragma pack()
 struct A12_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A12)];
-    char b;
-#else
     char a;
     A12 b;
-#endif
 };
 struct A12_extra_alignment var50;
 #pragma pack(1)
 struct A12_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A12)];
+#else
     A12 a;
+#endif
 };
 #pragma pack()
 struct A12_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A12_extra_packed)];
-    char b;
-#else
     char a;
     struct A12_extra_packed b;
-#endif
 };
 struct A12_extra_required_alignment var51;
 struct A12_extra_size {
@@ -549,28 +471,22 @@ typedef struct {
 A13 var53;
 #pragma pack()
 struct A13_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A13)];
-    char b;
-#else
     char a;
     A13 b;
-#endif
 };
 struct A13_extra_alignment var54;
 #pragma pack(1)
 struct A13_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A13)];
+#else
     A13 a;
+#endif
 };
 #pragma pack()
 struct A13_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A13_extra_packed)];
-    char b;
-#else
     char a;
     struct A13_extra_packed b;
-#endif
 };
 struct A13_extra_required_alignment var55;
 struct A13_extra_size {
@@ -590,28 +506,22 @@ typedef struct {
 A14 var57;
 #pragma pack()
 struct A14_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A14)];
-    char b;
-#else
     char a;
     A14 b;
-#endif
 };
 struct A14_extra_alignment var58;
 #pragma pack(1)
 struct A14_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A14)];
+#else
     A14 a;
+#endif
 };
 #pragma pack()
 struct A14_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A14_extra_packed)];
-    char b;
-#else
     char a;
     struct A14_extra_packed b;
-#endif
 };
 struct A14_extra_required_alignment var59;
 struct A14_extra_size {
@@ -631,28 +541,22 @@ typedef struct {
 A15 var61;
 #pragma pack()
 struct A15_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A15)];
-    char b;
-#else
     char a;
     A15 b;
-#endif
 };
 struct A15_extra_alignment var62;
 #pragma pack(1)
 struct A15_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A15)];
+#else
     A15 a;
+#endif
 };
 #pragma pack()
 struct A15_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A15_extra_packed)];
-    char b;
-#else
     char a;
     struct A15_extra_packed b;
-#endif
 };
 struct A15_extra_required_alignment var63;
 struct A15_extra_size {
@@ -672,28 +576,22 @@ typedef struct {
 A16 var65;
 #pragma pack()
 struct A16_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A16)];
-    char b;
-#else
     char a;
     A16 b;
-#endif
 };
 struct A16_extra_alignment var66;
 #pragma pack(1)
 struct A16_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A16)];
+#else
     A16 a;
+#endif
 };
 #pragma pack()
 struct A16_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A16_extra_packed)];
-    char b;
-#else
     char a;
     struct A16_extra_packed b;
-#endif
 };
 struct A16_extra_required_alignment var67;
 struct A16_extra_size {
@@ -713,28 +611,22 @@ typedef struct {
 A17 var69;
 #pragma pack()
 struct A17_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A17)];
-    char b;
-#else
     char a;
     A17 b;
-#endif
 };
 struct A17_extra_alignment var70;
 #pragma pack(1)
 struct A17_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A17)];
+#else
     A17 a;
+#endif
 };
 #pragma pack()
 struct A17_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A17_extra_packed)];
-    char b;
-#else
     char a;
     struct A17_extra_packed b;
-#endif
 };
 struct A17_extra_required_alignment var71;
 struct A17_extra_size {
@@ -754,28 +646,22 @@ typedef struct {
 A18 var73;
 #pragma pack()
 struct A18_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A18)];
-    char b;
-#else
     char a;
     A18 b;
-#endif
 };
 struct A18_extra_alignment var74;
 #pragma pack(1)
 struct A18_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A18)];
+#else
     A18 a;
+#endif
 };
 #pragma pack()
 struct A18_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A18_extra_packed)];
-    char b;
-#else
     char a;
     struct A18_extra_packed b;
-#endif
 };
 struct A18_extra_required_alignment var75;
 struct A18_extra_size {
@@ -795,28 +681,22 @@ typedef struct {
 A19 var77;
 #pragma pack()
 struct A19_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A19)];
-    char b;
-#else
     char a;
     A19 b;
-#endif
 };
 struct A19_extra_alignment var78;
 #pragma pack(1)
 struct A19_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A19)];
+#else
     A19 a;
+#endif
 };
 #pragma pack()
 struct A19_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A19_extra_packed)];
-    char b;
-#else
     char a;
     struct A19_extra_packed b;
-#endif
 };
 struct A19_extra_required_alignment var79;
 struct A19_extra_size {
@@ -836,28 +716,22 @@ typedef struct {
 A20 var81;
 #pragma pack()
 struct A20_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A20)];
-    char b;
-#else
     char a;
     A20 b;
-#endif
 };
 struct A20_extra_alignment var82;
 #pragma pack(1)
 struct A20_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A20)];
+#else
     A20 a;
+#endif
 };
 #pragma pack()
 struct A20_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A20_extra_packed)];
-    char b;
-#else
     char a;
     struct A20_extra_packed b;
-#endif
 };
 struct A20_extra_required_alignment var83;
 struct A20_extra_size {
@@ -877,28 +751,22 @@ typedef struct {
 A21 var85;
 #pragma pack()
 struct A21_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A21)];
-    char b;
-#else
     char a;
     A21 b;
-#endif
 };
 struct A21_extra_alignment var86;
 #pragma pack(1)
 struct A21_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A21)];
+#else
     A21 a;
+#endif
 };
 #pragma pack()
 struct A21_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A21_extra_packed)];
-    char b;
-#else
     char a;
     struct A21_extra_packed b;
-#endif
 };
 struct A21_extra_required_alignment var87;
 struct A21_extra_size {
@@ -918,28 +786,22 @@ typedef struct {
 A22 var89;
 #pragma pack()
 struct A22_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A22)];
-    char b;
-#else
     char a;
     A22 b;
-#endif
 };
 struct A22_extra_alignment var90;
 #pragma pack(1)
 struct A22_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A22)];
+#else
     A22 a;
+#endif
 };
 #pragma pack()
 struct A22_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A22_extra_packed)];
-    char b;
-#else
     char a;
     struct A22_extra_packed b;
-#endif
 };
 struct A22_extra_required_alignment var91;
 struct A22_extra_size {
@@ -959,28 +821,22 @@ typedef struct {
 A23 var93;
 #pragma pack()
 struct A23_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A23)];
-    char b;
-#else
     char a;
     A23 b;
-#endif
 };
 struct A23_extra_alignment var94;
 #pragma pack(1)
 struct A23_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A23)];
+#else
     A23 a;
+#endif
 };
 #pragma pack()
 struct A23_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A23_extra_packed)];
-    char b;
-#else
     char a;
     struct A23_extra_packed b;
-#endif
 };
 struct A23_extra_required_alignment var95;
 struct A23_extra_size {
@@ -1000,28 +856,22 @@ typedef struct {
 A24 var97;
 #pragma pack()
 struct A24_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A24)];
-    char b;
-#else
     char a;
     A24 b;
-#endif
 };
 struct A24_extra_alignment var98;
 #pragma pack(1)
 struct A24_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A24)];
+#else
     A24 a;
+#endif
 };
 #pragma pack()
 struct A24_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A24_extra_packed)];
-    char b;
-#else
     char a;
     struct A24_extra_packed b;
-#endif
 };
 struct A24_extra_required_alignment var99;
 struct A24_extra_size {
@@ -1041,28 +891,22 @@ typedef struct {
 A25 var101;
 #pragma pack()
 struct A25_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A25)];
-    char b;
-#else
     char a;
     A25 b;
-#endif
 };
 struct A25_extra_alignment var102;
 #pragma pack(1)
 struct A25_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A25)];
+#else
     A25 a;
+#endif
 };
 #pragma pack()
 struct A25_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A25_extra_packed)];
-    char b;
-#else
     char a;
     struct A25_extra_packed b;
-#endif
 };
 struct A25_extra_required_alignment var103;
 struct A25_extra_size {
@@ -1082,28 +926,22 @@ typedef struct {
 A26 var105;
 #pragma pack()
 struct A26_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A26)];
-    char b;
-#else
     char a;
     A26 b;
-#endif
 };
 struct A26_extra_alignment var106;
 #pragma pack(1)
 struct A26_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A26)];
+#else
     A26 a;
+#endif
 };
 #pragma pack()
 struct A26_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A26_extra_packed)];
-    char b;
-#else
     char a;
     struct A26_extra_packed b;
-#endif
 };
 struct A26_extra_required_alignment var107;
 struct A26_extra_size {
@@ -1123,28 +961,22 @@ typedef struct {
 A27 var109;
 #pragma pack()
 struct A27_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A27)];
-    char b;
-#else
     char a;
     A27 b;
-#endif
 };
 struct A27_extra_alignment var110;
 #pragma pack(1)
 struct A27_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A27)];
+#else
     A27 a;
+#endif
 };
 #pragma pack()
 struct A27_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A27_extra_packed)];
-    char b;
-#else
     char a;
     struct A27_extra_packed b;
-#endif
 };
 struct A27_extra_required_alignment var111;
 struct A27_extra_size {
@@ -1164,28 +996,22 @@ typedef struct {
 A28 var113;
 #pragma pack()
 struct A28_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A28)];
-    char b;
-#else
     char a;
     A28 b;
-#endif
 };
 struct A28_extra_alignment var114;
 #pragma pack(1)
 struct A28_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A28)];
+#else
     A28 a;
+#endif
 };
 #pragma pack()
 struct A28_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A28_extra_packed)];
-    char b;
-#else
     char a;
     struct A28_extra_packed b;
-#endif
 };
 struct A28_extra_required_alignment var115;
 struct A28_extra_size {
@@ -1205,28 +1031,22 @@ typedef struct {
 A29 var117;
 #pragma pack()
 struct A29_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A29)];
-    char b;
-#else
     char a;
     A29 b;
-#endif
 };
 struct A29_extra_alignment var118;
 #pragma pack(1)
 struct A29_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A29)];
+#else
     A29 a;
+#endif
 };
 #pragma pack()
 struct A29_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A29_extra_packed)];
-    char b;
-#else
     char a;
     struct A29_extra_packed b;
-#endif
 };
 struct A29_extra_required_alignment var119;
 struct A29_extra_size {
@@ -1246,28 +1066,22 @@ typedef struct {
 A30 var121;
 #pragma pack()
 struct A30_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A30)];
-    char b;
-#else
     char a;
     A30 b;
-#endif
 };
 struct A30_extra_alignment var122;
 #pragma pack(1)
 struct A30_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A30)];
+#else
     A30 a;
+#endif
 };
 #pragma pack()
 struct A30_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A30_extra_packed)];
-    char b;
-#else
     char a;
     struct A30_extra_packed b;
-#endif
 };
 struct A30_extra_required_alignment var123;
 struct A30_extra_size {
@@ -1287,28 +1101,22 @@ typedef struct {
 A31 var125;
 #pragma pack()
 struct A31_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A31)];
-    char b;
-#else
     char a;
     A31 b;
-#endif
 };
 struct A31_extra_alignment var126;
 #pragma pack(1)
 struct A31_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A31)];
+#else
     A31 a;
+#endif
 };
 #pragma pack()
 struct A31_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A31_extra_packed)];
-    char b;
-#else
     char a;
     struct A31_extra_packed b;
-#endif
 };
 struct A31_extra_required_alignment var127;
 struct A31_extra_size {
@@ -1328,28 +1136,22 @@ typedef struct {
 A32 var129;
 #pragma pack()
 struct A32_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A32)];
-    char b;
-#else
     char a;
     A32 b;
-#endif
 };
 struct A32_extra_alignment var130;
 #pragma pack(1)
 struct A32_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A32)];
+#else
     A32 a;
+#endif
 };
 #pragma pack()
 struct A32_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A32_extra_packed)];
-    char b;
-#else
     char a;
     struct A32_extra_packed b;
-#endif
 };
 struct A32_extra_required_alignment var131;
 struct A32_extra_size {
@@ -1369,28 +1171,22 @@ typedef struct {
 A33 var133;
 #pragma pack()
 struct A33_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A33)];
-    char b;
-#else
     char a;
     A33 b;
-#endif
 };
 struct A33_extra_alignment var134;
 #pragma pack(1)
 struct A33_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A33)];
+#else
     A33 a;
+#endif
 };
 #pragma pack()
 struct A33_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A33_extra_packed)];
-    char b;
-#else
     char a;
     struct A33_extra_packed b;
-#endif
 };
 struct A33_extra_required_alignment var135;
 struct A33_extra_size {
@@ -1410,28 +1206,22 @@ typedef struct {
 A34 var137;
 #pragma pack()
 struct A34_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A34)];
-    char b;
-#else
     char a;
     A34 b;
-#endif
 };
 struct A34_extra_alignment var138;
 #pragma pack(1)
 struct A34_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A34)];
+#else
     A34 a;
+#endif
 };
 #pragma pack()
 struct A34_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A34_extra_packed)];
-    char b;
-#else
     char a;
     struct A34_extra_packed b;
-#endif
 };
 struct A34_extra_required_alignment var139;
 struct A34_extra_size {
@@ -1451,28 +1241,22 @@ typedef struct {
 A35 var141;
 #pragma pack()
 struct A35_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A35)];
-    char b;
-#else
     char a;
     A35 b;
-#endif
 };
 struct A35_extra_alignment var142;
 #pragma pack(1)
 struct A35_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A35)];
+#else
     A35 a;
+#endif
 };
 #pragma pack()
 struct A35_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A35_extra_packed)];
-    char b;
-#else
     char a;
     struct A35_extra_packed b;
-#endif
 };
 struct A35_extra_required_alignment var143;
 struct A35_extra_size {
@@ -1492,28 +1276,22 @@ typedef struct {
 A36 var145;
 #pragma pack()
 struct A36_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A36)];
-    char b;
-#else
     char a;
     A36 b;
-#endif
 };
 struct A36_extra_alignment var146;
 #pragma pack(1)
 struct A36_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A36)];
+#else
     A36 a;
+#endif
 };
 #pragma pack()
 struct A36_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A36_extra_packed)];
-    char b;
-#else
     char a;
     struct A36_extra_packed b;
-#endif
 };
 struct A36_extra_required_alignment var147;
 struct A36_extra_size {
@@ -1533,28 +1311,22 @@ typedef struct {
 A37 var149;
 #pragma pack()
 struct A37_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A37)];
-    char b;
-#else
     char a;
     A37 b;
-#endif
 };
 struct A37_extra_alignment var150;
 #pragma pack(1)
 struct A37_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A37)];
+#else
     A37 a;
+#endif
 };
 #pragma pack()
 struct A37_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A37_extra_packed)];
-    char b;
-#else
     char a;
     struct A37_extra_packed b;
-#endif
 };
 struct A37_extra_required_alignment var151;
 struct A37_extra_size {
@@ -1574,28 +1346,22 @@ typedef struct {
 A38 var153;
 #pragma pack()
 struct A38_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A38)];
-    char b;
-#else
     char a;
     A38 b;
-#endif
 };
 struct A38_extra_alignment var154;
 #pragma pack(1)
 struct A38_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A38)];
+#else
     A38 a;
+#endif
 };
 #pragma pack()
 struct A38_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A38_extra_packed)];
-    char b;
-#else
     char a;
     struct A38_extra_packed b;
-#endif
 };
 struct A38_extra_required_alignment var155;
 struct A38_extra_size {
@@ -1615,28 +1381,22 @@ typedef struct {
 A39 var157;
 #pragma pack()
 struct A39_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A39)];
-    char b;
-#else
     char a;
     A39 b;
-#endif
 };
 struct A39_extra_alignment var158;
 #pragma pack(1)
 struct A39_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A39)];
+#else
     A39 a;
+#endif
 };
 #pragma pack()
 struct A39_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A39_extra_packed)];
-    char b;
-#else
     char a;
     struct A39_extra_packed b;
-#endif
 };
 struct A39_extra_required_alignment var159;
 struct A39_extra_size {
@@ -1656,28 +1416,22 @@ typedef union {
 B00 var161;
 #pragma pack()
 struct B00_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B00)];
-    char b;
-#else
     char a;
     B00 b;
-#endif
 };
 struct B00_extra_alignment var162;
 #pragma pack(1)
 struct B00_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B00)];
+#else
     B00 a;
+#endif
 };
 #pragma pack()
 struct B00_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B00_extra_packed)];
-    char b;
-#else
     char a;
     struct B00_extra_packed b;
-#endif
 };
 struct B00_extra_required_alignment var163;
 struct B00_extra_size {
@@ -1697,28 +1451,22 @@ typedef union {
 B01 var165;
 #pragma pack()
 struct B01_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B01)];
-    char b;
-#else
     char a;
     B01 b;
-#endif
 };
 struct B01_extra_alignment var166;
 #pragma pack(1)
 struct B01_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B01)];
+#else
     B01 a;
+#endif
 };
 #pragma pack()
 struct B01_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B01_extra_packed)];
-    char b;
-#else
     char a;
     struct B01_extra_packed b;
-#endif
 };
 struct B01_extra_required_alignment var167;
 struct B01_extra_size {
@@ -1738,28 +1486,22 @@ typedef union {
 B02 var169;
 #pragma pack()
 struct B02_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B02)];
-    char b;
-#else
     char a;
     B02 b;
-#endif
 };
 struct B02_extra_alignment var170;
 #pragma pack(1)
 struct B02_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B02)];
+#else
     B02 a;
+#endif
 };
 #pragma pack()
 struct B02_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B02_extra_packed)];
-    char b;
-#else
     char a;
     struct B02_extra_packed b;
-#endif
 };
 struct B02_extra_required_alignment var171;
 struct B02_extra_size {
@@ -1779,28 +1521,22 @@ typedef union {
 B03 var173;
 #pragma pack()
 struct B03_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B03)];
-    char b;
-#else
     char a;
     B03 b;
-#endif
 };
 struct B03_extra_alignment var174;
 #pragma pack(1)
 struct B03_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B03)];
+#else
     B03 a;
+#endif
 };
 #pragma pack()
 struct B03_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B03_extra_packed)];
-    char b;
-#else
     char a;
     struct B03_extra_packed b;
-#endif
 };
 struct B03_extra_required_alignment var175;
 struct B03_extra_size {
@@ -1820,28 +1556,22 @@ typedef union {
 B04 var177;
 #pragma pack()
 struct B04_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B04)];
-    char b;
-#else
     char a;
     B04 b;
-#endif
 };
 struct B04_extra_alignment var178;
 #pragma pack(1)
 struct B04_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B04)];
+#else
     B04 a;
+#endif
 };
 #pragma pack()
 struct B04_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B04_extra_packed)];
-    char b;
-#else
     char a;
     struct B04_extra_packed b;
-#endif
 };
 struct B04_extra_required_alignment var179;
 struct B04_extra_size {
@@ -1861,28 +1591,22 @@ typedef union {
 B05 var181;
 #pragma pack()
 struct B05_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B05)];
-    char b;
-#else
     char a;
     B05 b;
-#endif
 };
 struct B05_extra_alignment var182;
 #pragma pack(1)
 struct B05_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B05)];
+#else
     B05 a;
+#endif
 };
 #pragma pack()
 struct B05_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B05_extra_packed)];
-    char b;
-#else
     char a;
     struct B05_extra_packed b;
-#endif
 };
 struct B05_extra_required_alignment var183;
 struct B05_extra_size {
@@ -1902,28 +1626,22 @@ typedef union {
 B06 var185;
 #pragma pack()
 struct B06_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B06)];
-    char b;
-#else
     char a;
     B06 b;
-#endif
 };
 struct B06_extra_alignment var186;
 #pragma pack(1)
 struct B06_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B06)];
+#else
     B06 a;
+#endif
 };
 #pragma pack()
 struct B06_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B06_extra_packed)];
-    char b;
-#else
     char a;
     struct B06_extra_packed b;
-#endif
 };
 struct B06_extra_required_alignment var187;
 struct B06_extra_size {
@@ -1943,28 +1661,22 @@ typedef union {
 B07 var189;
 #pragma pack()
 struct B07_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B07)];
-    char b;
-#else
     char a;
     B07 b;
-#endif
 };
 struct B07_extra_alignment var190;
 #pragma pack(1)
 struct B07_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B07)];
+#else
     B07 a;
+#endif
 };
 #pragma pack()
 struct B07_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B07_extra_packed)];
-    char b;
-#else
     char a;
     struct B07_extra_packed b;
-#endif
 };
 struct B07_extra_required_alignment var191;
 struct B07_extra_size {
@@ -1984,28 +1696,22 @@ typedef union {
 B08 var193;
 #pragma pack()
 struct B08_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B08)];
-    char b;
-#else
     char a;
     B08 b;
-#endif
 };
 struct B08_extra_alignment var194;
 #pragma pack(1)
 struct B08_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B08)];
+#else
     B08 a;
+#endif
 };
 #pragma pack()
 struct B08_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B08_extra_packed)];
-    char b;
-#else
     char a;
     struct B08_extra_packed b;
-#endif
 };
 struct B08_extra_required_alignment var195;
 struct B08_extra_size {
@@ -2025,28 +1731,22 @@ typedef union {
 B09 var197;
 #pragma pack()
 struct B09_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B09)];
-    char b;
-#else
     char a;
     B09 b;
-#endif
 };
 struct B09_extra_alignment var198;
 #pragma pack(1)
 struct B09_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B09)];
+#else
     B09 a;
+#endif
 };
 #pragma pack()
 struct B09_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B09_extra_packed)];
-    char b;
-#else
     char a;
     struct B09_extra_packed b;
-#endif
 };
 struct B09_extra_required_alignment var199;
 struct B09_extra_size {
@@ -2066,28 +1766,22 @@ typedef union {
 B10 var201;
 #pragma pack()
 struct B10_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B10)];
-    char b;
-#else
     char a;
     B10 b;
-#endif
 };
 struct B10_extra_alignment var202;
 #pragma pack(1)
 struct B10_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B10)];
+#else
     B10 a;
+#endif
 };
 #pragma pack()
 struct B10_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B10_extra_packed)];
-    char b;
-#else
     char a;
     struct B10_extra_packed b;
-#endif
 };
 struct B10_extra_required_alignment var203;
 struct B10_extra_size {
@@ -2107,28 +1801,22 @@ typedef union {
 B11 var205;
 #pragma pack()
 struct B11_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B11)];
-    char b;
-#else
     char a;
     B11 b;
-#endif
 };
 struct B11_extra_alignment var206;
 #pragma pack(1)
 struct B11_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B11)];
+#else
     B11 a;
+#endif
 };
 #pragma pack()
 struct B11_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B11_extra_packed)];
-    char b;
-#else
     char a;
     struct B11_extra_packed b;
-#endif
 };
 struct B11_extra_required_alignment var207;
 struct B11_extra_size {
@@ -2148,28 +1836,22 @@ typedef union {
 B12 var209;
 #pragma pack()
 struct B12_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B12)];
-    char b;
-#else
     char a;
     B12 b;
-#endif
 };
 struct B12_extra_alignment var210;
 #pragma pack(1)
 struct B12_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B12)];
+#else
     B12 a;
+#endif
 };
 #pragma pack()
 struct B12_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B12_extra_packed)];
-    char b;
-#else
     char a;
     struct B12_extra_packed b;
-#endif
 };
 struct B12_extra_required_alignment var211;
 struct B12_extra_size {
@@ -2189,28 +1871,22 @@ typedef union {
 B13 var213;
 #pragma pack()
 struct B13_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B13)];
-    char b;
-#else
     char a;
     B13 b;
-#endif
 };
 struct B13_extra_alignment var214;
 #pragma pack(1)
 struct B13_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B13)];
+#else
     B13 a;
+#endif
 };
 #pragma pack()
 struct B13_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B13_extra_packed)];
-    char b;
-#else
     char a;
     struct B13_extra_packed b;
-#endif
 };
 struct B13_extra_required_alignment var215;
 struct B13_extra_size {
@@ -2230,28 +1906,22 @@ typedef union {
 B14 var217;
 #pragma pack()
 struct B14_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B14)];
-    char b;
-#else
     char a;
     B14 b;
-#endif
 };
 struct B14_extra_alignment var218;
 #pragma pack(1)
 struct B14_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B14)];
+#else
     B14 a;
+#endif
 };
 #pragma pack()
 struct B14_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B14_extra_packed)];
-    char b;
-#else
     char a;
     struct B14_extra_packed b;
-#endif
 };
 struct B14_extra_required_alignment var219;
 struct B14_extra_size {
@@ -2271,28 +1941,22 @@ typedef union {
 B15 var221;
 #pragma pack()
 struct B15_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B15)];
-    char b;
-#else
     char a;
     B15 b;
-#endif
 };
 struct B15_extra_alignment var222;
 #pragma pack(1)
 struct B15_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B15)];
+#else
     B15 a;
+#endif
 };
 #pragma pack()
 struct B15_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B15_extra_packed)];
-    char b;
-#else
     char a;
     struct B15_extra_packed b;
-#endif
 };
 struct B15_extra_required_alignment var223;
 struct B15_extra_size {
@@ -2312,28 +1976,22 @@ typedef union {
 B16 var225;
 #pragma pack()
 struct B16_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B16)];
-    char b;
-#else
     char a;
     B16 b;
-#endif
 };
 struct B16_extra_alignment var226;
 #pragma pack(1)
 struct B16_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B16)];
+#else
     B16 a;
+#endif
 };
 #pragma pack()
 struct B16_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B16_extra_packed)];
-    char b;
-#else
     char a;
     struct B16_extra_packed b;
-#endif
 };
 struct B16_extra_required_alignment var227;
 struct B16_extra_size {
@@ -2353,28 +2011,22 @@ typedef union {
 B17 var229;
 #pragma pack()
 struct B17_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B17)];
-    char b;
-#else
     char a;
     B17 b;
-#endif
 };
 struct B17_extra_alignment var230;
 #pragma pack(1)
 struct B17_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B17)];
+#else
     B17 a;
+#endif
 };
 #pragma pack()
 struct B17_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B17_extra_packed)];
-    char b;
-#else
     char a;
     struct B17_extra_packed b;
-#endif
 };
 struct B17_extra_required_alignment var231;
 struct B17_extra_size {
@@ -2394,28 +2046,22 @@ typedef union {
 B18 var233;
 #pragma pack()
 struct B18_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B18)];
-    char b;
-#else
     char a;
     B18 b;
-#endif
 };
 struct B18_extra_alignment var234;
 #pragma pack(1)
 struct B18_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B18)];
+#else
     B18 a;
+#endif
 };
 #pragma pack()
 struct B18_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B18_extra_packed)];
-    char b;
-#else
     char a;
     struct B18_extra_packed b;
-#endif
 };
 struct B18_extra_required_alignment var235;
 struct B18_extra_size {
@@ -2435,28 +2081,22 @@ typedef union {
 B19 var237;
 #pragma pack()
 struct B19_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B19)];
-    char b;
-#else
     char a;
     B19 b;
-#endif
 };
 struct B19_extra_alignment var238;
 #pragma pack(1)
 struct B19_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B19)];
+#else
     B19 a;
+#endif
 };
 #pragma pack()
 struct B19_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B19_extra_packed)];
-    char b;
-#else
     char a;
     struct B19_extra_packed b;
-#endif
 };
 struct B19_extra_required_alignment var239;
 struct B19_extra_size {
@@ -2476,28 +2116,22 @@ typedef union {
 B20 var241;
 #pragma pack()
 struct B20_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B20)];
-    char b;
-#else
     char a;
     B20 b;
-#endif
 };
 struct B20_extra_alignment var242;
 #pragma pack(1)
 struct B20_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B20)];
+#else
     B20 a;
+#endif
 };
 #pragma pack()
 struct B20_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B20_extra_packed)];
-    char b;
-#else
     char a;
     struct B20_extra_packed b;
-#endif
 };
 struct B20_extra_required_alignment var243;
 struct B20_extra_size {
@@ -2517,28 +2151,22 @@ typedef union {
 B21 var245;
 #pragma pack()
 struct B21_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B21)];
-    char b;
-#else
     char a;
     B21 b;
-#endif
 };
 struct B21_extra_alignment var246;
 #pragma pack(1)
 struct B21_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B21)];
+#else
     B21 a;
+#endif
 };
 #pragma pack()
 struct B21_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B21_extra_packed)];
-    char b;
-#else
     char a;
     struct B21_extra_packed b;
-#endif
 };
 struct B21_extra_required_alignment var247;
 struct B21_extra_size {
@@ -2558,28 +2186,22 @@ typedef union {
 B22 var249;
 #pragma pack()
 struct B22_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B22)];
-    char b;
-#else
     char a;
     B22 b;
-#endif
 };
 struct B22_extra_alignment var250;
 #pragma pack(1)
 struct B22_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B22)];
+#else
     B22 a;
+#endif
 };
 #pragma pack()
 struct B22_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B22_extra_packed)];
-    char b;
-#else
     char a;
     struct B22_extra_packed b;
-#endif
 };
 struct B22_extra_required_alignment var251;
 struct B22_extra_size {
@@ -2599,28 +2221,22 @@ typedef union {
 B23 var253;
 #pragma pack()
 struct B23_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B23)];
-    char b;
-#else
     char a;
     B23 b;
-#endif
 };
 struct B23_extra_alignment var254;
 #pragma pack(1)
 struct B23_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B23)];
+#else
     B23 a;
+#endif
 };
 #pragma pack()
 struct B23_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B23_extra_packed)];
-    char b;
-#else
     char a;
     struct B23_extra_packed b;
-#endif
 };
 struct B23_extra_required_alignment var255;
 struct B23_extra_size {
@@ -2640,28 +2256,22 @@ typedef union {
 B24 var257;
 #pragma pack()
 struct B24_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B24)];
-    char b;
-#else
     char a;
     B24 b;
-#endif
 };
 struct B24_extra_alignment var258;
 #pragma pack(1)
 struct B24_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B24)];
+#else
     B24 a;
+#endif
 };
 #pragma pack()
 struct B24_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B24_extra_packed)];
-    char b;
-#else
     char a;
     struct B24_extra_packed b;
-#endif
 };
 struct B24_extra_required_alignment var259;
 struct B24_extra_size {
@@ -2681,28 +2291,22 @@ typedef union {
 B25 var261;
 #pragma pack()
 struct B25_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B25)];
-    char b;
-#else
     char a;
     B25 b;
-#endif
 };
 struct B25_extra_alignment var262;
 #pragma pack(1)
 struct B25_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B25)];
+#else
     B25 a;
+#endif
 };
 #pragma pack()
 struct B25_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B25_extra_packed)];
-    char b;
-#else
     char a;
     struct B25_extra_packed b;
-#endif
 };
 struct B25_extra_required_alignment var263;
 struct B25_extra_size {
@@ -2722,28 +2326,22 @@ typedef union {
 B26 var265;
 #pragma pack()
 struct B26_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B26)];
-    char b;
-#else
     char a;
     B26 b;
-#endif
 };
 struct B26_extra_alignment var266;
 #pragma pack(1)
 struct B26_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B26)];
+#else
     B26 a;
+#endif
 };
 #pragma pack()
 struct B26_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B26_extra_packed)];
-    char b;
-#else
     char a;
     struct B26_extra_packed b;
-#endif
 };
 struct B26_extra_required_alignment var267;
 struct B26_extra_size {
@@ -2763,28 +2361,22 @@ typedef union {
 B27 var269;
 #pragma pack()
 struct B27_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B27)];
-    char b;
-#else
     char a;
     B27 b;
-#endif
 };
 struct B27_extra_alignment var270;
 #pragma pack(1)
 struct B27_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B27)];
+#else
     B27 a;
+#endif
 };
 #pragma pack()
 struct B27_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B27_extra_packed)];
-    char b;
-#else
     char a;
     struct B27_extra_packed b;
-#endif
 };
 struct B27_extra_required_alignment var271;
 struct B27_extra_size {
@@ -2804,28 +2396,22 @@ typedef union {
 B28 var273;
 #pragma pack()
 struct B28_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B28)];
-    char b;
-#else
     char a;
     B28 b;
-#endif
 };
 struct B28_extra_alignment var274;
 #pragma pack(1)
 struct B28_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B28)];
+#else
     B28 a;
+#endif
 };
 #pragma pack()
 struct B28_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B28_extra_packed)];
-    char b;
-#else
     char a;
     struct B28_extra_packed b;
-#endif
 };
 struct B28_extra_required_alignment var275;
 struct B28_extra_size {
@@ -2845,28 +2431,22 @@ typedef union {
 B29 var277;
 #pragma pack()
 struct B29_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B29)];
-    char b;
-#else
     char a;
     B29 b;
-#endif
 };
 struct B29_extra_alignment var278;
 #pragma pack(1)
 struct B29_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B29)];
+#else
     B29 a;
+#endif
 };
 #pragma pack()
 struct B29_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B29_extra_packed)];
-    char b;
-#else
     char a;
     struct B29_extra_packed b;
-#endif
 };
 struct B29_extra_required_alignment var279;
 struct B29_extra_size {
@@ -2886,28 +2466,22 @@ typedef union {
 B30 var281;
 #pragma pack()
 struct B30_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B30)];
-    char b;
-#else
     char a;
     B30 b;
-#endif
 };
 struct B30_extra_alignment var282;
 #pragma pack(1)
 struct B30_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B30)];
+#else
     B30 a;
+#endif
 };
 #pragma pack()
 struct B30_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B30_extra_packed)];
-    char b;
-#else
     char a;
     struct B30_extra_packed b;
-#endif
 };
 struct B30_extra_required_alignment var283;
 struct B30_extra_size {
@@ -2927,28 +2501,22 @@ typedef union {
 B31 var285;
 #pragma pack()
 struct B31_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B31)];
-    char b;
-#else
     char a;
     B31 b;
-#endif
 };
 struct B31_extra_alignment var286;
 #pragma pack(1)
 struct B31_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B31)];
+#else
     B31 a;
+#endif
 };
 #pragma pack()
 struct B31_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B31_extra_packed)];
-    char b;
-#else
     char a;
     struct B31_extra_packed b;
-#endif
 };
 struct B31_extra_required_alignment var287;
 struct B31_extra_size {
@@ -2968,28 +2536,22 @@ typedef union {
 B32 var289;
 #pragma pack()
 struct B32_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B32)];
-    char b;
-#else
     char a;
     B32 b;
-#endif
 };
 struct B32_extra_alignment var290;
 #pragma pack(1)
 struct B32_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B32)];
+#else
     B32 a;
+#endif
 };
 #pragma pack()
 struct B32_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B32_extra_packed)];
-    char b;
-#else
     char a;
     struct B32_extra_packed b;
-#endif
 };
 struct B32_extra_required_alignment var291;
 struct B32_extra_size {
@@ -3009,28 +2571,22 @@ typedef union {
 B33 var293;
 #pragma pack()
 struct B33_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B33)];
-    char b;
-#else
     char a;
     B33 b;
-#endif
 };
 struct B33_extra_alignment var294;
 #pragma pack(1)
 struct B33_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B33)];
+#else
     B33 a;
+#endif
 };
 #pragma pack()
 struct B33_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B33_extra_packed)];
-    char b;
-#else
     char a;
     struct B33_extra_packed b;
-#endif
 };
 struct B33_extra_required_alignment var295;
 struct B33_extra_size {
@@ -3050,28 +2606,22 @@ typedef union {
 B34 var297;
 #pragma pack()
 struct B34_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B34)];
-    char b;
-#else
     char a;
     B34 b;
-#endif
 };
 struct B34_extra_alignment var298;
 #pragma pack(1)
 struct B34_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B34)];
+#else
     B34 a;
+#endif
 };
 #pragma pack()
 struct B34_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B34_extra_packed)];
-    char b;
-#else
     char a;
     struct B34_extra_packed b;
-#endif
 };
 struct B34_extra_required_alignment var299;
 struct B34_extra_size {
@@ -3091,28 +2641,22 @@ typedef union {
 B35 var301;
 #pragma pack()
 struct B35_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B35)];
-    char b;
-#else
     char a;
     B35 b;
-#endif
 };
 struct B35_extra_alignment var302;
 #pragma pack(1)
 struct B35_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B35)];
+#else
     B35 a;
+#endif
 };
 #pragma pack()
 struct B35_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B35_extra_packed)];
-    char b;
-#else
     char a;
     struct B35_extra_packed b;
-#endif
 };
 struct B35_extra_required_alignment var303;
 struct B35_extra_size {
@@ -3132,28 +2676,22 @@ typedef union {
 B36 var305;
 #pragma pack()
 struct B36_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B36)];
-    char b;
-#else
     char a;
     B36 b;
-#endif
 };
 struct B36_extra_alignment var306;
 #pragma pack(1)
 struct B36_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B36)];
+#else
     B36 a;
+#endif
 };
 #pragma pack()
 struct B36_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B36_extra_packed)];
-    char b;
-#else
     char a;
     struct B36_extra_packed b;
-#endif
 };
 struct B36_extra_required_alignment var307;
 struct B36_extra_size {
@@ -3173,28 +2711,22 @@ typedef union {
 B37 var309;
 #pragma pack()
 struct B37_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B37)];
-    char b;
-#else
     char a;
     B37 b;
-#endif
 };
 struct B37_extra_alignment var310;
 #pragma pack(1)
 struct B37_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B37)];
+#else
     B37 a;
+#endif
 };
 #pragma pack()
 struct B37_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B37_extra_packed)];
-    char b;
-#else
     char a;
     struct B37_extra_packed b;
-#endif
 };
 struct B37_extra_required_alignment var311;
 struct B37_extra_size {
@@ -3214,28 +2746,22 @@ typedef union {
 B38 var313;
 #pragma pack()
 struct B38_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B38)];
-    char b;
-#else
     char a;
     B38 b;
-#endif
 };
 struct B38_extra_alignment var314;
 #pragma pack(1)
 struct B38_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B38)];
+#else
     B38 a;
+#endif
 };
 #pragma pack()
 struct B38_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B38_extra_packed)];
-    char b;
-#else
     char a;
     struct B38_extra_packed b;
-#endif
 };
 struct B38_extra_required_alignment var315;
 struct B38_extra_size {
@@ -3255,28 +2781,22 @@ typedef union {
 B39 var317;
 #pragma pack()
 struct B39_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B39)];
-    char b;
-#else
     char a;
     B39 b;
-#endif
 };
 struct B39_extra_alignment var318;
 #pragma pack(1)
 struct B39_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B39)];
+#else
     B39 a;
+#endif
 };
 #pragma pack()
 struct B39_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B39_extra_packed)];
-    char b;
-#else
     char a;
     struct B39_extra_packed b;
-#endif
 };
 struct B39_extra_required_alignment var319;
 struct B39_extra_size {

--- a/test/records/0065_test.c
+++ b/test/records/0065_test.c
@@ -18,28 +18,22 @@ typedef struct {
 #endif
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -61,28 +55,22 @@ typedef union {
 #endif
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {

--- a/test/records/0066_test.c
+++ b/test/records/0066_test.c
@@ -14,28 +14,22 @@ typedef struct {
 } A1;
 A1 var1;
 struct A1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A1)];
-    char b;
-#else
     char a;
     A1 b;
-#endif
 };
 struct A1_extra_alignment var2;
 #pragma pack(1)
 struct A1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A1)];
+#else
     A1 a;
+#endif
 };
 #pragma pack()
 struct A1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A1_extra_packed)];
-    char b;
-#else
     char a;
     struct A1_extra_packed b;
-#endif
 };
 struct A1_extra_required_alignment var3;
 struct A1_extra_size {
@@ -53,28 +47,22 @@ typedef union {
 } A2;
 A2 var5;
 struct A2_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A2)];
-    char b;
-#else
     char a;
     A2 b;
-#endif
 };
 struct A2_extra_alignment var6;
 #pragma pack(1)
 struct A2_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A2)];
+#else
     A2 a;
+#endif
 };
 #pragma pack()
 struct A2_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A2_extra_packed)];
-    char b;
-#else
     char a;
     struct A2_extra_packed b;
-#endif
 };
 struct A2_extra_required_alignment var7;
 struct A2_extra_size {
@@ -90,28 +78,22 @@ typedef int B __attribute__((aligned(128)));
 #endif
 B var9;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var10;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var11;
 struct B_extra_size {
@@ -125,28 +107,22 @@ typedef struct {
 } C1;
 C1 var13;
 struct C1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C1)];
-    char b;
-#else
     char a;
     C1 b;
-#endif
 };
 struct C1_extra_alignment var14;
 #pragma pack(1)
 struct C1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C1)];
+#else
     C1 a;
+#endif
 };
 #pragma pack()
 struct C1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C1_extra_packed)];
-    char b;
-#else
     char a;
     struct C1_extra_packed b;
-#endif
 };
 struct C1_extra_required_alignment var15;
 struct C1_extra_size {
@@ -160,28 +136,22 @@ typedef union {
 } C2;
 C2 var17;
 struct C2_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C2)];
-    char b;
-#else
     char a;
     C2 b;
-#endif
 };
 struct C2_extra_alignment var18;
 #pragma pack(1)
 struct C2_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C2)];
+#else
     C2 a;
+#endif
 };
 #pragma pack()
 struct C2_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C2_extra_packed)];
-    char b;
-#else
     char a;
     struct C2_extra_packed b;
-#endif
 };
 struct C2_extra_required_alignment var19;
 struct C2_extra_size {
@@ -199,28 +169,22 @@ typedef struct {
 } D1;
 D1 var21;
 struct D1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D1)];
-    char b;
-#else
     char a;
     D1 b;
-#endif
 };
 struct D1_extra_alignment var22;
 #pragma pack(1)
 struct D1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D1)];
+#else
     D1 a;
+#endif
 };
 #pragma pack()
 struct D1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D1_extra_packed)];
-    char b;
-#else
     char a;
     struct D1_extra_packed b;
-#endif
 };
 struct D1_extra_required_alignment var23;
 struct D1_extra_size {
@@ -238,28 +202,22 @@ typedef union {
 } D2;
 D2 var25;
 struct D2_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D2)];
-    char b;
-#else
     char a;
     D2 b;
-#endif
 };
 struct D2_extra_alignment var26;
 #pragma pack(1)
 struct D2_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D2)];
+#else
     D2 a;
+#endif
 };
 #pragma pack()
 struct D2_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D2_extra_packed)];
-    char b;
-#else
     char a;
     struct D2_extra_packed b;
-#endif
 };
 struct D2_extra_required_alignment var27;
 struct D2_extra_size {
@@ -281,28 +239,22 @@ typedef struct {
 #endif
 E1 var29;
 struct E1_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E1)];
-    char b;
-#else
     char a;
     E1 b;
-#endif
 };
 struct E1_extra_alignment var30;
 #pragma pack(1)
 struct E1_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E1)];
+#else
     E1 a;
+#endif
 };
 #pragma pack()
 struct E1_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E1_extra_packed)];
-    char b;
-#else
     char a;
     struct E1_extra_packed b;
-#endif
 };
 struct E1_extra_required_alignment var31;
 struct E1_extra_size {
@@ -324,28 +276,22 @@ typedef union {
 #endif
 E2 var33;
 struct E2_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E2)];
-    char b;
-#else
     char a;
     E2 b;
-#endif
 };
 struct E2_extra_alignment var34;
 #pragma pack(1)
 struct E2_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E2)];
+#else
     E2 a;
+#endif
 };
 #pragma pack()
 struct E2_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E2_extra_packed)];
-    char b;
-#else
     char a;
     struct E2_extra_packed b;
-#endif
 };
 struct E2_extra_required_alignment var35;
 struct E2_extra_size {

--- a/test/records/0072_test.c
+++ b/test/records/0072_test.c
@@ -11,28 +11,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -47,28 +41,22 @@ typedef union {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -84,28 +72,22 @@ typedef int C __attribute__((aligned(16)));
 #endif
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -120,28 +102,22 @@ typedef struct {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {
@@ -156,28 +132,22 @@ typedef union {
 } E;
 E var17;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var18;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var19;
 struct E_extra_size {

--- a/test/records/0073_test.c
+++ b/test/records/0073_test.c
@@ -12,28 +12,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef union {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -86,28 +74,22 @@ typedef int C __attribute__((aligned(16)));
 #endif
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -123,28 +105,22 @@ typedef struct {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {
@@ -160,28 +136,22 @@ typedef union {
 } E;
 E var17;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var18;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var19;
 struct E_extra_size {

--- a/test/records/0074_test.c
+++ b/test/records/0074_test.c
@@ -12,28 +12,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef union {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {

--- a/test/records/0077_test.c
+++ b/test/records/0077_test.c
@@ -14,28 +14,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -53,28 +47,22 @@ typedef struct {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -92,28 +80,22 @@ typedef union {
 } C;
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -131,28 +113,22 @@ typedef union {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {

--- a/test/records/0078_test.c
+++ b/test/records/0078_test.c
@@ -10,28 +10,22 @@ typedef struct {
 } A;
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -45,28 +39,22 @@ typedef union {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {

--- a/test/records/0080_test.c
+++ b/test/records/0080_test.c
@@ -12,28 +12,22 @@ typedef int A __attribute__((aligned(16)));
 #endif
 A var1;
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef struct {
 } B;
 B var5;
 struct B_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(B)];
-    char b;
-#else
     char a;
     B b;
-#endif
 };
 struct B_extra_alignment var6;
 #pragma pack(1)
 struct B_extra_packed {
+#ifdef MSVC
+    char a[sizeof(B)];
+#else
     B a;
+#endif
 };
 #pragma pack()
 struct B_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct B_extra_packed)];
-    char b;
-#else
     char a;
     struct B_extra_packed b;
-#endif
 };
 struct B_extra_required_alignment var7;
 struct B_extra_size {
@@ -85,28 +73,22 @@ typedef struct {
 } C;
 C var9;
 struct C_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(C)];
-    char b;
-#else
     char a;
     C b;
-#endif
 };
 struct C_extra_alignment var10;
 #pragma pack(1)
 struct C_extra_packed {
+#ifdef MSVC
+    char a[sizeof(C)];
+#else
     C a;
+#endif
 };
 #pragma pack()
 struct C_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct C_extra_packed)];
-    char b;
-#else
     char a;
     struct C_extra_packed b;
-#endif
 };
 struct C_extra_required_alignment var11;
 struct C_extra_size {
@@ -121,28 +103,22 @@ typedef struct {
 } D;
 D var13;
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var14;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var15;
 struct D_extra_size {
@@ -154,28 +130,22 @@ struct D_extra_size var16;
 typedef char unnamed_type_17[3];
 unnamed_type_17 var18;
 struct unnamed_type_17_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(unnamed_type_17)];
-    char b;
-#else
     char a;
     unnamed_type_17 b;
-#endif
 };
 struct unnamed_type_17_extra_alignment var19;
 #pragma pack(1)
 struct unnamed_type_17_extra_packed {
+#ifdef MSVC
+    char a[sizeof(unnamed_type_17)];
+#else
     unnamed_type_17 a;
+#endif
 };
 #pragma pack()
 struct unnamed_type_17_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct unnamed_type_17_extra_packed)];
-    char b;
-#else
     char a;
     struct unnamed_type_17_extra_packed b;
-#endif
 };
 struct unnamed_type_17_extra_required_alignment var20;
 struct unnamed_type_17_extra_size {
@@ -190,28 +160,22 @@ typedef struct {
 } E;
 E var22;
 struct E_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(E)];
-    char b;
-#else
     char a;
     E b;
-#endif
 };
 struct E_extra_alignment var23;
 #pragma pack(1)
 struct E_extra_packed {
+#ifdef MSVC
+    char a[sizeof(E)];
+#else
     E a;
+#endif
 };
 #pragma pack()
 struct E_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct E_extra_packed)];
-    char b;
-#else
     char a;
     struct E_extra_packed b;
-#endif
 };
 struct E_extra_required_alignment var24;
 struct E_extra_size {
@@ -227,28 +191,22 @@ typedef long long F __attribute__((aligned(2)));
 #endif
 F var26;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var27;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var28;
 struct F_extra_size {
@@ -265,28 +223,22 @@ typedef struct {
 } G;
 G var30;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var31;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var32;
 struct G_extra_size {

--- a/test/records/0081_test.c
+++ b/test/records/0081_test.c
@@ -12,28 +12,22 @@ typedef long long F __attribute__((aligned(2)));
 #endif
 F var1;
 struct F_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(F)];
-    char b;
-#else
     char a;
     F b;
-#endif
 };
 struct F_extra_alignment var2;
 #pragma pack(1)
 struct F_extra_packed {
+#ifdef MSVC
+    char a[sizeof(F)];
+#else
     F a;
+#endif
 };
 #pragma pack()
 struct F_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct F_extra_packed)];
-    char b;
-#else
     char a;
     struct F_extra_packed b;
-#endif
 };
 struct F_extra_required_alignment var3;
 struct F_extra_size {
@@ -48,28 +42,22 @@ typedef struct {
 } G;
 G var5;
 struct G_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(G)];
-    char b;
-#else
     char a;
     G b;
-#endif
 };
 struct G_extra_alignment var6;
 #pragma pack(1)
 struct G_extra_packed {
+#ifdef MSVC
+    char a[sizeof(G)];
+#else
     G a;
+#endif
 };
 #pragma pack()
 struct G_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct G_extra_packed)];
-    char b;
-#else
     char a;
     struct G_extra_packed b;
-#endif
 };
 struct G_extra_required_alignment var7;
 struct G_extra_size {

--- a/test/records/0088_test.c
+++ b/test/records/0088_test.c
@@ -10,28 +10,22 @@ typedef long long A;
 A var1;
 #pragma pack()
 struct A_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(A)];
-    char b;
-#else
     char a;
     A b;
-#endif
 };
 struct A_extra_alignment var2;
 #pragma pack(1)
 struct A_extra_packed {
+#ifdef MSVC
+    char a[sizeof(A)];
+#else
     A a;
+#endif
 };
 #pragma pack()
 struct A_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct A_extra_packed)];
-    char b;
-#else
     char a;
     struct A_extra_packed b;
-#endif
 };
 struct A_extra_required_alignment var3;
 struct A_extra_size {
@@ -49,28 +43,22 @@ typedef long long D __attribute__((aligned(2)));
 D var5;
 #pragma pack()
 struct D_extra_alignment {
-#ifdef MSVC
-    char a[_Alignof(D)];
-    char b;
-#else
     char a;
     D b;
-#endif
 };
 struct D_extra_alignment var6;
 #pragma pack(1)
 struct D_extra_packed {
+#ifdef MSVC
+    char a[sizeof(D)];
+#else
     D a;
+#endif
 };
 #pragma pack()
 struct D_extra_required_alignment {
-#ifdef MSVC
-    char a[_Alignof(struct D_extra_packed)];
-    char b;
-#else
     char a;
     struct D_extra_packed b;
-#endif
 };
 struct D_extra_required_alignment var7;
 struct D_extra_size {


### PR DESCRIPTION
Fix some bugs in the MSVC layout code
Change `alingof()` for MSVC
Re-work the extra tests to work better w/ MSVC
Cleanup runner a bit. Don't ignore extra tests for MSVC any more