### PR TITLE
Builtin: Add C23 unreachable() support to frontend

### DIFF
--- a/include/stddef.h
+++ b/include/stddef.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-/* Todo: Set to 202311L once header is compliant with C23 */
-#define __STDC_VERSION_STDDEF_H__ 0
+#define __STDC_VERSION_STDDEF_H__ 202311L
 
 typedef __PTRDIFF_TYPE__ ptrdiff_t;
 typedef __SIZE_TYPE__ size_t;
@@ -19,8 +18,14 @@ typedef struct {
 #define offsetof(T, member) __builtin_offsetof(T, member)
 
 #if __STDC_VERSION__ >= 202311L
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpre-c2x-compat"
-typedef typeof(nullptr) nullptr_t;
-#pragma GCC diagnostic pop
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wpre-c2x-compat"
+   typedef typeof(nullptr) nullptr_t;
+#  pragma GCC diagnostic pop
+
+#  if defined unreachable
+#    error unreachable() is a standard macro in C23
+#  else
+#    define unreachable() __builtin_unreachable()
+#  endif
 #endif

--- a/src/Builtins.zig
+++ b/src/Builtins.zig
@@ -53,7 +53,7 @@ fn add(
 }
 
 pub fn create(comp: *Compilation) !Builtins {
-    const builtin_count = 3;
+    const builtin_count = 4;
     const param_count = 5;
 
     var b = BuiltinMap{};
@@ -71,6 +71,7 @@ pub fn create(comp: *Compilation) !Builtins {
     add(a, &b, "__builtin_va_start", void_ty, &.{ va_list, .{ .specifier = .special_va_start } }, .func, .{});
     add(a, &b, "__builtin_va_end", void_ty, &.{va_list}, .func, .{});
     add(a, &b, "__builtin_va_copy", void_ty, &.{ va_list, va_list }, .func, .{});
+    add(a, &b, "__builtin_unreachable", void_ty, &.{}, .func, .{ .noreturn = true });
 
     return Builtins{ ._builtins = b, ._params = _params };
 }

--- a/test/cases/unreachable.c
+++ b/test/cases/unreachable.c
@@ -1,0 +1,5 @@
+//aro-args -std=c2x
+#include <stddef.h>
+void foo(void) {
+	unreachable();
+}


### PR DESCRIPTION
Note: the `Type` returned by `Builtin.get` for `__builtin_unreachable` is currently incorrect since it doesn't include the `noreturn` attribute - do you want me to add that or will that be handled in by grabbing the associated `Builtin.Attributes` object?