### PR TITLE
Use intmax_t/uintmax_t in preprocessor

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -341,9 +341,9 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     try comp.generateIntMaxAndWidth(w, "LONG_LONG", .{ .specifier = .long_long });
     try comp.generateIntMaxAndWidth(w, "WCHAR", comp.types.wchar);
     // try comp.generateIntMax(w, "WINT", comp.types.wchar);
-    // try comp.generateIntMax(w, "INTMAX", comp.types.wchar);
+    try comp.generateIntMax(w, "INTMAX", comp.intMaxType());
     try comp.generateIntMax(w, "SIZE", comp.types.size);
-    // try comp.generateIntMax(w, "UINTMAX", comp.types.wchar);
+    try comp.generateIntMax(w, "UINTMAX", comp.uintMaxType());
     try comp.generateIntMax(w, "PTRDIFF", comp.types.ptrdiff);
     // try comp.generateIntMax(w, "INTPTR", comp.types.wchar);
     // try comp.generateIntMax(w, "UINTPTR", comp.types.size);
@@ -552,6 +552,14 @@ fn generateNsConstantStringType(comp: *Compilation) !void {
     comp.types.ns_constant_string.fields[3] = .{ .name = try comp.intern("length"), .ty = .{ .specifier = .long } };
     comp.types.ns_constant_string.ty = .{ .specifier = .@"struct", .data = .{ .record = &comp.types.ns_constant_string.record } };
     record_layout.compute(&comp.types.ns_constant_string.record, comp.types.ns_constant_string.ty, comp, null);
+}
+
+pub fn intMaxType(comp: *const Compilation) Type {
+    return target.intMaxType(comp.target);
+}
+
+pub fn uintMaxType(comp: *const Compilation) Type {
+    return target.intMaxType(comp.target).makeIntegerUnsigned();
 }
 
 fn generateVaListType(comp: *Compilation) !Type {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -341,9 +341,9 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     try comp.generateIntMaxAndWidth(w, "LONG_LONG", .{ .specifier = .long_long });
     try comp.generateIntMaxAndWidth(w, "WCHAR", comp.types.wchar);
     // try comp.generateIntMax(w, "WINT", comp.types.wchar);
-    try comp.generateIntMax(w, "INTMAX", comp.intMaxType());
+    try comp.generateIntMaxAndWidth(w, "INTMAX", comp.intMaxType());
     try comp.generateIntMax(w, "SIZE", comp.types.size);
-    try comp.generateIntMax(w, "UINTMAX", comp.uintMaxType());
+    try comp.generateIntMaxAndWidth(w, "UINTMAX", comp.uintMaxType());
     try comp.generateIntMax(w, "PTRDIFF", comp.types.ptrdiff);
     // try comp.generateIntMax(w, "INTPTR", comp.types.wchar);
     // try comp.generateIntMax(w, "UINTPTR", comp.types.size);
@@ -647,7 +647,7 @@ fn generateIntMax(comp: *Compilation, w: anytype, name: []const u8, ty: Type) !v
     const max = if (bit_count == 128)
         @as(u128, if (unsigned) std.math.maxInt(u128) else std.math.maxInt(u128))
     else
-        (@as(u64, 1) << @truncate(u6, bit_count - @boolToInt(!unsigned))) - 1;
+        ty.maxInt(comp);
     try w.print("#define __{s}_MAX__ {d}{s}\n", .{ name, max, ty.intValueSuffix(comp) });
 }
 

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -239,9 +239,9 @@ pub fn intCast(v: *Value, old_ty: Type, new_ty: Type, comp: *Compilation) void {
     if (!old_ty.isUnsignedInt(comp)) {
         const size = new_ty.sizeof(comp).?;
         switch (size) {
-            1 => v.* = int(@bitCast(u8, v.getInt(i8))),
-            2 => v.* = int(@bitCast(u16, v.getInt(i16))),
-            4 => v.* = int(@bitCast(u32, v.getInt(i32))),
+            1 => v.* = int(@truncate(u8, @bitCast(u64, v.signExtend(old_ty, comp)))),
+            2 => v.* = int(@truncate(u16, @bitCast(u64, v.signExtend(old_ty, comp)))),
+            4 => v.* = int(@truncate(u32, @bitCast(u64, v.signExtend(old_ty, comp)))),
             8 => return,
             else => unreachable,
         }

--- a/src/target.zig
+++ b/src/target.zig
@@ -4,6 +4,37 @@ const Type = @import("Type.zig");
 const CType = @import("zig").CType;
 const TargetSet = @import("builtins/Properties.zig").TargetSet;
 
+/// intmax_t for this target
+pub fn intMaxType(target: std.Target) Type {
+    switch (target.cpu.arch) {
+        .aarch64,
+        .sparc64,
+        => if (target.os.tag != .openbsd) return .{ .specifier = .long },
+
+        .bpfel,
+        .bpfeb,
+        .loongarch64,
+        .riscv64,
+        .powerpc64,
+        .powerpc64le,
+        .tce,
+        .tcele,
+        .ve,
+        => return .{ .specifier = .long },
+
+        .x86_64 => switch (target.os.tag) {
+            .windows, .openbsd => {},
+            else => switch (target.abi) {
+                .gnux32, .muslx32 => {},
+                else => return .{ .specifier = .long },
+            },
+        },
+
+        else => {},
+    }
+    return .{ .specifier = .long_long };
+}
+
 pub fn getCharSignedness(target: std.Target) std.builtin.Signedness {
     switch (target.cpu.arch) {
         .aarch64,

--- a/test/cases/#if constant expression.c
+++ b/test/cases/#if constant expression.c
@@ -1,4 +1,4 @@
-//aro-args -E
+//aro-args -E -Wno-integer-overflow
 
 #if defined FOO & !defined(BAZ)
 void
@@ -20,4 +20,7 @@ long
 
 #if 0 || 0
 # error foo
+#endif
+#if 0U - 1 != 18446744073709551615ULL
+#error incorrect unsigned subtraction in preprocessor
 #endif

--- a/test/cases/intmax_t.c
+++ b/test/cases/intmax_t.c
@@ -1,0 +1,7 @@
+//aro-args --target=x86_64-linux-gnu
+
+_Static_assert(__INTMAX_MAX__ == 9223372036854775807L, "");
+_Static_assert(__INTMAX_WIDTH__ == 64, "");
+
+_Static_assert(__UINTMAX_MAX__ == 18446744073709551615UL, "");
+_Static_assert(__UINTMAX_WIDTH__ == 64, "");

--- a/test/cases/signed char.c
+++ b/test/cases/signed char.c
@@ -1,4 +1,4 @@
-//aro-args --target=aarch64-linux-gnu -fsigned-char
+//aro-args --target=aarch64-linux-gnu -fsigned-char -Wno-integer-overflow
 
 #if defined __CHAR_UNSIGNED__
 #error char should be signed
@@ -6,3 +6,11 @@
 
 _Static_assert((char)-1 == -1, "char should be signed");
 _Static_assert((char)0xFF == -1, "char should be signed");
+
+#if '\0' - 1 > 0
+#error "preprocessor char literal is unsigned when it should be signed"
+#endif
+
+#if u'\0' - 1 < 0
+#error "preprocessor u8 char literal is signed when it should be unsigned"
+#endif

--- a/test/cases/signed char.c
+++ b/test/cases/signed char.c
@@ -3,3 +3,6 @@
 #if defined __CHAR_UNSIGNED__
 #error char should be signed
 #endif
+
+_Static_assert((char)-1 == -1, "char should be signed");
+_Static_assert((char)0xFF == -1, "char should be signed");

--- a/test/cases/unsigned char.c
+++ b/test/cases/unsigned char.c
@@ -1,3 +1,4 @@
 //aro-args --target=x86_64-linux-gnu -funsigned-char
 
 _Static_assert(__CHAR_UNSIGNED__ == 1, "");
+_Static_assert((char)-1 == 0xFF, "char should be unsigned");

--- a/test/cases/unsigned char.c
+++ b/test/cases/unsigned char.c
@@ -1,4 +1,12 @@
-//aro-args --target=x86_64-linux-gnu -funsigned-char
+//aro-args --target=x86_64-linux-gnu -funsigned-char -Wno-integer-overflow
 
 _Static_assert(__CHAR_UNSIGNED__ == 1, "");
 _Static_assert((char)-1 == 0xFF, "char should be unsigned");
+
+#if '\0' - 1 < 0
+#error "preprocessor char literal is signed when it should be unsigned"
+#endif
+
+#if u'\0' - 1 < 0
+#error "preprocessor u8 char literal is signed when it should be unsigned"
+#endif


### PR DESCRIPTION
The preprocessor is supposed to do all math with `intmax_t` or `uintmax_t` instead of using C promotion rules. This adds support for determining the `intmax_t` type for different platforms + a fixes a few other bugs I found while working on that.