### PR TITLE
export Type.zig from library

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -12,6 +12,7 @@ pub const Preprocessor = @import("Preprocessor.zig");
 pub const Source = @import("Source.zig");
 pub const Tokenizer = @import("Tokenizer.zig");
 pub const Tree = @import("Tree.zig");
+pub const Type = @import("Type.zig");
 pub const TypeMapper = @import("StringInterner.zig").TypeMapper;
 pub const target_util = @import("target.zig");
 


### PR DESCRIPTION
Export Type.zig from the library.

I'm using arocc as a  library for my attempt at translate-c here
https://github.com/TwoClocks/aro-translate-c
