### PR TITLE
Parser: Add `_Float16` support

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1630,6 +1630,7 @@ fn typeSpec(p: *Parser, ty: *Type.Builder) Error!bool {
             .keyword_signed => try ty.combine(p, .signed, p.tok_i),
             .keyword_unsigned => try ty.combine(p, .unsigned, p.tok_i),
             .keyword_fp16 => try ty.combine(p, .fp16, p.tok_i),
+            .keyword_float16 => try ty.combine(p, .float16, p.tok_i),
             .keyword_float => try ty.combine(p, .float, p.tok_i),
             .keyword_double => try ty.combine(p, .double, p.tok_i),
             .keyword_complex => try ty.combine(p, .complex, p.tok_i),
@@ -4861,13 +4862,14 @@ const Result = struct {
 
         // if either is a float cast to that type
         if (a.ty.isFloat() or b.ty.isFloat()) {
-            const float_types = [6][2]Type.Specifier{
+            const float_types = [7][2]Type.Specifier{
                 .{ .complex_long_double, .long_double },
                 .{ .complex_float128, .float128 },
                 .{ .complex_float80, .float80 },
                 .{ .complex_double, .double },
                 .{ .complex_float, .float },
                 .{ .complex_fp16, .fp16 },
+                .{ .complex_float16, .float16 },
             };
             const a_spec = a.ty.canonicalize(.standard).specifier;
             const b_spec = b.ty.canonicalize(.standard).specifier;
@@ -4885,6 +4887,7 @@ const Result = struct {
             if (try a.floatConversion(b, a_spec, b_spec, p, float_types[3])) return;
             if (try a.floatConversion(b, a_spec, b_spec, p, float_types[4])) return;
             if (try a.floatConversion(b, a_spec, b_spec, p, float_types[5])) return;
+            if (try a.floatConversion(b, a_spec, b_spec, p, float_types[6])) return;
         }
 
         if (a.ty.eql(b.ty, p.comp, true)) {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4868,8 +4868,10 @@ const Result = struct {
                 .{ .complex_float80, .float80 },
                 .{ .complex_double, .double },
                 .{ .complex_float, .float },
-                .{ .complex_fp16, .fp16 },
-                .{ .complex_float16, .float16 },
+                // No `_Complex __fp16` type
+                .{ .invalid, .fp16 },
+                // No `_Complex _Float16`
+                .{ .invalid, .float16 },
             };
             const a_spec = a.ty.canonicalize(.standard).specifier;
             const b_spec = b.ty.canonicalize(.standard).specifier;

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7189,10 +7189,11 @@ fn parseFloat(p: *Parser, buf: []const u8, suffix: NumberSuffix) !Result {
             try p.err(.gnu_imaginary_constant);
             return p.todo("long double imaginary literals");
         },
-        .None, .I, .F, .IF => {
+        .None, .I, .F, .IF, .F16 => {
             const ty = Type{ .specifier = switch (suffix) {
                 .None, .I => .double,
                 .F, .IF => .float,
+                .F16 => .float16,
                 else => unreachable,
             } };
             const d_val = std.fmt.parseFloat(f64, buf) catch |er| switch (er) {
@@ -7202,6 +7203,7 @@ fn parseFloat(p: *Parser, buf: []const u8, suffix: NumberSuffix) !Result {
             const tag: Tree.Tag = switch (suffix) {
                 .None, .I => .double_literal,
                 .F, .IF => .float_literal,
+                .F16 => .float16_literal,
                 else => unreachable,
             };
             var res = Result{

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -241,6 +241,7 @@ pub const Token = struct {
         keyword_imag2,
         keyword_real1,
         keyword_real2,
+        keyword_float16,
 
         // clang keywords
         keyword_fp16,
@@ -375,6 +376,7 @@ pub const Token = struct {
                 .keyword_imag2,
                 .keyword_real1,
                 .keyword_real2,
+                .keyword_float16,
                 .keyword_fp16,
                 .keyword_declspec,
                 .keyword_int64,
@@ -632,6 +634,7 @@ pub const Token = struct {
                 .keyword_imag2 => "__imag__",
                 .keyword_real1 => "__real",
                 .keyword_real2 => "__real__",
+                .keyword_float16 => "_Float16",
                 .keyword_fp16 => "__fp16",
                 .keyword_declspec => "__declspec",
                 .keyword_int64 => "__int64",
@@ -899,6 +902,7 @@ pub const Token = struct {
         .{ "__imag__", .keyword_imag2 },
         .{ "__real", .keyword_real1 },
         .{ "__real__", .keyword_real2 },
+        .{ "_Float16", .keyword_float16 },
 
         // clang keywords
         .{ "__fp16", .keyword_fp16 },

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -470,6 +470,8 @@ pub const Tag = enum(u8) {
     int_literal,
     /// Same as int_literal, but originates from a char literal
     char_literal,
+    /// _Float16 literal
+    float16_literal,
     /// f32 literal
     float_literal,
     /// f64 literal
@@ -1181,6 +1183,7 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, mapper: StringInterner.Type
         .nullptr_literal,
         .int_literal,
         .char_literal,
+        .float16_literal,
         .float_literal,
         .double_literal,
         .string_literal_expr,

--- a/src/number_affixes.zig
+++ b/src/number_affixes.zig
@@ -74,6 +74,9 @@ pub const Suffix = enum {
     // float and imaginary float
     F, IF,
 
+    // _Float16
+    F16,
+
     // zig fmt: on
 
     const Tuple = struct { Suffix, []const []const u8 };
@@ -95,6 +98,7 @@ pub const Suffix = enum {
     };
 
     const FloatSuffixes = &[_]Tuple{
+        .{ .F16, &.{"F16"} },
         .{ .F, &.{"F"} },
         .{ .L, &.{"L"} },
 
@@ -110,7 +114,7 @@ pub const Suffix = enum {
             .float => FloatSuffixes,
             .int => IntSuffixes,
         };
-        var scratch: [2]u8 = undefined;
+        var scratch: [3]u8 = undefined;
         top: for (suffixes) |candidate| {
             const tag = candidate[0];
             const parts = candidate[1];
@@ -130,7 +134,7 @@ pub const Suffix = enum {
     pub fn isImaginary(suffix: Suffix) bool {
         return switch (suffix) {
             .I, .IL, .IF, .IU, .IUL, .ILL, .IULL => true,
-            .None, .L, .F, .U, .UL, .LL, .ULL => false,
+            .None, .L, .F16, .F, .U, .UL, .LL, .ULL => false,
         };
     }
 
@@ -138,7 +142,7 @@ pub const Suffix = enum {
         return switch (suffix) {
             .None, .L, .LL, .I, .IL, .ILL => true,
             .U, .UL, .ULL, .IU, .IUL, .IULL => false,
-            .F, .IF => unreachable,
+            .F, .IF, .F16 => unreachable,
         };
     }
 };

--- a/test/cases/_Float16.c
+++ b/test/cases/_Float16.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+
+_Float16 foo(_Float16 x, _Float16 y) {
+    return x + y ;
+}
+
+void bar(int x, ...) {
+    va_list va;
+    va_start(va, x);
+    va_end(va);
+}
+int baz();
+
+void quux(void) {
+    _Float16 f;
+    bar(1, f);  // _Float16 does not promote to double when used as vararg
+    baz(1, f);  // _Float16 does not promote to double when used as untyped arg
+}

--- a/test/cases/_Float16.c
+++ b/test/cases/_Float16.c
@@ -12,7 +12,7 @@ void bar(int x, ...) {
 int baz();
 
 void quux(void) {
-    _Float16 f;
+    _Float16 f = 1.0f16;
     bar(1, f);  // _Float16 does not promote to double when used as vararg
-    baz(1, f);  // _Float16 does not promote to double when used as untyped arg
+    baz(1, 2.0F16);  // _Float16 does not promote to double when used as untyped arg
 }

--- a/test/cases/_Float16.c
+++ b/test/cases/_Float16.c
@@ -1,3 +1,4 @@
+//aro-args --target=x86_64-linux-gnu
 #include <stdarg.h>
 
 _Float16 foo(_Float16 x, _Float16 y) {
@@ -15,4 +16,12 @@ void quux(void) {
     _Float16 f = 1.0f16;
     bar(1, f);  // _Float16 does not promote to double when used as vararg
     baz(1, 2.0F16);  // _Float16 does not promote to double when used as untyped arg
+}
+
+void conversions(void) {
+    double d = 1.0;
+    _Float16 f16 = 2.0f16;
+    __fp16 fp16 = 0;
+    d = d + f16;
+    (void)(f16 + fp16);  // _Float16 + __fp16 promotes both to float
 }

--- a/test/cases/ast/_Float16.c
+++ b/test/cases/ast/_Float16.c
@@ -79,3 +79,56 @@ fn_def: 'fn () void'
 
     implicit_return: 'void'
 
+fn_def: 'fn () void'
+ name: conversions
+ body:
+  compound_stmt: 'void'
+    var: 'double'
+     name: d
+     init:
+      double_literal: 'double' (value: 1)
+
+    var: '_Float16'
+     name: f16
+     init:
+      float16_literal: '_Float16' (value: 2)
+
+    var: '__fp16'
+     name: fp16
+     init:
+      implicit_cast: (int_to_float) '__fp16'
+        int_literal: 'int' (value: 0)
+
+    assign_expr: 'double'
+     lhs:
+      decl_ref_expr: 'double' lvalue
+       name: d
+     rhs:
+      add_expr: 'double'
+       lhs:
+        implicit_cast: (lval_to_rval) 'double'
+          decl_ref_expr: 'double' lvalue
+           name: d
+       rhs:
+        implicit_cast: (float_cast) 'double'
+          implicit_cast: (lval_to_rval) '_Float16'
+            decl_ref_expr: '_Float16' lvalue
+             name: f16
+
+    explicit_cast: (to_void) 'void'
+      paren_expr: 'float'
+       operand:
+        add_expr: 'float'
+         lhs:
+          implicit_cast: (float_cast) 'float'
+            implicit_cast: (lval_to_rval) '_Float16'
+              decl_ref_expr: '_Float16' lvalue
+               name: f16
+         rhs:
+          implicit_cast: (float_cast) 'float'
+            implicit_cast: (lval_to_rval) '__fp16'
+              decl_ref_expr: '__fp16' lvalue
+               name: fp16
+
+    implicit_return: 'void'
+

--- a/test/cases/ast/_Float16.c
+++ b/test/cases/ast/_Float16.c
@@ -1,0 +1,81 @@
+typedef: '[1]struct __va_list_tag'
+ name: va_list
+
+typedef: '[1]struct __va_list_tag'
+ name: __gnuc_va_list
+
+fn_def: 'fn (x: _Float16, y: _Float16) _Float16'
+ name: foo
+ body:
+  compound_stmt_two: 'void'
+    return_stmt: 'void'
+     expr:
+      add_expr: '_Float16'
+       lhs:
+        implicit_cast: (lval_to_rval) '_Float16'
+          decl_ref_expr: '_Float16' lvalue
+           name: x
+       rhs:
+        implicit_cast: (lval_to_rval) '_Float16'
+          decl_ref_expr: '_Float16' lvalue
+           name: y
+
+fn_def: 'fn (x: int, ...) void'
+ name: bar
+ body:
+  compound_stmt: 'void'
+    var: '[1]struct __va_list_tag'
+     name: va
+
+    builtin_call_expr: 'fn (d[1]struct __va_list_tag, ...) void'
+     name: __builtin_va_start
+     args:
+      implicit_cast: (array_to_pointer) 'd[1]struct __va_list_tag'
+        decl_ref_expr: '[1]struct __va_list_tag' lvalue
+         name: va
+      decl_ref_expr: 'int' lvalue
+       name: x
+
+    builtin_call_expr_one: 'fn (d[1]struct __va_list_tag) void'
+     name: __builtin_va_end
+     arg:
+      implicit_cast: (array_to_pointer) 'd[1]struct __va_list_tag'
+        decl_ref_expr: '[1]struct __va_list_tag' lvalue
+         name: va
+
+    implicit_return: 'void'
+
+fn_proto: 'fn (...) int'
+ name: baz
+
+fn_def: 'fn () void'
+ name: quux
+ body:
+  compound_stmt: 'void'
+    var: '_Float16'
+     name: f
+
+    call_expr: 'void'
+     lhs:
+      implicit_cast: (function_to_pointer) '*fn (x: int, ...) void'
+        decl_ref_expr: 'fn (x: int, ...) void' lvalue
+         name: bar
+     args:
+      int_literal: 'int' (value: 1)
+      implicit_cast: (lval_to_rval) '_Float16'
+        decl_ref_expr: '_Float16' lvalue
+         name: f
+
+    call_expr: 'int'
+     lhs:
+      implicit_cast: (function_to_pointer) '*fn (...) int'
+        decl_ref_expr: 'fn (...) int' lvalue
+         name: baz
+     args:
+      int_literal: 'int' (value: 1)
+      implicit_cast: (lval_to_rval) '_Float16'
+        decl_ref_expr: '_Float16' lvalue
+         name: f
+
+    implicit_return: 'void'
+

--- a/test/cases/ast/_Float16.c
+++ b/test/cases/ast/_Float16.c
@@ -54,6 +54,8 @@ fn_def: 'fn () void'
   compound_stmt: 'void'
     var: '_Float16'
      name: f
+     init:
+      float16_literal: '_Float16' (value: 1)
 
     call_expr: 'void'
      lhs:
@@ -73,9 +75,7 @@ fn_def: 'fn () void'
          name: baz
      args:
       int_literal: 'int' (value: 1)
-      implicit_cast: (lval_to_rval) '_Float16'
-        decl_ref_expr: '_Float16' lvalue
-         name: f
+      float16_literal: '_Float16' (value: 2)
 
     implicit_return: 'void'
 


### PR DESCRIPTION
Note: This includes the changes in the `promotions` branch.

Adds support for the `_Float16` type, and floating point literals of that type (`f16` suffix).

Removes `_Complex __fp16` since clang and gcc do not support that type.