### PR TITLE
Add C23 `nullptr` support to frontend

### DIFF
--- a/include/stddef.h
+++ b/include/stddef.h
@@ -17,3 +17,10 @@ typedef struct {
 
 #define NULL ((void*)0)
 #define offsetof(T, member) __builtin_offsetof(T, member)
+
+#if __STDC_VERSION__ >= 202311L
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpre-c2x-compat"
+typedef typeof(nullptr) nullptr_t;
+#pragma GCC diagnostic pop
+#endif

--- a/src/Attribute.zig
+++ b/src/Attribute.zig
@@ -46,12 +46,14 @@ pub const ArgumentType = enum {
     float,
     array,
     expression,
+    nullptr_t,
 
     pub fn toString(self: ArgumentType) []const u8 {
         return switch (self) {
             .string => "a string",
             .identifier => "an identifier",
             .int, .alignment => "an integer constant",
+            .nullptr_t => "nullptr",
             .float => "a floating point number",
             .array => "an array",
             .expression => "an expression",
@@ -79,6 +81,7 @@ pub const ArgumentType = enum {
             .unavailable => .expression,
             .float => .float,
             .array => .array,
+            .nullptr_t => .nullptr_t,
         };
     }
 };

--- a/src/CodeGen.zig
+++ b/src/CodeGen.zig
@@ -163,6 +163,8 @@ fn genType(c: *CodeGen, base_ty: Type) !Interner.Ref {
     } else if (ty.specifier == .vector) {
         const elem = try c.genType(ty.elemType());
         key = .{ .vector = .{ .child = elem, .len = @intCast(u32, ty.data.array.len) } };
+    } else if (ty.is(.nullptr_t)) {
+        return c.comp.diag.fatalNoSrc("TODO lower nullptr_t", .{});
     }
     return c.builder.pool.put(c.builder.gpa, key);
 }
@@ -539,6 +541,7 @@ fn genExpr(c: *CodeGen, node: NodeIndex) Error!Ir.Ref {
         .case_range_stmt,
         .goto_stmt,
         .computed_goto_stmt,
+        .nullptr_literal,
         => return c.comp.diag.fatalNoSrc("TODO CodeGen.genStmt {}\n", .{c.node_tag[@enumToInt(node)]}),
         .comma_expr => {
             _ = try c.genExpr(data.bin.lhs);

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -1059,7 +1059,7 @@ const messages = struct {
         const kind = .warning;
         const suppress_version = .c2x;
     };
-    const static_assert_missing_message_c2x_compat = struct {
+    const pre_c2x_compat = struct {
         const msg = "{s} is incompatible with C standards before C2x";
         const extra = .str;
         const kind = .off;
@@ -2183,6 +2183,11 @@ const messages = struct {
     const constant_expression_conversion_not_allowed = struct {
         const msg = "this conversion is not allowed in a constant expression";
         const kind = .note;
+    };
+    const invalid_object_cast = struct {
+        const msg = "cannot cast an object of type {s}";
+        const extra = .str;
+        const kind = .@"error";
     };
 };
 

--- a/src/Interner.zig
+++ b/src/Interner.zig
@@ -46,6 +46,7 @@ pub const Key = union(enum) {
                 std.hash.autoHash(&hasher, val.tag);
                 switch (val.tag) {
                     .unavailable => unreachable,
+                    .nullptr_t => std.hash.autoHash(&hasher, @as(u64, 0)),
                     .int => std.hash.autoHash(&hasher, val.data.int),
                     .float => std.hash.autoHash(&hasher, @bitCast(u64, val.data.float)),
                     .array => @panic("TODO"),
@@ -73,6 +74,7 @@ pub const Key = union(enum) {
                 if (a_info.tag != b_info.tag) return false;
                 switch (a_info.tag) {
                     .unavailable => unreachable,
+                    .nullptr_t => return true,
                     .int => return a_info.data.int == b_info.data.int,
                     .float => return a_info.data.float == b_info.data.float,
                     .array => @panic("TODO"),

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4414,11 +4414,11 @@ const Result = struct {
                     const other_res = if (a_nullptr) b else a;
                     if (other_res.ty.isPtr()) {
                         try nullptr_res.nullCast(p, other_res.ty);
-                        return a.shouldEval(b, p);
+                        return other_res.shouldEval(nullptr_res, p);
                     } else if (other_res.val.isZero()) {
                         other_res.val = .{ .tag = .nullptr_t };
                         try other_res.nullCast(p, nullptr_res.ty);
-                        return a.shouldEval(b, p);
+                        return other_res.shouldEval(nullptr_res, p);
                     }
                     return a.invalidBinTy(tok, b, p);
                 }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1009,7 +1009,7 @@ fn staticAssert(p: *Parser) Error!bool {
     _ = try p.expectToken(.semicolon);
     if (str.node == .none) {
         try p.errTok(.static_assert_missing_message, static_assert);
-        try p.errStr(.static_assert_missing_message_c2x_compat, static_assert, "'_Static_assert' with no message");
+        try p.errStr(.pre_c2x_compat, static_assert, "'_Static_assert' with no message");
     }
 
     // Array will never be zero; a value of zero for a pointer is a null pointer constant
@@ -1176,6 +1176,10 @@ fn typeof(p: *Parser) Error!?Type {
     const typeof_expr = try p.parseNoEval(expr);
     try typeof_expr.expect(p);
     try p.expectClosing(l_paren, .r_paren);
+    // Special case nullptr_t since it's defined as typeof(nullptr)
+    if (typeof_expr.ty.is(.nullptr_t)) {
+        return Type{ .specifier = .nullptr_t, .qual = typeof_expr.ty.qual.inheritFromTypeof() };
+    }
 
     const inner = try p.arena.create(Type.Expr);
     inner.* = .{
@@ -3546,7 +3550,7 @@ fn stmt(p: *Parser) Error!NodeIndex {
         try cond.lvalConversion(p);
         if (cond.ty.isInt())
             try cond.intCast(p, cond.ty.integerPromotion(p.comp), cond_tok)
-        else if (!cond.ty.isFloat() and !cond.ty.isPtr())
+        else if (!cond.ty.isScalarNonInt())
             try p.errStr(.statement_scalar, l_paren + 1, try p.typeStr(cond.ty));
         try cond.saveValue(p);
         try p.expectClosing(l_paren, .r_paren);
@@ -3604,7 +3608,7 @@ fn stmt(p: *Parser) Error!NodeIndex {
         try cond.lvalConversion(p);
         if (cond.ty.isInt())
             try cond.intCast(p, cond.ty.integerPromotion(p.comp), cond_tok)
-        else if (!cond.ty.isFloat() and !cond.ty.isPtr())
+        else if (!cond.ty.isScalarNonInt())
             try p.errStr(.statement_scalar, l_paren + 1, try p.typeStr(cond.ty));
         try cond.saveValue(p);
         try p.expectClosing(l_paren, .r_paren);
@@ -3637,7 +3641,7 @@ fn stmt(p: *Parser) Error!NodeIndex {
         try cond.lvalConversion(p);
         if (cond.ty.isInt())
             try cond.intCast(p, cond.ty.integerPromotion(p.comp), cond_tok)
-        else if (!cond.ty.isFloat() and !cond.ty.isPtr())
+        else if (!cond.ty.isScalarNonInt())
             try p.errStr(.statement_scalar, l_paren + 1, try p.typeStr(cond.ty));
         try cond.saveValue(p);
         try p.expectClosing(l_paren, .r_paren);
@@ -3672,7 +3676,7 @@ fn stmt(p: *Parser) Error!NodeIndex {
             try cond.lvalConversion(p);
             if (cond.ty.isInt())
                 try cond.intCast(p, cond.ty.integerPromotion(p.comp), cond_tok)
-            else if (!cond.ty.isFloat() and !cond.ty.isPtr())
+            else if (!cond.ty.isScalarNonInt())
                 try p.errStr(.statement_scalar, l_paren + 1, try p.typeStr(cond.ty));
         }
         try cond.saveValue(p);
@@ -4245,6 +4249,9 @@ const Result = struct {
     }
 
     fn boolRes(lhs: *Result, p: *Parser, tag: Tree.Tag, rhs: Result) !void {
+        if (lhs.val.tag == .nullptr_t) {
+            lhs.val = Value.int(0);
+        }
         if (lhs.ty.specifier != .invalid) {
             lhs.ty = Type.int;
         }
@@ -4385,13 +4392,15 @@ const Result = struct {
         }
         if (kind == .arithmetic) return a.invalidBinTy(tok, b, p);
 
+        const a_nullptr = a.ty.is(.nullptr_t);
+        const b_nullptr = b.ty.is(.nullptr_t);
         const a_ptr = a.ty.isPtr();
         const b_ptr = b.ty.isPtr();
         const a_scalar = a_arithmetic or a_ptr;
         const b_scalar = b_arithmetic or b_ptr;
         switch (kind) {
             .boolean_logic => {
-                if (!a_scalar or !b_scalar) return a.invalidBinTy(tok, b, p);
+                if (!(a_scalar or a_nullptr) or !(b_scalar or b_nullptr)) return a.invalidBinTy(tok, b, p);
 
                 // Do integer promotions but nothing else
                 if (a_int) try a.intCast(p, a.ty.integerPromotion(p.comp), tok);
@@ -4399,6 +4408,20 @@ const Result = struct {
                 return a.shouldEval(b, p);
             },
             .relational, .equality => {
+                if (kind == .equality and (a_nullptr or b_nullptr)) {
+                    if (a_nullptr and b_nullptr) return a.shouldEval(b, p);
+                    const nullptr_res = if (a_nullptr) a else b;
+                    const other_res = if (a_nullptr) b else a;
+                    if (other_res.ty.isPtr()) {
+                        try nullptr_res.nullCast(p, other_res.ty);
+                        return a.shouldEval(b, p);
+                    } else if (other_res.val.isZero()) {
+                        other_res.val = .{ .tag = .nullptr_t };
+                        try other_res.nullCast(p, nullptr_res.ty);
+                        return a.shouldEval(b, p);
+                    }
+                    return a.invalidBinTy(tok, b, p);
+                }
                 // comparisons between floats and pointes not allowed
                 if (!a_scalar or !b_scalar or (a_float and b_ptr) or (b_float and a_ptr))
                     return a.invalidBinTy(tok, b, p);
@@ -4424,6 +4447,7 @@ const Result = struct {
                     try b.toVoid(p);
                     return true;
                 }
+                if (a_nullptr and b_nullptr) return true;
                 if ((a_ptr and b_int) or (a_int and b_ptr)) {
                     if (a.val.isZero() or b.val.isZero()) {
                         try a.nullCast(p, b.ty);
@@ -4438,6 +4462,12 @@ const Result = struct {
                     return true;
                 }
                 if (a_ptr and b_ptr) return a.adjustCondExprPtrs(tok, b, p);
+                if ((a_ptr and b_nullptr) or (a_nullptr and b_ptr)) {
+                    const nullptr_res = if (a_nullptr) a else b;
+                    const ptr_res = if (a_nullptr) b else a;
+                    try nullptr_res.nullCast(p, ptr_res.ty);
+                    return true;
+                }
                 if (a.ty.isRecord() and b.ty.isRecord() and a.ty.eql(b.ty, p.comp, false)) {
                     return true;
                 }
@@ -4667,7 +4697,7 @@ const Result = struct {
     }
 
     fn nullCast(res: *Result, p: *Parser, ptr_ty: Type) Error!void {
-        if (!res.val.isZero()) return;
+        if (!res.ty.is(.nullptr_t) and !res.val.isZero()) return;
         res.ty = ptr_ty;
         try res.implicitCast(p, .null_to_pointer);
     }
@@ -4772,17 +4802,38 @@ const Result = struct {
     /// Saves value and replaces it with `.unavailable`.
     fn saveValue(res: *Result, p: *Parser) !void {
         assert(!p.in_macro);
-        if (res.val.tag == .unavailable) return;
+        if (res.val.tag == .unavailable or res.val.tag == .nullptr_t) return;
         if (!p.in_macro) try p.value_map.put(res.node, res.val);
         res.val.tag = .unavailable;
     }
 
     fn castType(res: *Result, p: *Parser, to: Type, tok: TokenIndex) !void {
         var cast_kind: Tree.CastKind = undefined;
+
         if (to.is(.void)) {
             // everything can cast to void
             cast_kind = .to_void;
             res.val.tag = .unavailable;
+        } else if (to.is(.nullptr_t)) {
+            if (res.ty.is(.nullptr_t)) {
+                cast_kind = .no_op;
+            } else {
+                try p.errStr(.invalid_object_cast, tok, try p.typePairStrExtra(res.ty, " to ", to));
+                return error.ParsingFailed;
+            }
+        } else if (res.ty.is(.nullptr_t)) {
+            if (to.is(.bool)) {
+                res.ty = to;
+                try res.implicitCast(p, .bitcast);
+                res.val = Value.int(0);
+                try res.saveValue(p);
+            } else if (to.isPtr()) {
+                try res.nullCast(p, to);
+            } else {
+                try p.errStr(.invalid_object_cast, tok, try p.typePairStrExtra(res.ty, " to ", to));
+                return error.ParsingFailed;
+            }
+            cast_kind = .no_op;
         } else if (res.val.isZero() and to.isPtr()) {
             cast_kind = .null_to_pointer;
         } else if (to.isScalar()) cast: {
@@ -4996,8 +5047,10 @@ const Result = struct {
         // Subject of the coercion does not need to be qualified.
         var unqual_ty = dest_ty.canonicalize(.standard);
         unqual_ty.qual = .{};
-        if (unqual_ty.is(.bool)) {
-            if (res.ty.isScalar()) {
+        if (unqual_ty.is(.nullptr_t)) {
+            if (res.ty.is(.nullptr_t)) return;
+        } else if (unqual_ty.is(.bool)) {
+            if (res.ty.isScalar() and !res.ty.is(.nullptr_t)) {
                 // this is ridiculous but it's what clang does
                 try res.boolCast(p, unqual_ty, tok);
                 return;
@@ -5019,7 +5072,7 @@ const Result = struct {
                 return;
             }
         } else if (unqual_ty.isPtr()) {
-            if (res.val.isZero()) {
+            if (res.ty.is(.nullptr_t) or res.val.isZero()) {
                 try res.nullCast(p, dest_ty);
                 return;
             } else if (res.ty.isInt()) {
@@ -6002,6 +6055,8 @@ fn unExpr(p: *Parser) Error!Result {
             if (operand.val.tag == .int) {
                 const res = Value.int(@boolToInt(!operand.val.getBool()));
                 operand.val = res;
+            } else if (operand.val.tag == .nullptr_t) {
+                operand.val = Value.int(1);
             } else {
                 if (operand.ty.isDecayed()) {
                     operand.val = Value.int(0);
@@ -6484,6 +6539,7 @@ fn checkArrayBounds(p: *Parser, index: Result, array: Result, tok: TokenIndex) !
 ///  : IDENTIFIER
 ///  | keyword_true
 ///  | keyword_false
+///  | keyword_nullptr
 ///  | INTEGER_LITERAL
 ///  | FLOAT_LITERAL
 ///  | IMAGINARY_LITERAL
@@ -6598,6 +6654,19 @@ fn primaryExpr(p: *Parser) Error!Result {
             std.debug.assert(!p.in_macro); // Should have been replaced with .one / .zero
             try p.value_map.put(res.node, res.val);
             return res;
+        },
+        .keyword_nullptr => {
+            defer p.tok_i += 1;
+            try p.errStr(.pre_c2x_compat, p.tok_i, "'nullptr'");
+            return Result{
+                .val = .{ .tag = .nullptr_t },
+                .ty = .{ .specifier = .nullptr_t },
+                .node = try p.addNode(.{
+                    .tag = .nullptr_literal,
+                    .ty = .{ .specifier = .nullptr_t },
+                    .data = undefined,
+                }),
+            };
         },
         .macro_func, .macro_function => {
             defer p.tok_i += 1;

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4823,9 +4823,10 @@ const Result = struct {
             }
         } else if (res.ty.is(.nullptr_t)) {
             if (to.is(.bool)) {
-                res.ty = to;
-                try res.implicitCast(p, .bitcast);
-                res.val = Value.int(0);
+                try res.nullCast(p, res.ty);
+                res.val.toBool();
+                res.ty = .{ .specifier = .bool };
+                try res.implicitCast(p, .pointer_to_bool);
                 try res.saveValue(p);
             } else if (to.isPtr()) {
                 try res.nullCast(p, to);

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -198,6 +198,7 @@ pub const Token = struct {
         keyword_constexpr,
         keyword_true,
         keyword_false,
+        keyword_nullptr,
 
         // Preprocessor directives
         keyword_include,
@@ -399,6 +400,7 @@ pub const Token = struct {
                 .keyword_constexpr,
                 .keyword_true,
                 .keyword_false,
+                .keyword_nullptr,
                 => return true,
                 else => return false,
             }
@@ -586,6 +588,7 @@ pub const Token = struct {
                 .keyword_constexpr => "constexpr",
                 .keyword_true => "true",
                 .keyword_false => "false",
+                .keyword_nullptr => "nullptr",
                 .keyword_include => "include",
                 .keyword_include_next => "include_next",
                 .keyword_define => "define",
@@ -748,6 +751,7 @@ pub const Token = struct {
             .keyword_constexpr,
             .keyword_true,
             .keyword_false,
+            .keyword_nullptr,
             => if (standard.atLeast(.c2x)) kw else .identifier,
 
             .keyword_int64,
@@ -849,6 +853,7 @@ pub const Token = struct {
         .{ "constexpr", .keyword_constexpr },
         .{ "true", .keyword_true },
         .{ "false", .keyword_false },
+        .{ "nullptr", .keyword_nullptr },
 
         // Preprocessor directives
         .{ "include", .keyword_include },
@@ -2026,7 +2031,7 @@ test "digraphs" {
 }
 
 test "C23 keywords" {
-    try expectTokensExtra("true false alignas alignof bool static_assert thread_local", &.{
+    try expectTokensExtra("true false alignas alignof bool static_assert thread_local nullptr", &.{
         .keyword_true,
         .keyword_false,
         .keyword_c23_alignas,
@@ -2034,6 +2039,7 @@ test "C23 keywords" {
         .keyword_c23_bool,
         .keyword_c23_static_assert,
         .keyword_c23_thread_local,
+        .keyword_nullptr,
     }, .c2x);
 }
 

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -463,6 +463,8 @@ pub const Tag = enum(u8) {
     enumeration_ref,
     /// C23 bool literal `true` / `false`
     bool_literal,
+    /// C23 nullptr literal
+    nullptr_literal,
     /// integer literal, always unsigned
     int_literal,
     /// Same as int_literal, but originates from a char literal
@@ -1145,6 +1147,7 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, mapper: StringInterner.Type
             if (color) util.setColor(.reset, w);
         },
         .bool_literal,
+        .nullptr_literal,
         .int_literal,
         .char_literal,
         .float_literal,

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -364,6 +364,9 @@ pub const Specifier = enum {
 
     /// special type used to implement __builtin_va_start
     special_va_start,
+
+    /// C23 nullptr_t
+    nullptr_t,
 };
 
 /// All fields of Type except data may be mutated
@@ -432,7 +435,12 @@ pub fn isArray(ty: Type) bool {
 }
 
 pub fn isScalar(ty: Type) bool {
-    return ty.isInt() or ty.isFloat() or ty.isPtr();
+    return ty.isInt() or ty.isScalarNonInt();
+}
+
+/// To avoid calling isInt() twice for allowable loop/if controlling expressions
+pub fn isScalarNonInt(ty: Type) bool {
+    return ty.isFloat() or ty.isPtr() or ty.is(.nullptr_t);
 }
 
 pub fn isDecayed(ty: Type) bool {
@@ -834,6 +842,7 @@ pub fn sizeof(ty: Type, comp: *const Compilation) ?u64 {
         .decayed_typeof_type,
         .decayed_typeof_expr,
         .static_array,
+        .nullptr_t,
         => CType.ptrBitWidth(comp.target) >> 3,
         .array, .vector => {
             const size = ty.data.array.elem.sizeof(comp) orelse return null;
@@ -946,6 +955,7 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
         .decayed_variable_len_array,
         .decayed_unspecified_variable_len_array,
         .static_array,
+        .nullptr_t,
         => switch (comp.target.cpu.arch) {
             .avr => 1,
             else => CType.ptrBitWidth(comp.target) >> 3,
@@ -1245,6 +1255,7 @@ pub const Builder = struct {
     pub const Specifier = union(enum) {
         none,
         void,
+        nullptr_t,
         bool,
         char,
         schar,
@@ -1355,6 +1366,7 @@ pub const Builder = struct {
             return switch (spec) {
                 .none => unreachable,
                 .void => "void",
+                .nullptr_t => "nullptr_t",
                 .bool => if (langopts.standard.atLeast(.c2x)) "bool" else "_Bool",
                 .char => "char",
                 .schar => "signed char",
@@ -1488,6 +1500,7 @@ pub const Builder = struct {
                 }
             },
             .void => ty.specifier = .void,
+            .nullptr_t => unreachable, // nullptr_t can only be accessed via typeof(nullptr)
             .bool => ty.specifier = .bool,
             .char => ty.specifier = .char,
             .schar => ty.specifier = .schar,
@@ -1678,6 +1691,7 @@ pub const Builder = struct {
         const inner = switch (new.specifier) {
             .typeof_type => new.data.sub_type.*,
             .typeof_expr => new.data.expr.ty,
+            .nullptr_t => new, // typeof(nullptr) is special-cased to be an unwrapped typeof-expr
             else => unreachable,
         };
 
@@ -2019,6 +2033,7 @@ pub const Builder = struct {
     pub fn fromType(ty: Type) Builder.Specifier {
         return switch (ty.specifier) {
             .void => .void,
+            .nullptr_t => .nullptr_t,
             .bool => .bool,
             .char => .char,
             .schar => .schar,

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -16,6 +16,7 @@ data: union {
 
 const Tag = enum {
     unavailable,
+    nullptr_t,
     /// int is used to store integer, boolean and pointer values
     int,
     float,
@@ -270,6 +271,7 @@ pub fn toBool(v: *Value) void {
 pub fn isZero(v: Value) bool {
     return switch (v.tag) {
         .unavailable => false,
+        .nullptr_t => false,
         .int => v.data.int == 0,
         .float => v.data.float == 0,
         .array => false,
@@ -280,6 +282,7 @@ pub fn isZero(v: Value) bool {
 pub fn getBool(v: Value) bool {
     return switch (v.tag) {
         .unavailable => unreachable,
+        .nullptr_t => false,
         .int => v.data.int != 0,
         .float => v.data.float != 0,
         .array => true,
@@ -516,6 +519,13 @@ pub fn bitNot(v: Value, ty: Type, comp: *Compilation) Value {
 
 pub fn compare(a: Value, op: std.math.CompareOperator, b: Value, ty: Type, comp: *const Compilation) bool {
     assert(a.tag == b.tag);
+    if (a.tag == .nullptr_t) {
+        return switch (op) {
+            .eq => true,
+            .neq => false,
+            else => unreachable,
+        };
+    }
     const S = struct {
         inline fn doICompare(comptime T: type, aa: Value, opp: std.math.CompareOperator, bb: Value) bool {
             const a_val = aa.getInt(T);

--- a/test/cases/nullptr.c
+++ b/test/cases/nullptr.c
@@ -1,0 +1,127 @@
+//aro-args -std=c2x
+#include <stddef.h>
+// Comments below from N3047 working draft — August 4, 2022 § 7.21.2
+// Because it is considered to be a scalar type, nullptr_t may appear in any context where (void*)0 would be valid,
+// for example,
+// — as the operand of alignas, sizeof or typeof operators,
+// — as the operand of an implicit or explicit conversion to a pointer type,
+// — as the assignment expression in an assignment or initialization of an object of type nullptr_t,
+// — as an argument to a parameter of type nullptr_t or in a variable argument list,
+// — as a void expression,
+// — as the operand of an implicit or explicit conversion to bool,
+// — as an operand of a _Generic primary expression,
+// - as an operand of the !, &&, || or conditional operators, or
+// — as the controlling expression of an if or iteration statement.
+
+static_assert(sizeof(nullptr) == sizeof(char *));
+static_assert(alignof(nullptr_t) == alignof(char *));
+static_assert(!nullptr);
+static_assert(nullptr || true);
+static_assert(!(nullptr && true));
+static_assert(nullptr == nullptr);
+static_assert(!(nullptr && nullptr));
+static_assert(nullptr == false);
+static_assert(nullptr == 0);
+static_assert(nullptr ? 0 : 1);
+static_assert(nullptr || 1);
+static_assert(nullptr ? 0 : 1);
+
+void foo(nullptr_t param) {
+    char *p1 = nullptr;
+    char *p2 = (nullptr_t) nullptr;
+    p2 = nullptr;
+    nullptr_t p3 = nullptr;
+    p3 = nullptr;
+    const int *p4 = nullptr;
+    p4 = nullptr;
+    float (*p5)(int) = nullptr;
+}
+
+void bar(int param1, ...) {
+
+}
+
+void generic_nullptr(void) {
+
+}
+void generic_int(int x) {
+
+}
+void generic_ptr(void *p) {
+
+}
+
+void baz(void) {
+    foo(nullptr);
+    nullptr_t nullptr_t_var = nullptr;
+    foo(nullptr_t_var);
+    bar(0, nullptr);
+    nullptr_t_var = (nullptr_t)nullptr;
+    (void)nullptr;
+    bool b = (bool)nullptr;
+    b = !nullptr;
+
+    if (nullptr){}
+    while (nullptr){ break; }
+    for (; nullptr; ){ break; }
+
+    _Generic(nullptr,
+        nullptr_t: generic_nullptr,
+        int: generic_int,
+        void *: generic_ptr
+    )();
+    _Generic(0,
+        nullptr_t: generic_nullptr,
+        int: generic_int,
+        void *: generic_ptr
+    )(0);
+    _Generic((void*)0,
+        nullptr_t: generic_nullptr,
+        int: generic_int,
+        void *: generic_ptr
+    )(0);
+
+    void *vp = 1 ? nullptr : nullptr;
+    vp = 1 ? nullptr : &b;
+}
+
+void bad_nullptr_use(void) {
+    static_assert(nullptr != 1);
+    static_assert(nullptr != true);
+    bool b = nullptr;
+    int x = nullptr;
+    nullptr_t p = 0;
+    float f = (float)nullptr;
+    x = (int)nullptr;
+    void *vp = 1 ? nullptr : 0;
+    nullptr > 1;
+    nullptr > 1.0;
+    nullptr == 1;
+    nullptr == 1.0;
+    nullptr & 1;
+    nullptr + 1;
+    p + 1;
+    nullptr - 1;
+    vp = (nullptr_t)0;
+    vp = (nullptr_t)(void *)0;
+}
+
+#define EXPECTED_ERRORS "nullptr.c:89:27: error: invalid operands to binary expression ('nullptr_t' and 'int')" \
+    "nullptr.c:90:27: error: invalid operands to binary expression ('nullptr_t' and 'bool')" \
+    "nullptr.c:91:14: error: initializing 'bool' from incompatible type 'nullptr_t'" \
+    "nullptr.c:92:13: error: initializing 'int' from incompatible type 'nullptr_t'" \
+    "nullptr.c:93:19: error: initializing 'nullptr_t' from incompatible type 'int'" \
+    "nullptr.c:94:15: error: cannot cast an object of type 'nullptr_t' to 'float'" \
+    "nullptr.c:95:9: error: cannot cast an object of type 'nullptr_t' to 'int'" \
+    "nullptr.c:96:28: error: invalid operands to binary expression ('nullptr_t' and 'int')" \
+    "nullptr.c:97:13: error: invalid operands to binary expression ('nullptr_t' and 'int')" \
+    "nullptr.c:98:13: error: invalid operands to binary expression ('nullptr_t' and 'double')" \
+    "nullptr.c:99:13: error: invalid operands to binary expression ('nullptr_t' and 'int')" \
+    "nullptr.c:100:13: error: invalid operands to binary expression ('nullptr_t' and 'double')" \
+    "nullptr.c:101:13: error: invalid operands to binary expression ('nullptr_t' and 'int')" \
+    "nullptr.c:102:13: error: invalid operands to binary expression ('nullptr_t' and 'int')" \
+    "nullptr.c:103:7: error: invalid operands to binary expression ('nullptr_t' and 'int')" \
+    "nullptr.c:104:13: error: invalid operands to binary expression ('nullptr_t' and 'int')" \
+    "nullptr.c:105:10: error: cannot cast an object of type 'int' to 'nullptr_t'" \
+    "nullptr.c:106:10: error: cannot cast an object of type 'void *' to 'nullptr_t'" \
+


### PR DESCRIPTION
I tried to follow clang's example; including when their behavior seems to go against the draft - e.g. it's an error in clang to assign `nullptr` to a bool without a cast, but the draft seems to indicate that is ok and should evaluate to `false`.

I left the IR unimplemented because I'm not sure if you want to add a new constant type for `null` - but it's supposed to have the `size and alignment of nullptr_t is the same as for a pointer to character type. An object representation of the value nullptr is the same as the object representation of a null pointer value of type void*`. Reading from a variable of type `nullptr_t` always produces the value that would be produced by reading from a null pointer of type `void *`.

I'm not saving values of `nullptr_t` into `value_map` since variables of that type can only have 1 value - I can change this if it makes IR easier to deal with.
