### PR TITLE
build: Zig build system update - remove RunStep.expected_term usage

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -96,16 +96,6 @@ pub fn build(b: *Build) !void {
     }
     exe.install();
 
-    const run_cmd = exe.run();
-    run_cmd.expected_term = null;
-    run_cmd.step.dependOn(b.getInstallStep());
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
-
-    const run_step = b.step("run", "Run the app");
-    run_step.dependOn(&run_cmd.step);
-
     const tests_step = b.step("test", "Run all tests");
     tests_step.dependOn(&exe.step);
 


### PR DESCRIPTION
Not sure if this is the right fix because I don't actually remember what `expected_term` used to be, but since we were setting it to null maybe it's not needed? With latest Zig it complains `no field named 'expected_term' in struct 'Build.RunStep'` 