### PR TITLE
Type: remove unused parameters to `combine`

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -2562,7 +2562,7 @@ fn declarator(
         try p.expectClosing(l_paren, .r_paren);
         const suffix_start = p.tok_i;
         const outer = try p.directDeclarator(d.ty, &d, kind);
-        try res.ty.combine(outer, p, res.func_declarator orelse suffix_start);
+        try res.ty.combine(outer);
         try res.ty.validateCombinedType(p, suffix_start);
         res.old_style_func = d.old_style_func;
         return res;
@@ -2702,7 +2702,7 @@ fn directDeclarator(p: *Parser, base_type: Type, d: *Declarator, kind: Declarato
             res_ty.specifier = .array;
         }
 
-        try res_ty.combine(outer, p, l_bracket);
+        try res_ty.combine(outer);
         return res_ty;
     } else if (p.eatToken(.l_paren)) |l_paren| {
         d.func_declarator = l_paren;
@@ -2718,7 +2718,7 @@ fn directDeclarator(p: *Parser, base_type: Type, d: *Declarator, kind: Declarato
             var res_ty = Type{ .specifier = .func, .data = .{ .func = func_ty } };
 
             const outer = try p.directDeclarator(base_type, d, kind);
-            try res_ty.combine(outer, p, l_paren);
+            try res_ty.combine(outer);
             return res_ty;
         }
 
@@ -2760,7 +2760,7 @@ fn directDeclarator(p: *Parser, base_type: Type, d: *Declarator, kind: Declarato
         };
 
         const outer = try p.directDeclarator(base_type, d, kind);
-        try res_ty.combine(outer, p, l_paren);
+        try res_ty.combine(outer);
         return res_ty;
     } else return base_type;
 }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1165,20 +1165,20 @@ pub fn makeComplex(ty: Type) Type {
 }
 
 /// Combines types recursively in the order they were parsed, uses `.void` specifier as a sentinel value.
-pub fn combine(inner: *Type, outer: Type, p: *Parser, source_tok: TokenIndex) Parser.Error!void {
+pub fn combine(inner: *Type, outer: Type) Parser.Error!void {
     switch (inner.specifier) {
-        .pointer => return inner.data.sub_type.combine(outer, p, source_tok),
+        .pointer => return inner.data.sub_type.combine(outer),
         .unspecified_variable_len_array => {
-            try inner.data.sub_type.combine(outer, p, source_tok);
+            try inner.data.sub_type.combine(outer);
         },
         .variable_len_array => {
-            try inner.data.expr.ty.combine(outer, p, source_tok);
+            try inner.data.expr.ty.combine(outer);
         },
         .array, .static_array, .incomplete_array => {
-            try inner.data.array.elem.combine(outer, p, source_tok);
+            try inner.data.array.elem.combine(outer);
         },
         .func, .var_args_func, .old_style_func => {
-            try inner.data.func.return_type.combine(outer, p, source_tok);
+            try inner.data.func.return_type.combine(outer);
         },
         .decayed_array,
         .decayed_static_array,


### PR DESCRIPTION
These parameters don't seem to actually be used (just passed along to recursive calls to the same function). Not sure if they're there as a placeholder for future use or just a remnant of some earlier code