### PR TITLE
Add C23 char8_t

### DIFF
--- a/src/Driver.zig
+++ b/src/Driver.zig
@@ -60,6 +60,8 @@ pub const usage =
     \\  -c                      Only run preprocess, compile, and assemble steps
     \\  -D <macro>=<value>      Define <macro> to <value> (defaults to 1)
     \\  -E                      Only run the preprocessor
+    \\  -fchar8_t               Enable char8_t (enabled by default in C2X and later)
+    \\  -fno-char8_t            Disable char8_t (disabled by default for pre-C2X)
     \\  -fcolor-diagnostics     Enable colors in diagnostics
     \\  -fno-color-diagnostics  Disable colors in diagnostics
     \\  -fdeclspec              Enable support for __declspec attributes
@@ -169,6 +171,10 @@ pub fn parseArgs(
                 d.only_compile = true;
             } else if (mem.eql(u8, arg, "-E")) {
                 d.only_preprocess = true;
+            } else if (mem.eql(u8, arg, "-fchar8_t")) {
+                d.comp.langopts.has_char8_t_override = true;
+            } else if (mem.eql(u8, arg, "-fno-char8_t")) {
+                d.comp.langopts.has_char8_t_override = false;
             } else if (mem.eql(u8, arg, "-fcolor-diagnostics")) {
                 color_setting = .on;
             } else if (mem.eql(u8, arg, "-fno-color-diagnostics")) {

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -104,6 +104,8 @@ allow_half_args_and_returns: bool = false,
 fp_eval_method: ?FPEvalMethod = null,
 /// If set, use specified signedness for `char` instead of the target's default char signedness
 char_signedness_override: ?std.builtin.Signedness = null,
+/// If set, override the default availability of char8_t (by default, enabled in C2X and later; disabled otherwise)
+has_char8_t_override: ?bool = null,
 
 pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!void {
     self.standard = Standard.NameMap.get(name) orelse return error.InvalidStandard;
@@ -117,6 +119,10 @@ pub fn enableMSExtensions(self: *LangOpts) void {
 pub fn disableMSExtensions(self: *LangOpts) void {
     self.declspec_attrs = false;
     self.ms_extensions = true;
+}
+
+pub fn hasChar8_T(self: *const LangOpts) bool {
+    return self.has_char8_t_override orelse self.standard.atLeast(.c2x);
 }
 
 pub fn hasDigraphs(self: *const LangOpts) bool {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7634,6 +7634,8 @@ fn genericSelection(p: *Parser) Error!Result {
     const controlling_tok = p.tok_i;
     const controlling = try p.parseNoEval(assignExpr);
     _ = try p.expectToken(.comma);
+    var controlling_ty = controlling.ty;
+    if (controlling_ty.isArray()) controlling_ty.decayArray();
 
     const list_buf_top = p.list_buf.items.len;
     defer p.list_buf.items.len = list_buf_top;
@@ -7661,7 +7663,7 @@ fn genericSelection(p: *Parser) Error!Result {
             const node = try p.assignExpr();
             try node.expect(p);
 
-            if (ty.eql(controlling.ty, p.comp, false)) {
+            if (ty.eql(controlling_ty, p.comp, false)) {
                 if (chosen.node == .none) {
                     chosen = node;
                     chosen_tok = start;
@@ -7711,7 +7713,7 @@ fn genericSelection(p: *Parser) Error!Result {
             }));
             chosen = default;
         } else {
-            try p.errStr(.generic_no_match, controlling_tok, try p.typeStr(controlling.ty));
+            try p.errStr(.generic_no_match, controlling_tok, try p.typeStr(controlling_ty));
             return error.ParsingFailed;
         }
     } else {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -570,6 +570,9 @@ pub fn parse(pp: *Preprocessor) Compilation.Error!Tree {
     _ = try p.addNode(.{ .tag = .invalid, .ty = undefined, .data = undefined });
 
     {
+        if (p.comp.langopts.hasChar8_T()) {
+            try p.syms.defineTypedef(&p, try p.comp.intern("char8_t"), .{ .specifier = .uchar }, 0, .none);
+        }
         try p.syms.defineTypedef(&p, try p.comp.intern("__int128_t"), .{ .specifier = .int128 }, 0, .none);
         try p.syms.defineTypedef(&p, try p.comp.intern("__uint128_t"), .{ .specifier = .uint128 }, 0, .none);
 

--- a/test/cases/c17 char8_t enabled.c
+++ b/test/cases/c17 char8_t enabled.c
@@ -3,3 +3,17 @@
 void foo(void) {
     char8_t c = 0;
 }
+
+_Static_assert (_Generic (u8"hello", unsigned char*: 1, default: 2) == 1, "Incorrect type for u8 string literal");
+_Static_assert (_Generic (u8"A"[0], unsigned char:  1, default: 2) == 1, "Incorrect type for u8 string literal element");
+
+const char cbuf1[] = u8"text";
+const char cbuf2[] = { u8"text" };
+const signed char scbuf1[] = u8"text";
+const signed char scbuf2[] = { u8"text" };
+const unsigned char ucbuf1[] = u8"text";
+const unsigned char ucbuf2[] = { u8"text" };
+const char8_t c8buf1[] = u8"text";
+const char8_t c8buf2[] = { u8"text" };
+const char8_t c8buf3[] = "text";
+const char8_t c8buf4[] = { "text" };

--- a/test/cases/c17 char8_t enabled.c
+++ b/test/cases/c17 char8_t enabled.c
@@ -1,0 +1,5 @@
+//aro-args -std=c17 -fchar8_t
+
+void foo(void) {
+    char8_t c = 0;
+}

--- a/test/cases/c17 char8_t.c
+++ b/test/cases/c17 char8_t.c
@@ -4,5 +4,14 @@ void foo(void) {
     char8_t c = 0;
 }
 
-#define EXPECTED_ERRORS "c17 char8_t.c:4:5: error: use of undeclared identifier 'char8_t'" \
+_Static_assert (_Generic (u8"hello", char*: 1, default: 2) == 1, "Incorrect type for u8 string literal");
+_Static_assert (_Generic (u8"A"[0], char:  1, default: 2) == 1, "Incorrect type for u8 string literal element");
 
+const char cbuf1[] = u8"text";
+const char cbuf2[] = { u8"text" };
+const signed char scbuf1[] = u8"text";
+const signed char scbuf2[] = { u8"text" };
+const unsigned char ucbuf1[] = u8"text";
+const unsigned char ucbuf2[] = { u8"text" };
+
+#define EXPECTED_ERRORS "c17 char8_t.c:4:5: error: use of undeclared identifier 'char8_t'" \

--- a/test/cases/c17 char8_t.c
+++ b/test/cases/c17 char8_t.c
@@ -1,0 +1,8 @@
+//aro-args -std=c17
+
+void foo(void) {
+    char8_t c = 0;
+}
+
+#define EXPECTED_ERRORS "c17 char8_t.c:4:5: error: use of undeclared identifier 'char8_t'" \
+

--- a/test/cases/c2x char8_t disabled.c
+++ b/test/cases/c2x char8_t disabled.c
@@ -1,0 +1,8 @@
+//aro-args -std=c2x -fno-char8_t
+
+void foo(void) {
+    char8_t c = 0;
+}
+
+#define EXPECTED_ERRORS "c2x char8_t disabled.c:4:5: error: use of undeclared identifier 'char8_t'" \
+

--- a/test/cases/c2x char8_t disabled.c
+++ b/test/cases/c2x char8_t disabled.c
@@ -4,5 +4,15 @@ void foo(void) {
     char8_t c = 0;
 }
 
+_Static_assert(_Generic(u8"hello", char*: 1, default: 2) == 1, "Incorrect type for u8 string literal");
+_Static_assert(_Generic(u8"A"[0], char:  1, default: 2) == 1, "Incorrect type for u8 string literal element");
+
+const char cbuf1[] = u8"text";
+const char cbuf2[] = { u8"text" };
+const signed char scbuf1[] = u8"text";
+const signed char scbuf2[] = { u8"text" };
+const unsigned char ucbuf1[] = u8"text";
+const unsigned char ucbuf2[] = { u8"text" };
+
 #define EXPECTED_ERRORS "c2x char8_t disabled.c:4:5: error: use of undeclared identifier 'char8_t'" \
 

--- a/test/cases/c2x char8_t.c
+++ b/test/cases/c2x char8_t.c
@@ -3,3 +3,17 @@
 void foo(void) {
     char8_t c = 0;
 }
+
+_Static_assert(_Generic(u8"hello", unsigned char*: 1, default: 2) == 1, "Incorrect type for u8 string literal");
+_Static_assert(_Generic(u8"A"[0], unsigned char:  1, default: 2) == 1, "Incorrect type for u8 string literal element");
+
+const char cbuf1[] = u8"text";
+const char cbuf2[] = { u8"text" };
+const signed char scbuf1[] = u8"text";
+const signed char scbuf2[] = { u8"text" };
+const unsigned char ucbuf1[] = u8"text";
+const unsigned char ucbuf2[] = { u8"text" };
+const char8_t c8buf1[] = u8"text";
+const char8_t c8buf2[] = { u8"text" };
+const char8_t c8buf3[] = "text";
+const char8_t c8buf4[] = { "text" };

--- a/test/cases/c2x char8_t.c
+++ b/test/cases/c2x char8_t.c
@@ -1,0 +1,5 @@
+//aro-args -std=c2x
+
+void foo(void) {
+    char8_t c = 0;
+}

--- a/test/cases/generic.c
+++ b/test/cases/generic.c
@@ -7,6 +7,7 @@ void foo(void) {
     (void)_Generic(7, int: 8, int: 9);
     _Static_assert(_Generic(7, int[2]: 8, int(int): 9, default: 1) == 1, "test failure");
     _Static_assert(_Generic(7, default: 1) == 1, "test failure");
+    _Static_assert(_Generic("hello", char *: 1, default: 2) == 1, "test failure");
 }
 
 #define EXPECTED_ERRORS "generic.c:2:15: error: expected ',', found ')'" \


### PR DESCRIPTION
Adds `char8_t` as a builtin typedef for `unsigned char` in C23 or if `-fchar8_t` is passed. Unlike C++ it's just a typedef and not a distinct incompatible type.

If `char8_t` is enabled, `u8` string literals have type `char8_t[N]` instead of `char[N]`, but can still be used to initialize arrays of `char` or `signed char`.

Fixes a bug with `_Generic` where the controlling expression was not undergoing array decay.