### PR TITLE
Fix some promotion edge cases

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -529,6 +529,10 @@ fn generateBuiltinTypes(comp: *Compilation) !void {
     try comp.generateNsConstantStringType();
 }
 
+pub fn hasHalfPrecisionFloatABI(comp: *const Compilation) bool {
+    return target.hasHalfPrecisionFloatABI(comp.target);
+}
+
 fn generateNsConstantStringType(comp: *Compilation) !void {
     comp.types.ns_constant_string.record = .{
         .name = try comp.intern("__NSConstantString_tag"),

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -530,7 +530,7 @@ fn generateBuiltinTypes(comp: *Compilation) !void {
 }
 
 pub fn hasHalfPrecisionFloatABI(comp: *const Compilation) bool {
-    return target.hasHalfPrecisionFloatABI(comp.target);
+    return comp.langopts.allow_half_args_and_returns or target.hasHalfPrecisionFloatABI(comp.target);
 }
 
 fn generateNsConstantStringType(comp: *Compilation) !void {

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2214,8 +2214,8 @@ const messages = struct {
         const extra = .str;
         const kind = .@"error";
     };
-    const suggest_pointer_for_invalid_parameter_type = struct {
-        const msg = "parameters cannot have {s} type; did you forget * ?";
+    const suggest_pointer_for_invalid_fp16 = struct {
+        const msg = "{s} cannot have __fp16 type; did you forget * ?";
         const extra = .str;
         const kind = .@"error";
     };

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2214,6 +2214,11 @@ const messages = struct {
         const extra = .str;
         const kind = .@"error";
     };
+    const suggest_pointer_for_invalid_parameter_type = struct {
+        const msg = "parameters cannot have {s} type; did you forget * ?";
+        const extra = .str;
+        const kind = .@"error";
+    };
 };
 
 list: std.ArrayListUnmanaged(Message) = .{},

--- a/src/Driver.zig
+++ b/src/Driver.zig
@@ -75,6 +75,8 @@ pub const usage =
     \\  -fmacro-backtrace-limit=<limit>
     \\                          Set limit on how many macro expansion traces are shown in errors (default 6)
     \\  -fnative-half-type      Use the native half type for __fp16 instead of promoting to float
+    \\  -fnative-half-arguments-and-returns
+    \\                          Allow half-precision function arguments and return values
     \\  -fshort-enums           Use the narrowest possible integer type for enums
     \\  -fno-short-enums        Use "int" as the tag type for enums
     \\  -fsyntax-only           Only run the preprocessor, parser, and semantic analysis stages
@@ -185,6 +187,8 @@ pub fn parseArgs(
                 d.comp.diag.macro_backtrace_limit = limit;
             } else if (mem.eql(u8, arg, "-fnative-half-type")) {
                 d.comp.langopts.use_native_half_type = true;
+            } else if (mem.eql(u8, arg, "-fnative-half-arguments-and-returns")) {
+                d.comp.langopts.allow_half_args_and_returns = true;
             } else if (mem.eql(u8, arg, "-fshort-enums")) {
                 d.comp.langopts.short_enums = true;
             } else if (mem.eql(u8, arg, "-fno-short-enums")) {

--- a/src/Driver.zig
+++ b/src/Driver.zig
@@ -64,6 +64,8 @@ pub const usage =
     \\  -fno-color-diagnostics  Disable colors in diagnostics
     \\  -fdeclspec              Enable support for __declspec attributes
     \\  -fno-declspec           Disable support for __declspec attributes
+    \\  -ffp-eval-method=[source|double|extended]
+    \\                          Evaluation method to use for floating-point arithmetic
     \\  -fms-extensions         Enable support for Microsoft extensions
     \\  -fno-ms-extensions      Disable support for Microsoft extensions
     \\  -fdollars-in-identifiers        

--- a/src/Driver.zig
+++ b/src/Driver.zig
@@ -74,6 +74,7 @@ pub const usage =
     \\                          Disallow '$' in identifiers
     \\  -fmacro-backtrace-limit=<limit>
     \\                          Set limit on how many macro expansion traces are shown in errors (default 6)
+    \\  -fnative-half-type      Use the native half type for __fp16 instead of promoting to float
     \\  -fshort-enums           Use the narrowest possible integer type for enums
     \\  -fno-short-enums        Use "int" as the tag type for enums
     \\  -fsyntax-only           Only run the preprocessor, parser, and semantic analysis stages
@@ -182,6 +183,8 @@ pub fn parseArgs(
 
                 if (limit == 0) limit = std.math.maxInt(u32);
                 d.comp.diag.macro_backtrace_limit = limit;
+            } else if (mem.eql(u8, arg, "-fnative-half-type")) {
+                d.comp.langopts.use_native_half_type = true;
             } else if (mem.eql(u8, arg, "-fshort-enums")) {
                 d.comp.langopts.short_enums = true;
             } else if (mem.eql(u8, arg, "-fno-short-enums")) {

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -96,6 +96,8 @@ declspec_attrs: bool = false,
 ms_extensions: bool = false,
 /// true or false if digraph support explicitly enabled/disabled with -fdigraphs/-fno-digraphs
 digraphs: ?bool = null,
+/// If set, use the native half type instead of promoting to float
+use_native_half_type: bool = false,
 
 /// null indicates that the user did not select a value, use target to determine default
 fp_eval_method: ?FPEvalMethod = null,

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -98,7 +98,8 @@ ms_extensions: bool = false,
 digraphs: ?bool = null,
 /// If set, use the native half type instead of promoting to float
 use_native_half_type: bool = false,
-
+/// If set, function arguments and return values may be of type __fp16 even if there is no standard ABI for it
+allow_half_args_and_returns: bool = false,
 /// null indicates that the user did not select a value, use target to determine default
 fp_eval_method: ?FPEvalMethod = null,
 

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4817,6 +4817,9 @@ const Result = struct {
     }
 
     fn usualUnaryConversion(res: *Result, p: *Parser, tok: TokenIndex) Error!void {
+        if (res.ty.is(.fp16) and !p.comp.langopts.use_native_half_type) {
+            return res.floatCast(p, .{ .specifier = .float });
+        }
         if (res.ty.isInt()) {
             const slice = p.nodes.slice();
             if (Tree.bitfieldWidth(slice, res.node, true)) |width| {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4818,7 +4818,13 @@ const Result = struct {
 
     fn usualUnaryConversion(res: *Result, p: *Parser, tok: TokenIndex) Error!void {
         if (res.ty.isInt()) {
-            try res.intCast(p, res.ty.integerPromotion(p.comp), tok);
+            const slice = p.nodes.slice();
+            if (Tree.bitfieldWidth(slice, res.node, true)) |width| {
+                if (res.ty.bitfieldPromotion(p.comp, width)) |promotion_ty| {
+                    return res.intCast(p, promotion_ty, tok);
+                }
+            }
+            return res.intCast(p, res.ty.integerPromotion(p.comp), tok);
         }
     }
 

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -3573,9 +3573,8 @@ fn stmt(p: *Parser) Error!NodeIndex {
         var cond = try p.expr();
         try cond.expect(p);
         try cond.lvalConversion(p);
-        if (cond.ty.isInt())
-            try cond.intCast(p, cond.ty.integerPromotion(p.comp), cond_tok)
-        else if (!cond.ty.isScalarNonInt())
+        try cond.usualUnaryConversion(p, cond_tok);
+        if (!cond.ty.isScalar())
             try p.errStr(.statement_scalar, l_paren + 1, try p.typeStr(cond.ty));
         try cond.saveValue(p);
         try p.expectClosing(l_paren, .r_paren);
@@ -3600,9 +3599,9 @@ fn stmt(p: *Parser) Error!NodeIndex {
         var cond = try p.expr();
         try cond.expect(p);
         try cond.lvalConversion(p);
-        if (cond.ty.isInt())
-            try cond.intCast(p, cond.ty.integerPromotion(p.comp), cond_tok)
-        else
+        try cond.usualUnaryConversion(p, cond_tok);
+
+        if (!cond.ty.isInt())
             try p.errStr(.statement_int, l_paren + 1, try p.typeStr(cond.ty));
         try cond.saveValue(p);
         try p.expectClosing(l_paren, .r_paren);
@@ -3631,9 +3630,8 @@ fn stmt(p: *Parser) Error!NodeIndex {
         var cond = try p.expr();
         try cond.expect(p);
         try cond.lvalConversion(p);
-        if (cond.ty.isInt())
-            try cond.intCast(p, cond.ty.integerPromotion(p.comp), cond_tok)
-        else if (!cond.ty.isScalarNonInt())
+        try cond.usualUnaryConversion(p, cond_tok);
+        if (!cond.ty.isScalar())
             try p.errStr(.statement_scalar, l_paren + 1, try p.typeStr(cond.ty));
         try cond.saveValue(p);
         try p.expectClosing(l_paren, .r_paren);
@@ -3664,9 +3662,9 @@ fn stmt(p: *Parser) Error!NodeIndex {
         var cond = try p.expr();
         try cond.expect(p);
         try cond.lvalConversion(p);
-        if (cond.ty.isInt())
-            try cond.intCast(p, cond.ty.integerPromotion(p.comp), cond_tok)
-        else if (!cond.ty.isScalarNonInt())
+        try cond.usualUnaryConversion(p, cond_tok);
+
+        if (!cond.ty.isScalar())
             try p.errStr(.statement_scalar, l_paren + 1, try p.typeStr(cond.ty));
         try cond.saveValue(p);
         try p.expectClosing(l_paren, .r_paren);
@@ -3699,9 +3697,8 @@ fn stmt(p: *Parser) Error!NodeIndex {
         var cond = try p.expr();
         if (cond.node != .none) {
             try cond.lvalConversion(p);
-            if (cond.ty.isInt())
-                try cond.intCast(p, cond.ty.integerPromotion(p.comp), cond_tok)
-            else if (!cond.ty.isScalarNonInt())
+            try cond.usualUnaryConversion(p, cond_tok);
+            if (!cond.ty.isScalar())
                 try p.errStr(.statement_scalar, l_paren + 1, try p.typeStr(cond.ty));
         }
         try cond.saveValue(p);
@@ -4819,7 +4816,16 @@ const Result = struct {
         try res.implicitCast(p, .null_to_pointer);
     }
 
+    fn usualUnaryConversion(res: *Result, p: *Parser, tok: TokenIndex) Error!void {
+        if (res.ty.isInt()) {
+            try res.intCast(p, res.ty.integerPromotion(p.comp), tok);
+        }
+    }
+
     fn usualArithmeticConversion(a: *Result, b: *Result, p: *Parser, tok: TokenIndex) Error!void {
+        try a.usualUnaryConversion(p, tok);
+        try b.usualUnaryConversion(p, tok);
+
         // if either is a float cast to that type
         if (a.ty.isFloat() or b.ty.isFloat()) {
             const float_types = [6][2]Type.Specifier{
@@ -4848,21 +4854,18 @@ const Result = struct {
             if (try a.floatConversion(b, a_spec, b_spec, p, float_types[5])) return;
         }
 
-        // Do integer promotion on both operands
-        const a_promoted = a.ty.integerPromotion(p.comp);
-        const b_promoted = b.ty.integerPromotion(p.comp);
-        if (a_promoted.eql(b_promoted, p.comp, true)) {
+        if (a.ty.eql(b.ty, p.comp, true)) {
             // cast to promoted type
-            try a.intCast(p, a_promoted, tok);
-            try b.intCast(p, a_promoted, tok);
+            try a.intCast(p, a.ty, tok);
+            try b.intCast(p, b.ty, tok);
             return;
         }
 
-        const a_unsigned = a_promoted.isUnsignedInt(p.comp);
-        const b_unsigned = b_promoted.isUnsignedInt(p.comp);
+        const a_unsigned = a.ty.isUnsignedInt(p.comp);
+        const b_unsigned = b.ty.isUnsignedInt(p.comp);
         if (a_unsigned == b_unsigned) {
             // cast to greater signed or unsigned type
-            const res_spec = std.math.max(@enumToInt(a_promoted.specifier), @enumToInt(b_promoted.specifier));
+            const res_spec = std.math.max(@enumToInt(a.ty.specifier), @enumToInt(b.ty.specifier));
             const res_ty = Type{ .specifier = @intToEnum(Type.Specifier, res_spec) };
             try a.intCast(p, res_ty, tok);
             try b.intCast(p, res_ty, tok);
@@ -4870,15 +4873,15 @@ const Result = struct {
         }
 
         // cast to the unsigned type with greater rank
-        const a_larger = @enumToInt(a_promoted.specifier) > @enumToInt(b_promoted.specifier);
-        const b_larger = @enumToInt(b_promoted.specifier) > @enumToInt(a_promoted.specifier);
+        const a_larger = @enumToInt(a.ty.specifier) > @enumToInt(b.ty.specifier);
+        const b_larger = @enumToInt(b.ty.specifier) > @enumToInt(a.ty.specifier);
         if (a_unsigned) {
-            const target = if (a_larger) a_promoted else b_promoted;
+            const target = if (a_larger) a.ty else b.ty;
             try a.intCast(p, target, tok);
             try b.intCast(p, target, tok);
         } else {
             assert(b_unsigned);
-            const target = if (b_larger) b_promoted else a_promoted;
+            const target = if (b_larger) b.ty else a.ty;
             try a.intCast(p, target, tok);
             try b.intCast(p, target, tok);
         }
@@ -6064,7 +6067,8 @@ fn unExpr(p: *Parser) Error!Result {
             if (!operand.ty.isInt() and !operand.ty.isFloat())
                 try p.errStr(.invalid_argument_un, tok, try p.typeStr(operand.ty));
 
-            if (operand.ty.isInt()) try operand.intCast(p, operand.ty.integerPromotion(p.comp), tok);
+            try operand.usualUnaryConversion(p, tok);
+
             return operand;
         },
         .minus => {
@@ -6076,7 +6080,7 @@ fn unExpr(p: *Parser) Error!Result {
             if (!operand.ty.isInt() and !operand.ty.isFloat())
                 try p.errStr(.invalid_argument_un, tok, try p.typeStr(operand.ty));
 
-            if (operand.ty.isInt()) try operand.intCast(p, operand.ty.integerPromotion(p.comp), tok);
+            try operand.usualUnaryConversion(p, tok);
             if (operand.val.tag == .int or operand.val.tag == .float) {
                 _ = operand.val.sub(operand.val.zero(), operand.val, operand.ty, p.comp);
             } else {
@@ -6097,7 +6101,7 @@ fn unExpr(p: *Parser) Error!Result {
                 try p.errTok(.not_assignable, tok);
                 return error.ParsingFailed;
             }
-            if (operand.ty.isInt()) try operand.intCast(p, operand.ty.integerPromotion(p.comp), tok);
+            try operand.usualUnaryConversion(p, tok);
 
             if (operand.val.tag == .int or operand.val.tag == .float) {
                 if (operand.val.add(operand.val, operand.val.one(), operand.ty, p.comp))
@@ -6121,7 +6125,7 @@ fn unExpr(p: *Parser) Error!Result {
                 try p.errTok(.not_assignable, tok);
                 return error.ParsingFailed;
             }
-            if (operand.ty.isInt()) try operand.intCast(p, operand.ty.integerPromotion(p.comp), tok);
+            try operand.usualUnaryConversion(p, tok);
 
             if (operand.val.tag == .int or operand.val.tag == .float) {
                 if (operand.val.sub(operand.val, operand.val.one(), operand.ty, p.comp))
@@ -6139,13 +6143,13 @@ fn unExpr(p: *Parser) Error!Result {
             var operand = try p.castExpr();
             try operand.expect(p);
             try operand.lvalConversion(p);
-            if (!operand.ty.isInt()) try p.errStr(.invalid_argument_un, tok, try p.typeStr(operand.ty));
+            try operand.usualUnaryConversion(p, tok);
             if (operand.ty.isInt()) {
-                try operand.intCast(p, operand.ty.integerPromotion(p.comp), tok);
                 if (operand.val.tag == .int) {
                     operand.val = operand.val.bitNot(operand.ty, p.comp);
                 }
             } else {
+                try p.errStr(.invalid_argument_un, tok, try p.typeStr(operand.ty));
                 operand.val.tag = .unavailable;
             }
             try operand.un(p, .bit_not_expr);
@@ -6160,7 +6164,7 @@ fn unExpr(p: *Parser) Error!Result {
             if (!operand.ty.isScalar())
                 try p.errStr(.invalid_argument_un, tok, try p.typeStr(operand.ty));
 
-            if (operand.ty.isInt()) try operand.intCast(p, operand.ty.integerPromotion(p.comp), tok);
+            try operand.usualUnaryConversion(p, tok);
             if (operand.val.tag == .int) {
                 const res = Value.int(@boolToInt(!operand.val.getBool()));
                 operand.val = res;
@@ -6362,7 +6366,7 @@ fn suffixExpr(p: *Parser, lhs: Result) Error!Result {
                 try p.err(.not_assignable);
                 return error.ParsingFailed;
             }
-            if (operand.ty.isInt()) try operand.intCast(p, operand.ty.integerPromotion(p.comp), p.tok_i);
+            try operand.usualUnaryConversion(p, p.tok_i);
 
             try operand.un(p, .post_inc_expr);
             return operand;
@@ -6378,7 +6382,7 @@ fn suffixExpr(p: *Parser, lhs: Result) Error!Result {
                 try p.err(.not_assignable);
                 return error.ParsingFailed;
             }
-            if (operand.ty.isInt()) try operand.intCast(p, operand.ty.integerPromotion(p.comp), p.tok_i);
+            try operand.usualUnaryConversion(p, p.tok_i);
 
             try operand.un(p, .post_dec_expr);
             return operand;

--- a/src/SymbolStack.zig
+++ b/src/SymbolStack.zig
@@ -287,7 +287,7 @@ pub fn defineParam(s: *SymbolStack, p: *Parser, name: StringId, ty: Type, tok: T
             else => {},
         }
     }
-    if (ty.is(.fp16)) {
+    if (ty.is(.fp16) and !p.comp.hasHalfPrecisionFloatABI()) {
         try p.errStr(.suggest_pointer_for_invalid_parameter_type, tok, "__fp16");
     }
     try s.syms.append(p.pp.comp.gpa, .{

--- a/src/SymbolStack.zig
+++ b/src/SymbolStack.zig
@@ -288,7 +288,7 @@ pub fn defineParam(s: *SymbolStack, p: *Parser, name: StringId, ty: Type, tok: T
         }
     }
     if (ty.is(.fp16) and !p.comp.hasHalfPrecisionFloatABI()) {
-        try p.errStr(.suggest_pointer_for_invalid_parameter_type, tok, "__fp16");
+        try p.errStr(.suggest_pointer_for_invalid_fp16, tok, "parameters");
     }
     try s.syms.append(p.pp.comp.gpa, .{
         .kind = .def,

--- a/src/SymbolStack.zig
+++ b/src/SymbolStack.zig
@@ -287,6 +287,9 @@ pub fn defineParam(s: *SymbolStack, p: *Parser, name: StringId, ty: Type, tok: T
             else => {},
         }
     }
+    if (ty.is(.fp16)) {
+        try p.errStr(.suggest_pointer_for_invalid_parameter_type, tok, "__fp16");
+    }
     try s.syms.append(p.pp.comp.gpa, .{
         .kind = .def,
         .name = name,

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1265,6 +1265,9 @@ pub fn validateCombinedType(ty: Type, p: *Parser, source_tok: TokenIndex) Parser
                 try p.errStr(.qual_on_ret_type, source_tok, "atomic");
                 ret_ty.qual.atomic = false;
             }
+            if (ret_ty.is(.fp16) and !p.comp.hasHalfPrecisionFloatABI()) {
+                try p.errStr(.suggest_pointer_for_invalid_fp16, source_tok, "function return value");
+            }
         },
         .typeof_type, .decayed_typeof_type => return ty.data.sub_type.validateCombinedType(p, source_tok),
         .typeof_expr, .decayed_typeof_expr => return ty.data.expr.ty.validateCombinedType(p, source_tok),

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1139,6 +1139,22 @@ pub fn originalTypeOfDecayedArray(ty: Type) Type {
     return copy;
 }
 
+/// Rank for floating point conversions, ignoring domain (complex vs real)
+/// Asserts that ty is a floating point type
+pub fn floatRank(ty: Type) usize {
+    const real = ty.makeReal();
+    return switch (real.specifier) {
+        // TODO: bfloat16 => 0, float16 => 1
+        .fp16 => 2,
+        .float => 3,
+        .double => 4,
+        .long_double => 5,
+        .float128 => 6,
+        // TODO: ibm128 => 7
+        else => unreachable,
+    };
+}
+
 pub fn makeReal(ty: Type) Type {
     // TODO discards attributed/typeof
     var base = ty.canonicalize(.standard);

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -702,6 +702,24 @@ pub fn integerPromotion(ty: Type, comp: *Compilation) Type {
     };
 }
 
+/// Promote a bitfield. If `int` can hold all the values of the underlying field,
+/// promote to int. Otherwise, promote to unsigned int
+/// Returns null if no promotion is necessary
+pub fn bitfieldPromotion(ty: Type, comp: *Compilation, width: u32) ?Type {
+    const type_size_bits = ty.bitSizeof(comp).?;
+
+    // Note: GCC and clang will promote `long: 3` to int even though the C standard does not allow this
+    if (width < type_size_bits) {
+        return int;
+    }
+
+    if (width == type_size_bits) {
+        return if (ty.isUnsignedInt(comp)) .{ .specifier = .uint } else int;
+    }
+
+    return null;
+}
+
 pub fn hasIncompleteSize(ty: Type) bool {
     return switch (ty.specifier) {
         .void, .incomplete_array, .invalid => true,

--- a/src/target.zig
+++ b/src/target.zig
@@ -164,6 +164,13 @@ pub fn hasInt128(target: std.Target) bool {
     return target.cpu.arch.ptrBitWidth() >= 64;
 }
 
+pub fn hasHalfPrecisionFloatABI(target: std.Target) bool {
+    return switch (target.cpu.arch) {
+        .thumb, .thumbeb, .arm, .aarch64 => true,
+        else => false,
+    };
+}
+
 pub const FPSemantics = enum {
     None,
     IEEEHalf,

--- a/test/cases/allow fp16 parameter.c
+++ b/test/cases/allow fp16 parameter.c
@@ -1,0 +1,5 @@
+//aro-args --target=x86_64-linux-gnu -fnative-half-arguments-and-returns
+
+void foo(__fp16 x) {
+
+}

--- a/test/cases/allow fp16 parameter.c
+++ b/test/cases/allow fp16 parameter.c
@@ -1,5 +1,5 @@
 //aro-args --target=x86_64-linux-gnu -fnative-half-arguments-and-returns
 
-void foo(__fp16 x) {
-
+__fp16 foo(__fp16 x) {
+    return 0;
 }

--- a/test/cases/ast/float eval method.c
+++ b/test/cases/ast/float eval method.c
@@ -1,0 +1,57 @@
+fn_def: 'fn () void'
+ name: foo
+ body:
+  compound_stmt: 'void'
+    var: 'float'
+     name: a
+     init:
+      float_literal: 'float' (value: 1)
+
+    var: 'float'
+     name: b
+     init:
+      float_literal: 'float' (value: 2)
+
+    var: 'float'
+     name: c
+     init:
+      implicit_cast: (float_cast) 'float'
+        add_expr: 'double'
+         lhs:
+          implicit_cast: (float_cast) 'double'
+            implicit_cast: (lval_to_rval) 'float'
+              decl_ref_expr: 'float' lvalue
+               name: a
+         rhs:
+          implicit_cast: (float_cast) 'double'
+            implicit_cast: (lval_to_rval) 'float'
+              decl_ref_expr: 'float' lvalue
+               name: b
+
+    var: '_Complex float'
+     name: ca
+     init:
+      implicit_cast: (real_to_complex_float) '_Complex float'
+        float_literal: 'float' (value: 0)
+
+    assign_expr: '_Complex float'
+     lhs:
+      decl_ref_expr: '_Complex float' lvalue
+       name: ca
+     rhs:
+      implicit_cast: (complex_float_cast) '_Complex float'
+        add_expr: '_Complex double'
+         lhs:
+          implicit_cast: (complex_float_cast) '_Complex double'
+            implicit_cast: (lval_to_rval) '_Complex float'
+              decl_ref_expr: '_Complex float' lvalue
+               name: ca
+         rhs:
+          implicit_cast: (real_to_complex_float) '_Complex double'
+            implicit_cast: (float_cast) 'double'
+              implicit_cast: (lval_to_rval) 'float'
+                decl_ref_expr: 'float' lvalue
+                 name: a
+
+    implicit_return: 'void'
+

--- a/test/cases/ast/native half type.c
+++ b/test/cases/ast/native half type.c
@@ -1,0 +1,33 @@
+fn_def: 'fn () void'
+ name: foo
+ body:
+  compound_stmt: 'void'
+    var: '__fp16'
+     name: x
+     init:
+      implicit_cast: (float_cast) '__fp16'
+        float_literal: 'float' (value: 1)
+
+    var: '__fp16'
+     name: y
+     init:
+      implicit_cast: (float_cast) '__fp16'
+        float_literal: 'float' (value: 2)
+
+    assign_expr: '__fp16'
+     lhs:
+      decl_ref_expr: '__fp16' lvalue
+       name: x
+     rhs:
+      add_expr: '__fp16'
+       lhs:
+        implicit_cast: (lval_to_rval) '__fp16'
+          decl_ref_expr: '__fp16' lvalue
+           name: x
+       rhs:
+        implicit_cast: (lval_to_rval) '__fp16'
+          decl_ref_expr: '__fp16' lvalue
+           name: y
+
+    implicit_return: 'void'
+

--- a/test/cases/ast/promotion edge cases.c
+++ b/test/cases/ast/promotion edge cases.c
@@ -77,5 +77,29 @@ fn_def: 'fn () void'
        rhs:
         int_literal: 'int' (value: 1)
 
+    var: '__fp16'
+     name: fp16
+     init:
+      implicit_cast: (float_cast) '__fp16'
+        float_literal: 'float' (value: 0)
+
+    assign_expr: '__fp16'
+     lhs:
+      decl_ref_expr: '__fp16' lvalue
+       name: fp16
+     rhs:
+      implicit_cast: (float_cast) '__fp16'
+        add_expr: 'float'
+         lhs:
+          implicit_cast: (float_cast) 'float'
+            implicit_cast: (lval_to_rval) '__fp16'
+              decl_ref_expr: '__fp16' lvalue
+               name: fp16
+         rhs:
+          implicit_cast: (float_cast) 'float'
+            implicit_cast: (lval_to_rval) '__fp16'
+              decl_ref_expr: '__fp16' lvalue
+               name: fp16
+
     implicit_return: 'void'
 

--- a/test/cases/ast/promotion edge cases.c
+++ b/test/cases/ast/promotion edge cases.c
@@ -1,0 +1,81 @@
+struct_decl_two: 'struct S'
+  record_field_decl: 'unsigned int'
+   name: x
+   bits:
+    int_literal: 'int' (value: 3)
+  record_field_decl: 'long'
+   name: y
+   bits:
+    int_literal: 'int' (value: 5)
+
+fn_def: 'fn () void'
+ name: foo
+ body:
+  compound_stmt: 'void'
+    var: 'char'
+     name: c
+     init:
+      implicit_cast: (int_cast) 'char'
+        int_literal: 'int' (value: 0)
+
+    var: 'double'
+     name: d
+     init:
+      double_literal: 'double' (value: 2)
+
+    assign_expr: 'double'
+     lhs:
+      decl_ref_expr: 'double' lvalue
+       name: d
+     rhs:
+      add_expr: 'double'
+       lhs:
+        implicit_cast: (lval_to_rval) 'double'
+          decl_ref_expr: 'double' lvalue
+           name: d
+       rhs:
+        implicit_cast: (int_to_float) 'double'
+          implicit_cast: (int_cast) 'int'
+            implicit_cast: (lval_to_rval) 'char'
+              decl_ref_expr: 'char' lvalue
+               name: c
+
+    var: 'struct S'
+     name: s
+     init:
+      struct_init_expr_two: 'struct S'
+        int_literal: 'unsigned int' (value: 1)
+        int_literal: 'long' (value: 1)
+
+    var: 'int'
+     name: x
+     init:
+      add_expr: 'int'
+       lhs:
+        implicit_cast: (int_cast) 'int'
+          implicit_cast: (lval_to_rval) 'unsigned int'
+            member_access_expr: 'unsigned int' lvalue bitfield
+             lhs:
+              decl_ref_expr: 'struct S' lvalue
+               name: s
+             name: x
+       rhs:
+        int_literal: 'int' (value: 1)
+
+    var: 'int'
+     name: y
+     init:
+      add_expr: 'int'
+       lhs:
+        implicit_cast: (int_cast) 'int'
+          implicit_cast: (lval_to_rval) 'long'
+            member_access_expr: 'long' lvalue bitfield
+             lhs:
+              decl_ref_expr: 'struct S' lvalue
+               name: s
+             name: y
+       rhs:
+        int_literal: 'int' (value: 1)
+
+    implicit_return: 'void'
+

--- a/test/cases/float eval method.c
+++ b/test/cases/float eval method.c
@@ -1,0 +1,8 @@
+//aro-args -ffp-eval-method=double --target=x86_64-linux-gnu
+
+void foo(void) {
+	float a = 1.0f, b = 2.0f;
+	float c = a + b;
+	_Complex float ca = 0.0f;
+	ca = ca + a;
+}

--- a/test/cases/fp16 parameter aarch64.c
+++ b/test/cases/fp16 parameter aarch64.c
@@ -1,4 +1,4 @@
 //aro-args --target=aarch64-linux-gnu
-void foo(__fp16 x) {
-
+__fp16 foo(__fp16 x) {
+	return 0;
 }

--- a/test/cases/fp16 parameter aarch64.c
+++ b/test/cases/fp16 parameter aarch64.c
@@ -1,0 +1,4 @@
+//aro-args --target=aarch64-linux-gnu
+void foo(__fp16 x) {
+
+}

--- a/test/cases/fp16 parameter.c
+++ b/test/cases/fp16 parameter.c
@@ -1,0 +1,6 @@
+void foo(__fp16 param) {
+
+}
+
+#define EXPECTED_ERRORS "fp16 parameter.c:1:17: error: parameters cannot have __fp16 type; did you forget * ?" \
+

--- a/test/cases/fp16 parameter.c
+++ b/test/cases/fp16 parameter.c
@@ -1,6 +1,7 @@
-void foo(__fp16 param) {
-
+__fp16 foo(__fp16 param) {
+    return 0;
 }
 
-#define EXPECTED_ERRORS "fp16 parameter.c:1:17: error: parameters cannot have __fp16 type; did you forget * ?" \
+#define EXPECTED_ERRORS "fp16 parameter.c:1:19: error: parameters cannot have __fp16 type; did you forget * ?" \
+    "fp16 parameter.c:1:11: error: function return value cannot have __fp16 type; did you forget * ?" \
 

--- a/test/cases/native half type.c
+++ b/test/cases/native half type.c
@@ -1,0 +1,6 @@
+//aro-args -fnative-half-type
+void foo(void) {
+	__fp16 x = 1.0f;
+	__fp16 y = 2.0f;
+	x = x + y;
+}

--- a/test/cases/promotion edge cases.c
+++ b/test/cases/promotion edge cases.c
@@ -1,0 +1,12 @@
+struct S {
+    unsigned x: 3;
+    long y: 5;
+};
+void foo(void) {
+    char c = 0;
+    double d = 2.0;
+    d = d + c; // promote char to int then to double
+    struct S s = { .x = 1U, .y = 1L};
+    int x = s.x + 1; // unsigned bitfield promotes to int if it fits
+    int y = s.y + 1; // long bitfield promotes to int if it fits
+}

--- a/test/cases/promotion edge cases.c
+++ b/test/cases/promotion edge cases.c
@@ -9,4 +9,6 @@ void foo(void) {
     struct S s = { .x = 1U, .y = 1L};
     int x = s.x + 1; // unsigned bitfield promotes to int if it fits
     int y = s.y + 1; // long bitfield promotes to int if it fits
+    __fp16 fp16 = 0.0f;
+    fp16 = fp16 + fp16; // __fp16 casts to float for arithmetic
 }


### PR DESCRIPTION
Promote char/short to int before converting to floating point if use in FP arithmetic.

Promote bitfields to int if int is large enough to contain all the values (keeping some gcc/clang errata)

Promote __fp16 to float for arithmetic, and disallow it as a parameter type

Use fp_eval_method setting to promote intermediate floating point results

Avoid extra implicit cast when converting between real and complex of same underlying type in an init expression.