### PR TITLE
Parser: apply a default layout to records

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -453,7 +453,7 @@ fn generateVaListType(comp: *Compilation) !Type {
             record_ty.fields[3] = .{ .name = try comp.intern("__gr_offs"), .ty = .{ .specifier = .int } };
             record_ty.fields[4] = .{ .name = try comp.intern("__vr_offs"), .ty = .{ .specifier = .int } };
             ty = .{ .specifier = .@"struct", .data = .{ .record = record_ty } };
-            record_layout.compute(ty, comp, null);
+            record_layout.compute(record_ty, ty, comp, null);
         },
         .x86_64_va_list => {
             const record_ty = try arena.create(Type.Record);
@@ -471,7 +471,7 @@ fn generateVaListType(comp: *Compilation) !Type {
             record_ty.fields[2] = .{ .name = try comp.intern("overflow_arg_area"), .ty = void_ptr };
             record_ty.fields[3] = .{ .name = try comp.intern("reg_save_area"), .ty = void_ptr };
             ty = .{ .specifier = .@"struct", .data = .{ .record = record_ty } };
-            record_layout.compute(ty, comp, null);
+            record_layout.compute(record_ty, ty, comp, null);
         },
     }
     if (kind == .char_ptr or kind == .void_ptr) {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1922,7 +1922,7 @@ fn recordSpec(p: *Parser) Error!Type {
             // TODO: msvc considers `#pragma pack` on a per-field basis
             .msvc => p.pragma_pack,
         };
-        record_layout.compute(ty, p.pp.comp, pragma_pack_value);
+        record_layout.compute(record_ty, ty, p.pp.comp, pragma_pack_value);
     }
 
     // finish by creating a node

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -259,7 +259,12 @@ pub const Record = struct {
         r.name = name;
         r.fields.len = std.math.maxInt(usize);
         r.field_attributes = null;
-        r.type_layout = undefined;
+        r.type_layout = .{
+            .size_bits = 8,
+            .field_alignment_bits = 8,
+            .pointer_alignment_bits = 8,
+            .required_alignment_bits = 8,
+        };
         return r;
     }
 };

--- a/src/record_layout.zig
+++ b/src/record_layout.zig
@@ -568,8 +568,7 @@ const MsvcContext = struct {
     }
 };
 
-pub fn compute(ty: Type, comp: *const Compilation, pragma_pack: ?u8) void {
-    const rec = getMutableRecord(ty);
+pub fn compute(rec: *Type.Record, ty: Type, comp: *const Compilation, pragma_pack: ?u8) void {
     switch (comp.langopts.emulate) {
         .gcc, .clang => {
             var context = SysVContext.init(ty, comp, pragma_pack);
@@ -578,7 +577,7 @@ pub fn compute(ty: Type, comp: *const Compilation, pragma_pack: ?u8) void {
 
             context.size_bits = std.mem.alignForwardGeneric(u64, context.size_bits, context.aligned_bits);
 
-            rec.type_layout = TypeLayout{
+            rec.type_layout = .{
                 .size_bits = context.size_bits,
                 .field_alignment_bits = context.aligned_bits,
                 .pointer_alignment_bits = context.aligned_bits,
@@ -602,7 +601,7 @@ pub fn compute(ty: Type, comp: *const Compilation, pragma_pack: ?u8) void {
                 context.handleZeroSizedRecord();
             }
             context.size_bits = std.mem.alignForwardGeneric(u64, context.size_bits, context.pointer_align_bits);
-            rec.type_layout = TypeLayout{
+            rec.type_layout = .{
                 .size_bits = context.size_bits,
                 .field_alignment_bits = context.field_align_bits,
                 .pointer_alignment_bits = context.pointer_align_bits,
@@ -630,16 +629,6 @@ fn computeLayout(ty: Type, comp: *const Compilation) TypeLayout {
             .required_alignment_bits = BITS_PER_BYTE,
         };
     }
-}
-
-pub fn getMutableRecord(ty: Type) *Type.Record {
-    return switch (ty.specifier) {
-        .attributed => getMutableRecord(ty.data.attributed.base),
-        .typeof_type, .decayed_typeof_type => getMutableRecord(ty.data.sub_type.*),
-        .typeof_expr, .decayed_typeof_expr => getMutableRecord(ty.data.expr.ty),
-        .@"struct", .@"union" => ty.data.record,
-        else => unreachable,
-    };
 }
 
 fn isPacked(attrs: ?[]const Attribute) bool {

--- a/test/cases/nested invalid struct layout.c
+++ b/test/cases/nested invalid struct layout.c
@@ -1,0 +1,11 @@
+struct Foo {
+    Bar bar;
+};
+
+struct Baz {
+    struct Foo foo;
+};
+
+#define EXPECTED_ERRORS "nested invalid struct layout.c:2:5: error: expected '}', found 'an identifier'" \
+    "nested invalid struct layout.c:1:12: note: to match this '{'" \
+


### PR DESCRIPTION
If layout for a record is not computed because it is incomplete due to errors, it could still end up being used in subsequent records. If that happens we don't want undefined values in the record's layout field.

Fixes #409