### PR TITLE
Add C23 _BitInt suffix for integer literals

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -24,7 +24,7 @@ pub const Error = error{
     FatalError,
 } || Allocator.Error;
 
-pub const BitIntMaxBits = 128;
+pub const bit_int_max_bits = 128;
 
 gpa: Allocator,
 sources: std.StringArrayHashMap(Source),
@@ -349,7 +349,7 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     // try comp.generateIntMax(w, "UINTPTR", comp.types.size);
 
     // int widths
-    try w.print("#define __BITINT_MAXWIDTH__ {d}\n", .{BitIntMaxBits});
+    try w.print("#define __BITINT_MAXWIDTH__ {d}\n", .{bit_int_max_bits});
 
     // sizeof types
     try comp.generateSizeofType(w, "__SIZEOF_FLOAT__", .{ .specifier = .float });

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -24,6 +24,8 @@ pub const Error = error{
     FatalError,
 } || Allocator.Error;
 
+pub const BitIntMaxBits = 128;
+
 gpa: Allocator,
 sources: std.StringArrayHashMap(Source),
 diag: Diagnostics,
@@ -347,7 +349,7 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     // try comp.generateIntMax(w, "UINTPTR", comp.types.size);
 
     // int widths
-    try w.writeAll("#define __BITINT_MAXWIDTH__ 128\n");
+    try w.print("#define __BITINT_MAXWIDTH__ {d}\n", .{BitIntMaxBits});
 
     // sizeof types
     try comp.generateSizeofType(w, "__SIZEOF_FLOAT__", .{ .specifier = .float });

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2154,7 +2154,7 @@ const messages = struct {
         const kind = .@"error";
     };
     const bit_int_too_big = struct {
-        const msg = "{s} of bit sizes greater than 128 not supported";
+        const msg = "{s} of bit sizes greater than " ++ std.fmt.comptimePrint("{d}", .{Compilation.BitIntMaxBits}) ++ " not supported";
         const extra = .str;
         const kind = .@"error";
     };

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2219,6 +2219,12 @@ const messages = struct {
         const extra = .str;
         const kind = .@"error";
     };
+    const bitint_suffix = struct {
+        const msg = "'_BitInt' suffix for literals is a C2x extension";
+        const opt = "c2x-extensions";
+        const kind = .warning;
+        const suppress_version = .c2x;
+    };
 };
 
 list: std.ArrayListUnmanaged(Message) = .{},

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2154,7 +2154,7 @@ const messages = struct {
         const kind = .@"error";
     };
     const bit_int_too_big = struct {
-        const msg = "{s} of bit sizes greater than " ++ std.fmt.comptimePrint("{d}", .{Compilation.BitIntMaxBits}) ++ " not supported";
+        const msg = "{s} of bit sizes greater than " ++ std.fmt.comptimePrint("{d}", .{Compilation.bit_int_max_bits}) ++ " not supported";
         const extra = .str;
         const kind = .@"error";
     };

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7367,7 +7367,7 @@ fn bitInt(p: *Parser, base: u8, buf: []const u8, suffix: NumberSuffix, tok_i: To
         // value of the constant is positive or was specified in hexadecimal or octal notation.
         const sign_bits = @boolToInt(suffix.isSignedInteger());
         const bits_needed = count + sign_bits;
-        if (bits_needed > Compilation.BitIntMaxBits) {
+        if (bits_needed > Compilation.bit_int_max_bits) {
             const specifier: Type.Builder.Specifier = switch (suffix) {
                 .WB => .{ .bit_int = 0 },
                 .UWB => .{ .ubit_int = 0 },
@@ -7381,7 +7381,7 @@ fn bitInt(p: *Parser, base: u8, buf: []const u8, suffix: NumberSuffix, tok_i: To
         if (bits_needed > 64) {
             return p.todo("_BitInt constants > 64 bits");
         }
-        break :blk @intCast(std.math.IntFittingRange(0, Compilation.BitIntMaxBits), bits_needed);
+        break :blk @intCast(std.math.IntFittingRange(0, Compilation.bit_int_max_bits), bits_needed);
     };
 
     const val = c.to(u64) catch |e| switch (e) {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7361,7 +7361,8 @@ fn bitInt(p: *Parser, base: u8, buf: []const u8, suffix: NumberSuffix, tok_i: To
     };
     const c = managed.toConst();
     const bits_needed = blk: {
-        const count = c.bitCountTwosComp();
+        // Literal `0` requires at least 1 bit
+        const count = std.math.max(1, c.bitCountTwosComp());
         // The wb suffix results in a _BitInt that includes space for the sign bit even if the
         // value of the constant is positive or was specified in hexadecimal or octal notation.
         const sign_bits = @boolToInt(suffix.isSignedInteger());

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -683,21 +683,24 @@ pub fn integerPromotion(ty: Type, comp: *Compilation) Type {
         if (ty.hasIncompleteSize()) return .{ .specifier = .int };
         specifier = ty.data.@"enum".tag_ty.specifier;
     }
-    return .{
-        .specifier = switch (specifier) {
-            // zig fmt: off
-            .bool, .char, .schar, .uchar, .short => .int,
-            .ushort => if (ty.sizeof(comp).? == sizeof(.{ .specifier = .int }, comp)) Specifier.uint else .int,
-            .int, .uint, .long, .ulong, .long_long, .ulong_long, .int128, .uint128, .complex_char,
-            .complex_schar, .complex_uchar, .complex_short, .complex_ushort, .complex_int,
-            .complex_uint, .complex_long, .complex_ulong, .complex_long_long, .complex_ulong_long,
-            .complex_int128, .complex_uint128, .bit_int, .complex_bit_int => specifier,
-            // zig fmt: on
-            .typeof_type => return ty.data.sub_type.integerPromotion(comp),
-            .typeof_expr => return ty.data.expr.ty.integerPromotion(comp),
-            .attributed => return ty.data.attributed.base.integerPromotion(comp),
-            .invalid => .invalid,
-            else => unreachable, // not an integer type
+    return switch (specifier) {
+        .bit_int, .complex_bit_int => .{ .specifier = .bit_int, .data = .{ .int = ty.data.int } },
+        else => .{
+            .specifier = switch (specifier) {
+                // zig fmt: off
+                .bool, .char, .schar, .uchar, .short => .int,
+                .ushort => if (ty.sizeof(comp).? == sizeof(.{ .specifier = .int }, comp)) Specifier.uint else .int,
+                .int, .uint, .long, .ulong, .long_long, .ulong_long, .int128, .uint128, .complex_char,
+                .complex_schar, .complex_uchar, .complex_short, .complex_ushort, .complex_int,
+                .complex_uint, .complex_long, .complex_ulong, .complex_long_long, .complex_ulong_long,
+                .complex_int128, .complex_uint128 => specifier,
+                // zig fmt: on
+                .typeof_type => return ty.data.sub_type.integerPromotion(comp),
+                .typeof_expr => return ty.data.expr.ty.integerPromotion(comp),
+                .attributed => return ty.data.attributed.base.integerPromotion(comp),
+                .invalid => .invalid,
+                else => unreachable, // _BitInt, or not an integer type
+            },
         },
     };
 }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -679,12 +679,15 @@ pub fn getRecord(ty: Type) ?*const Type.Record {
 
 pub fn integerPromotion(ty: Type, comp: *Compilation) Type {
     var specifier = ty.specifier;
-    if (specifier == .@"enum") {
-        if (ty.hasIncompleteSize()) return .{ .specifier = .int };
-        specifier = ty.data.@"enum".tag_ty.specifier;
+    switch (specifier) {
+        .@"enum" => {
+            if (ty.hasIncompleteSize()) return .{ .specifier = .int };
+            specifier = ty.data.@"enum".tag_ty.specifier;
+        },
+        .bit_int, .complex_bit_int => return .{ .specifier = specifier, .data = ty.data },
+        else => {},
     }
     return switch (specifier) {
-        .bit_int, .complex_bit_int => .{ .specifier = .bit_int, .data = .{ .int = ty.data.int } },
         else => .{
             .specifier = switch (specifier) {
                 // zig fmt: off

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1586,7 +1586,7 @@ pub const Builder = struct {
                         return error.ParsingFailed;
                     }
                 }
-                if (bits > 128) {
+                if (bits > Compilation.BitIntMaxBits) {
                     try p.errStr(.bit_int_too_big, b.bit_int_tok.?, b.specifier.str(p.comp.langopts).?);
                     return error.ParsingFailed;
                 }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1589,7 +1589,7 @@ pub const Builder = struct {
                         return error.ParsingFailed;
                     }
                 }
-                if (bits > Compilation.BitIntMaxBits) {
+                if (bits > Compilation.bit_int_max_bits) {
                     try p.errStr(.bit_int_too_big, b.bit_int_tok.?, b.specifier.str(p.comp.langopts).?);
                     return error.ParsingFailed;
                 }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -2452,7 +2452,12 @@ pub fn dump(ty: Type, mapper: StringInterner.TypeMapper, langopts: LangOpts, w: 
             try ty.data.attributed.base.dump(mapper, langopts, w);
             try w.writeAll(")");
         },
-        else => try w.writeAll(Builder.fromType(ty).str(langopts).?),
+        else => {
+            try w.writeAll(Builder.fromType(ty).str(langopts).?);
+            if (ty.specifier == .bit_int or ty.specifier == .complex_bit_int) {
+                try w.print("({d})", .{ty.data.int.bits});
+            }
+        },
     }
 }
 

--- a/src/number_affixes.zig
+++ b/src/number_affixes.zig
@@ -77,6 +77,12 @@ pub const Suffix = enum {
     // _Float16
     F16,
 
+    // Imaginary _Bitint
+    IWB, IUWB,
+
+    // _Bitint
+    WB, UWB,
+
     // zig fmt: on
 
     const Tuple = struct { Suffix, []const []const u8 };
@@ -84,15 +90,19 @@ pub const Suffix = enum {
     const IntSuffixes = &[_]Tuple{
         .{ .U, &.{"U"} },
         .{ .L, &.{"L"} },
+        .{ .WB, &.{"WB"} },
         .{ .UL, &.{ "U", "L" } },
+        .{ .UWB, &.{ "U", "WB" } },
         .{ .LL, &.{"LL"} },
         .{ .ULL, &.{ "U", "LL" } },
 
         .{ .I, &.{"I"} },
 
+        .{ .IWB, &.{ "I", "WB" } },
         .{ .IU, &.{ "I", "U" } },
         .{ .IL, &.{ "I", "L" } },
         .{ .IUL, &.{ "I", "U", "L" } },
+        .{ .IUWB, &.{ "I", "U", "WB" } },
         .{ .ILL, &.{ "I", "LL" } },
         .{ .IULL, &.{ "I", "U", "LL" } },
     };
@@ -133,16 +143,27 @@ pub const Suffix = enum {
 
     pub fn isImaginary(suffix: Suffix) bool {
         return switch (suffix) {
-            .I, .IL, .IF, .IU, .IUL, .ILL, .IULL => true,
-            .None, .L, .F16, .F, .U, .UL, .LL, .ULL => false,
+            .I, .IL, .IF, .IU, .IUL, .ILL, .IULL, .IWB, .IUWB => true,
+            .None, .L, .F16, .F, .U, .UL, .LL, .ULL, .WB, .UWB => false,
         };
     }
 
     pub fn isSignedInteger(suffix: Suffix) bool {
         return switch (suffix) {
-            .None, .L, .LL, .I, .IL, .ILL => true,
-            .U, .UL, .ULL, .IU, .IUL, .IULL => false,
+            .None, .L, .LL, .I, .IL, .ILL, .WB, .IWB => true,
+            .U, .UL, .ULL, .IU, .IUL, .IULL, .UWB, .IUWB => false,
             .F, .IF, .F16 => unreachable,
+        };
+    }
+
+    pub fn signedness(suffix: Suffix) std.builtin.Signedness {
+        return if (suffix.isSignedInteger()) .signed else .unsigned;
+    }
+
+    pub fn isBitInt(suffix: Suffix) bool {
+        return switch (suffix) {
+            .WB, .UWB, .IWB, .IUWB => true,
+            else => false,
         };
     }
 };

--- a/test/cases/_BitInt.c
+++ b/test/cases/_BitInt.c
@@ -19,7 +19,10 @@ unsigned _BitInt(0) d;
 
 _BitInt(5) g = 2wb;
 unsigned _BitInt(5) h = 3Uwb;
+#pragma GCC diagnostic ignored "-Wc2x-extensions"
 int x = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFwb;
+int y = 0wb;
+int z = 0uwb;
 
 #define EXPECTED_ERRORS "_BitInt.c:3:1: warning: '_BitInt' in C17 and earlier is a Clang extension' [-Wbit-int-extension]" \
     "_BitInt.c:16:1: error: _BitInt of bit sizes greater than 128 not supported" \
@@ -27,6 +30,5 @@ int x = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
     "_BitInt.c:18:10: error: unsigned _BitInt must have a bit size of at least 1" \
     "_BitInt.c:20:16: warning: '_BitInt' suffix for literals is a C2x extension [-Wc2x-extensions]" \
     "_BitInt.c:21:25: warning: '_BitInt' suffix for literals is a C2x extension [-Wc2x-extensions]" \
-    "_BitInt.c:22:9: warning: '_BitInt' suffix for literals is a C2x extension [-Wc2x-extensions]" \
-    "_BitInt.c:22:9: error: _BitInt of bit sizes greater than 128 not supported" \
+    "_BitInt.c:23:9: error: _BitInt of bit sizes greater than 128 not supported" \
 

--- a/test/cases/_BitInt.c
+++ b/test/cases/_BitInt.c
@@ -17,7 +17,16 @@ _BitInt(129) f;
 signed _BitInt(1) e;
 unsigned _BitInt(0) d;
 
+_BitInt(5) g = 2wb;
+unsigned _BitInt(5) h = 3Uwb;
+int x = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFwb;
+
 #define EXPECTED_ERRORS "_BitInt.c:3:1: warning: '_BitInt' in C17 and earlier is a Clang extension' [-Wbit-int-extension]" \
     "_BitInt.c:16:1: error: _BitInt of bit sizes greater than 128 not supported" \
     "_BitInt.c:17:8: error: signed _BitInt must have a bit size of at least 2" \
     "_BitInt.c:18:10: error: unsigned _BitInt must have a bit size of at least 1" \
+    "_BitInt.c:20:16: warning: '_BitInt' suffix for literals is a C2x extension [-Wc2x-extensions]" \
+    "_BitInt.c:21:25: warning: '_BitInt' suffix for literals is a C2x extension [-Wc2x-extensions]" \
+    "_BitInt.c:22:9: warning: '_BitInt' suffix for literals is a C2x extension [-Wc2x-extensions]" \
+    "_BitInt.c:22:9: error: _BitInt of bit sizes greater than 128 not supported" \
+


### PR DESCRIPTION
Currently only supports 64-bit or smaller literals.  We'll need a way to handle larger values - any thoughts on that? 128-bit `int` field in `Value.data`? make `Value.data.int` a union w/ 64 bit int or pointer to bigint?