### PR TITLE
Allow overriding char signedness

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -329,7 +329,7 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     try generateDateAndTime(w);
 
     // types
-    if (target.getCharSignedness(comp.target) == .unsigned) try w.writeAll("#define __CHAR_UNSIGNED__ 1\n");
+    if (comp.getCharSignedness() == .unsigned) try w.writeAll("#define __CHAR_UNSIGNED__ 1\n");
     try w.writeAll("#define __CHAR_BIT__ 8\n");
 
     // int maxs
@@ -681,6 +681,10 @@ pub fn fixedEnumTagSpecifier(comp: *const Compilation) ?Type.Specifier {
         .gcc => {},
     }
     return null;
+}
+
+pub fn getCharSignedness(comp: *const Compilation) std.builtin.Signedness {
+    return comp.langopts.char_signedness_override orelse target.getCharSignedness(comp.target);
 }
 
 pub fn defineSystemIncludes(comp: *Compilation) !void {

--- a/src/Driver.zig
+++ b/src/Driver.zig
@@ -79,7 +79,11 @@ pub const usage =
     \\                          Allow half-precision function arguments and return values
     \\  -fshort-enums           Use the narrowest possible integer type for enums
     \\  -fno-short-enums        Use "int" as the tag type for enums
+    \\  -fsigned-char           "char" is signed
+    \\  -fno-signed-char        "char" is unsigned
     \\  -fsyntax-only           Only run the preprocessor, parser, and semantic analysis stages
+    \\  -funsigned-char         "char" is unsigned
+    \\  -fno-unsigned-char      "char" is signed
     \\  -I <dir>                Add directory to include search path
     \\  -isystem                Add directory to SYSTEM include search path
     \\  --emulate=[clang|gcc|msvc]
@@ -193,6 +197,14 @@ pub fn parseArgs(
                 d.comp.langopts.short_enums = true;
             } else if (mem.eql(u8, arg, "-fno-short-enums")) {
                 d.comp.langopts.short_enums = false;
+            } else if (mem.eql(u8, arg, "-fsigned-char")) {
+                d.comp.langopts.setCharSignedness(.signed);
+            } else if (mem.eql(u8, arg, "-fno-signed-char")) {
+                d.comp.langopts.setCharSignedness(.unsigned);
+            } else if (mem.eql(u8, arg, "-funsigned-char")) {
+                d.comp.langopts.setCharSignedness(.unsigned);
+            } else if (mem.eql(u8, arg, "-fno-unsigned-char")) {
+                d.comp.langopts.setCharSignedness(.signed);
             } else if (mem.eql(u8, arg, "-fdeclspec")) {
                 d.comp.langopts.declspec_attrs = true;
             } else if (mem.eql(u8, arg, "-fno-declspec")) {

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -102,6 +102,8 @@ use_native_half_type: bool = false,
 allow_half_args_and_returns: bool = false,
 /// null indicates that the user did not select a value, use target to determine default
 fp_eval_method: ?FPEvalMethod = null,
+/// If set, use specified signedness for `char` instead of the target's default char signedness
+char_signedness_override: ?std.builtin.Signedness = null,
 
 pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!void {
     self.standard = Standard.NameMap.get(name) orelse return error.InvalidStandard;
@@ -128,4 +130,8 @@ pub fn setEmulatedCompiler(self: *LangOpts, compiler: Compiler) void {
 
 pub fn setFpEvalMethod(self: *LangOpts, fp_eval_method: FPEvalMethod) void {
     self.fp_eval_method = fp_eval_method;
+}
+
+pub fn setCharSignedness(self: *LangOpts, signedness: std.builtin.Signedness) void {
+    self.char_signedness_override = signedness;
 }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -554,7 +554,7 @@ pub fn isConst(ty: Type) bool {
 pub fn isUnsignedInt(ty: Type, comp: *const Compilation) bool {
     return switch (ty.specifier) {
         // zig fmt: off
-        .char, .complex_char => return target.getCharSignedness(comp.target) == .unsigned,
+        .char, .complex_char => return comp.getCharSignedness() == .unsigned,
         .uchar, .ushort, .uint, .ulong, .ulong_long, .bool, .complex_uchar, .complex_ushort,
         .complex_uint, .complex_ulong, .complex_ulong_long, .complex_uint128 => true,
         // zig fmt: on
@@ -2323,7 +2323,7 @@ pub fn intValueSuffix(ty: Type, comp: *const Compilation) []const u8 {
         .long => "L",
         .long_long => "LL",
         .uchar, .char => {
-            if (ty.specifier == .char and target.getCharSignedness(comp.target) == .signed) return "";
+            if (ty.specifier == .char and comp.getCharSignedness() == .signed) return "";
             // Only 8-bit char supported currently;
             // TODO: handle platforms with 16-bit int + 16-bit char
             std.debug.assert(ty.sizeof(comp).? == 8);

--- a/test/cases/signed char.c
+++ b/test/cases/signed char.c
@@ -1,0 +1,5 @@
+//aro-args --target=aarch64-linux-gnu -fsigned-char
+
+#if defined __CHAR_UNSIGNED__
+#error char should be signed
+#endif

--- a/test/cases/unsigned char.c
+++ b/test/cases/unsigned char.c
@@ -1,0 +1,3 @@
+//aro-args --target=x86_64-linux-gnu -funsigned-char
+
+_Static_assert(__CHAR_UNSIGNED__ == 1, "");


### PR DESCRIPTION
Adds support for the `-fsigned-char` / `-funsigned-char` family of command line flags