### PR TITLE
Parser: improve sizeof/alignof handling and errors

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -149,6 +149,8 @@ pub const Options = packed struct {
     @"expansion-to-defined": Kind = .default,
     @"bit-int-extension": Kind = .default,
     @"keyword-macro": Kind = .default,
+    @"pointer-arith": Kind = .default,
+    @"sizeof-array-argument": Kind = .default,
 };
 
 const messages = struct {
@@ -2142,6 +2144,19 @@ const messages = struct {
         const extra = .str;
         const opt = "ignored-attributes";
         const kind = .warning;
+    };
+    const pointer_arith_void = struct {
+        const msg = "invalid application of '{s}' to a void type";
+        const extra = .str;
+        const kind = .off;
+        const pedantic = true;
+        const opt = "pointer-arith";
+    };
+    const sizeof_array_arg = struct {
+        const msg = "sizeof on array function parameter will return size of {s}";
+        const extra = .str;
+        const kind = .warning;
+        const opt = "sizeof-array-argument";
     };
 };
 

--- a/test/cases/sizeof alignof.c
+++ b/test/cases/sizeof alignof.c
@@ -23,8 +23,21 @@ _Static_assert(sizeof((void)1, (int*)0) == sizeof(int*), "sizeof");
 
 _Static_assert(_Alignof(struct does_not_exist) == 0, "");
 
+#pragma GCC diagnostic warning "-Wpointer-arith"
+_Static_assert(sizeof(void) == 1, "");
+_Static_assert(_Alignof(void) == 1, "");
+void array_params(int x, int y[5], int z[x]) {
+    _Static_assert(sizeof(y) == sizeof(int *), "");
+    _Static_assert(sizeof(z) == sizeof(int *), "");
+}
+
 #define EXPECTED_ERRORS "sizeof alignof.c:10:19: error: expected parentheses around type name" \
     "sizeof alignof.c:10:37: error: expected parentheses around type name" \
     "sizeof alignof.c:14:32: warning: '_Alignof' applied to an expression is a GNU extension [-Wgnu-alignof-expression]" \
     "sizeof alignof.c:19:20: warning: '_Alignof' applied to an expression is a GNU extension [-Wgnu-alignof-expression]" \
     "sizeof alignof.c:24:24: error: invalid application of 'alignof' to an incomplete type 'struct does_not_exist'" \
+    "sizeof alignof.c:27:16: warning: invalid application of 'sizeof' to a void type [-Wpointer-arith]" \
+    "sizeof alignof.c:28:16: warning: invalid application of 'alignof' to a void type [-Wpointer-arith]" \
+    "sizeof alignof.c:30:20: warning: sizeof on array function parameter will return size of 'int *' instead of 'int [5]' [-Wsizeof-array-argument]" \
+    "sizeof alignof.c:31:20: warning: sizeof on array function parameter will return size of 'int *' instead of 'int [<expr>]' [-Wsizeof-array-argument]" \
+


### PR DESCRIPTION
1. Issue a warning for sizeof/alignof `void`
2. Issue a warning for sizeof(decayed array)
3. Treat sizeof(incomplete_size_type) or alignof(non_alignable_type) as parse errors. This matches clang's behavior and lets us remove some hacky error-suppression code in static_assert handling

This is part of the groundwork for some other static_assert changes I'll be making (clang trunk no longer requires that static_assert expressions be *integer* constants: https://godbolt.org/z/oafvqTEjx) which is itself part of the work for adding C23 nullptr support.