### PR TITLE
u8 char literals and some other char improvements

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -6956,6 +6956,7 @@ fn primaryExpr(p: *Parser) Error!Result {
         .string_literal_wide,
         => return p.stringLiteral(),
         .char_literal,
+        .char_literal_utf_8,
         .char_literal_utf_16,
         .char_literal_utf_32,
         .char_literal_wide,
@@ -7133,6 +7134,7 @@ fn charLiteral(p: *Parser) Error!Result {
     defer p.tok_i += 1;
     const ty: Type = switch (p.tok_ids[p.tok_i]) {
         .char_literal => .{ .specifier = .int },
+        .char_literal_utf_8 => .{ .specifier = .uchar },
         .char_literal_wide => p.comp.types.wchar,
         .char_literal_utf_16 => .{ .specifier = .ushort },
         .char_literal_utf_32 => .{ .specifier = .ulong },
@@ -7141,6 +7143,7 @@ fn charLiteral(p: *Parser) Error!Result {
     const max: u32 = switch (p.tok_ids[p.tok_i]) {
         .char_literal => std.math.maxInt(u8),
         .char_literal_wide => @intCast(u32, p.comp.types.wchar.maxInt(p.comp)),
+        .char_literal_utf_8 => std.math.maxInt(u8),
         .char_literal_utf_16 => std.math.maxInt(u16),
         .char_literal_utf_32 => std.math.maxInt(u32),
         else => unreachable,
@@ -7148,6 +7151,7 @@ fn charLiteral(p: *Parser) Error!Result {
     var multichar: u8 = switch (p.tok_ids[p.tok_i]) {
         .char_literal => 0,
         .char_literal_wide => 4,
+        .char_literal_utf_8 => 2,
         .char_literal_utf_16 => 2,
         .char_literal_utf_32 => 2,
         else => unreachable,

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7246,7 +7246,7 @@ fn charLiteral(p: *Parser) Error!Result {
             6 => val = 0,
             else => {},
         }
-        const ov = @mulWithOverflow(val, max);
+        const ov = @mulWithOverflow(val, max +% 1);
         if (ov[1] != 0 and !overflow_reported) {
             try p.errExtra(.char_lit_too_wide, p.tok_i, .{ .unsigned = i });
             overflow_reported = true;

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -37,6 +37,7 @@ pub const Token = struct {
 
         // char literals with prefixes
         char_literal,
+        char_literal_utf_8,
         char_literal_utf_16,
         char_literal_utf_32,
         char_literal_wide,
@@ -464,6 +465,7 @@ pub const Token = struct {
                 .string_literal_utf_32,
                 .string_literal_wide,
                 .char_literal,
+                .char_literal_utf_8,
                 .char_literal_utf_16,
                 .char_literal_utf_32,
                 .char_literal_wide,
@@ -695,6 +697,7 @@ pub const Token = struct {
                 .string_literal_wide,
                 => "a string literal",
                 .char_literal,
+                .char_literal_utf_8,
                 .char_literal_utf_16,
                 .char_literal_utf_32,
                 .char_literal_wide,
@@ -719,6 +722,7 @@ pub const Token = struct {
                 .string_literal_wide,
 
                 .char_literal,
+                .char_literal_utf_8,
                 .char_literal_utf_16,
                 .char_literal_utf_32,
                 .char_literal_wide,
@@ -1151,6 +1155,10 @@ pub fn next(self: *Tokenizer) Token {
                 '\"' => {
                     id = .string_literal_utf_8;
                     state = .string_literal;
+                },
+                '\'' => {
+                    id = .char_literal_utf_8;
+                    state = .char_literal_start;
                 },
                 else => {
                     codepoint_len = 0;
@@ -1954,6 +1962,7 @@ test "string prefix" {
         \\U"foo"
         \\L"foo"
         \\'foo'
+        \\u8'A'
         \\u'foo'
         \\U'foo'
         \\L'foo'
@@ -1970,6 +1979,8 @@ test "string prefix" {
         .string_literal_wide,
         .nl,
         .char_literal,
+        .nl,
+        .char_literal_utf_8,
         .nl,
         .char_literal_utf_16,
         .nl,

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -33,7 +33,7 @@ pub const Token = struct {
         if (new.len == 0 or tok.id == .whitespace) return;
         var list = std.ArrayList(Source.Location).init(gpa);
         defer {
-            std.mem.set(Source.Location, list.items.ptr[list.items.len..list.capacity], .{});
+            @memset(list.items.ptr[list.items.len..list.capacity], .{});
             // Add a sentinel to indicate the end of the list since
             // the ArrayList's capacity isn't guaranteed to be exactly
             // what we ask for.

--- a/test/cases/u8 character constant.c
+++ b/test/cases/u8 character constant.c
@@ -1,0 +1,14 @@
+const unsigned char c = u8'A';
+_Static_assert(c == 'A', "");
+
+_Static_assert(u8'\xff' == 0xFF, "");
+
+const unsigned char c2 = u8'™';
+
+#if u8'A'
+#else
+    #error Character constant should be true in preprocessor
+#endif
+
+#define EXPECTED_ERRORS "u8 character constant.c:6:26: error: character too large for enclosing character literal type" \
+

--- a/test/cases/u8 character constant.c
+++ b/test/cases/u8 character constant.c
@@ -4,6 +4,8 @@ _Static_assert(c == 'A', "");
 _Static_assert(u8'\xff' == 0xFF, "");
 
 const unsigned char c2 = u8'™';
+const unsigned char c3 = u8'£'; // Unicode codepoint 0xA3
+const unsigned char c4 = u8'AA';
 
 #if u8'A'
 #else
@@ -11,4 +13,6 @@ const unsigned char c2 = u8'™';
 #endif
 
 #define EXPECTED_ERRORS "u8 character constant.c:6:26: error: character too large for enclosing character literal type" \
+    "u8 character constant.c:7:26: error: character too large for enclosing character literal type" \
+    "u8 character constant.c:8:26: error: Unicode character literals may not contain multiple characters" \
 

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -8,7 +8,13 @@ _Static_assert(sizeof L' ' == sizeof(wchar_t), "sizes don't match");
 unsigned short a = u'￿' + u'𐀁';
 _Static_assert(L'ab' == 'b', "expected to match");
 _Static_assert(U'ab' == 'b', "should not be evaluated");
+_Static_assert('\1' == 0x01, "");
+#if __INT_MAX__ >= 0x01020304
+_Static_assert('\1\2\3\4' == 0x01020304, "");
+#endif
 
 #define EXPECTED_ERRORS "wide character constants.c:8:27: error: character too large for enclosing character literal type" \
     "wide character constants.c:9:16: warning: extraneous characters in character constant ignored" \
     "wide character constants.c:10:16: error: Unicode character literals may not contain multiple characters" \
+    "wide character constants.c:13:16: warning: multi-character character constant [-Wmultichar]" \
+


### PR DESCRIPTION
Add support for C23 u8 character constants

disallow multibyte constants for character literals and u8 character literals (this matches the behavior of clang where e.g. `'\xA3'` is allowed but `'£'` is not, even though `£` is unicode code point 0xA3; because `£` is encoded as `0xC2A3`, which is too large for a char; clang does this even though the type of the char literal is indeed `int`.)

Fix an issue where multi-character character constants received an incorrect value due to multiplying by e.g. 0xFF instead of 0x100