### PR TITLE
Improve integer conversion

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4903,6 +4903,10 @@ const Result = struct {
         }
 
         const target = a.ty.integerConversion(b.ty, p.comp);
+        if (!target.isReal()) {
+            try a.saveValue(p);
+            try b.saveValue(p);
+        }
         try a.intCast(p, target, tok);
         try b.intCast(p, target, tok);
     }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4899,30 +4899,9 @@ const Result = struct {
             return;
         }
 
-        const a_unsigned = a.ty.isUnsignedInt(p.comp);
-        const b_unsigned = b.ty.isUnsignedInt(p.comp);
-        if (a_unsigned == b_unsigned) {
-            // cast to greater signed or unsigned type
-            const res_spec = std.math.max(@enumToInt(a.ty.specifier), @enumToInt(b.ty.specifier));
-            const res_ty = Type{ .specifier = @intToEnum(Type.Specifier, res_spec) };
-            try a.intCast(p, res_ty, tok);
-            try b.intCast(p, res_ty, tok);
-            return;
-        }
-
-        // cast to the unsigned type with greater rank
-        const a_larger = @enumToInt(a.ty.specifier) > @enumToInt(b.ty.specifier);
-        const b_larger = @enumToInt(b.ty.specifier) > @enumToInt(a.ty.specifier);
-        if (a_unsigned) {
-            const target = if (a_larger) a.ty else b.ty;
-            try a.intCast(p, target, tok);
-            try b.intCast(p, target, tok);
-        } else {
-            assert(b_unsigned);
-            const target = if (b_larger) b.ty else a.ty;
-            try a.intCast(p, target, tok);
-            try b.intCast(p, target, tok);
-        }
+        const target = a.ty.integerConversion(b.ty, p.comp);
+        try a.intCast(p, target, tok);
+        try b.intCast(p, target, tok);
     }
 
     fn floatConversion(a: *Result, b: *Result, a_spec: Type.Specifier, b_spec: Type.Specifier, p: *Parser, pair: [2]Type.Specifier) !bool {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4713,8 +4713,11 @@ const Result = struct {
                 res.ty = int_ty;
                 try res.implicitCast(p, .int_cast);
             } else if (old_real) {
-                res.ty = int_ty.makeReal();
-                try res.implicitCast(p, .int_cast);
+                const real_int_ty = int_ty.makeReal();
+                if (!res.ty.eql(real_int_ty, p.comp, false)) {
+                    res.ty = real_int_ty;
+                    try res.implicitCast(p, .int_cast);
+                }
                 res.ty = int_ty;
                 try res.implicitCast(p, .real_to_complex_int);
             } else if (new_real) {

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1126,6 +1126,7 @@ pub fn eql(a_param: Type, b_param: Type, comp: *const Compilation, check_qualifi
 
         .@"struct", .@"union" => if (a.data.record != b.data.record) return false,
         .@"enum" => if (a.data.@"enum" != b.data.@"enum") return false,
+        .bit_int, .complex_bit_int => return a.data.int.bits == b.data.int.bits and a.data.int.signedness == b.data.int.signedness,
 
         else => {},
     }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1254,8 +1254,8 @@ pub fn floatRank(ty: Type) usize {
 /// Asserts that ty is an integer type
 pub fn integerRank(ty: Type, comp: *const Compilation) usize {
     const real = ty.makeReal();
-    return switch (real.specifier) {
-        .bit_int => @as(usize, real.data.int.bits) << 3,
+    return @intCast(usize, switch (real.specifier) {
+        .bit_int => @as(u64, real.data.int.bits) << 3,
 
         .bool => 1 + (ty.bitSizeof(comp).? << 3),
         .char, .schar, .uchar => 2 + (ty.bitSizeof(comp).? << 3),
@@ -1266,7 +1266,7 @@ pub fn integerRank(ty: Type, comp: *const Compilation) usize {
         .int128, .uint128 => 7 + (ty.bitSizeof(comp).? << 3),
 
         else => unreachable,
-    };
+    });
 }
 
 pub fn makeReal(ty: Type) Type {

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -237,10 +237,6 @@ pub fn intCast(v: *Value, old_ty: Type, new_ty: Type, comp: *Compilation) void {
     if (v.tag == .unavailable) return;
     if (new_ty.is(.bool)) return v.toBool();
     if (!old_ty.isUnsignedInt(comp)) {
-        if (!new_ty.isReal()) {
-            v.* = .{ .tag = .unavailable };
-            return;
-        }
         const size = new_ty.sizeof(comp).?;
         switch (size) {
             1 => v.* = int(@bitCast(u8, v.getInt(i8))),

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -237,6 +237,10 @@ pub fn intCast(v: *Value, old_ty: Type, new_ty: Type, comp: *Compilation) void {
     if (v.tag == .unavailable) return;
     if (new_ty.is(.bool)) return v.toBool();
     if (!old_ty.isUnsignedInt(comp)) {
+        if (!new_ty.isReal()) {
+            v.* = .{ .tag = .unavailable };
+            return;
+        }
         const size = new_ty.sizeof(comp).?;
         switch (size) {
             1 => v.* = int(@bitCast(u8, v.getInt(i8))),

--- a/test/cases/integer conversions 32bit.c
+++ b/test/cases/integer conversions 32bit.c
@@ -1,0 +1,7 @@
+//aro-args --target=x86-linux-gnu -Wno-unused-value -Wno-c2x-extensions
+
+void foo(void) {
+    1U + 1L;
+}
+
+#define EXPECTED_TYPES "unsigned long"

--- a/test/cases/integer conversions.c
+++ b/test/cases/integer conversions.c
@@ -1,0 +1,22 @@
+//aro-args --target=x86_64-linux-gnu -Wno-unused-value -Wno-c2x-extensions
+
+void foo(void) {
+    _BitInt(8) x = 0;
+    x + 1;
+
+    _BitInt(32) y = 0;
+    y + 1;
+
+    _BitInt(33) z = 0;
+    z + 1;
+
+    _Complex unsigned cx = 0;
+    cx + 1L;
+
+    _Complex int cy = 0;
+    cy + 4294967296wb;
+}
+
+#define EXPECTED_TYPES "_BitInt(8)" "int" "_BitInt(32)" "int" "_BitInt(33)" "_BitInt(33)" \
+	"_Complex unsigned int" "_Complex long" "_Complex int" "_Complex _BitInt(34)" \
+


### PR DESCRIPTION
Fixes #459 as well as some edge cases on 32-bit systems (e.g. `long` + `unsigned` should be `unsigned long` if `long` and `unsigned` are the same size) and with complex integers.