### PR TITLE
Begin implementing stdint.h

### DIFF
--- a/include/stdint.h
+++ b/include/stdint.h
@@ -23,10 +23,10 @@
 #define INTMAX_MAX   __INTMAX_MAX__
 #define UINTMAX_MAX  __UINTMAX_MAX__
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
-# define INTPTR_WIDTH  __INTPTR_WIDTH__
-# define UINTPTR_WIDTH __UINTPTR_WIDTH__
-# define INTMAX_WIDTH __INTMAX_WIDTH__
-# define UINTMAX_WIDTH __UINTMAX_WIDTH__
+# define INTPTR_WIDTH     __INTPTR_WIDTH__
+# define UINTPTR_WIDTH    __UINTPTR_WIDTH__
+# define INTMAX_WIDTH     __INTMAX_WIDTH__
+# define UINTMAX_WIDTH    __UINTMAX_WIDTH__
 # define PTRDIFF_WIDTH    __PTRDIFF_WIDTH__
 # define SIZE_WIDTH       __SIZE_WIDTH__
 # define WCHAR_WIDTH      __WCHAR_WIDTH__
@@ -84,5 +84,97 @@ typedef __UINTMAX_TYPE__ uintmax_t;
 
 #endif /* __INT64_TYPE__ */
 
+#ifdef __INT32_TYPE__
+# ifndef __int8_t_defined /* glibc sys/types.h also defines int32_t*/
+   typedef __INT32_TYPE__ int32_t;
+# endif /* __int8_t_defined */
+  typedef __UINT32_TYPE__ uint32_t;
+
+# undef __int32_c_suffix
+# undef __int16_c_suffix
+# undef  __int8_c_suffix
+# ifdef __INT32_C_SUFFIX__
+#  define __int32_c_suffix __INT32_C_SUFFIX__
+#  define __int16_c_suffix __INT32_C_SUFFIX__
+#  define  __int8_c_suffix __INT32_C_SUFFIX__
+# endif /* __INT32_C_SUFFIX__ */
+
+# ifdef __int32_c_suffix
+#  define INT32_C(v) (__stdint_int_c(v, __int32_c_suffix))
+#  define UINT32_C(v) (__stdint_uint_c(v, __int32_c_suffix))
+# else
+#  define INT32_C(v) (v)
+#  define UINT32_C(v) (v ## U)
+# endif /* __int32_c_suffix */
+
+# define INT32_MAX           INT32_C( 2147483647)
+# define INT32_MIN         (-INT32_C( 2147483647)-1)
+# define UINT32_MAX         UINT32_C(4294967295)
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#  define UINT32_WIDTH         32
+#  define INT32_WIDTH          UINT32_WIDTH
+# endif /* __STDC_VERSION__ */
+
+#endif /* __INT32_TYPE__ */
+
+#ifdef __INT16_TYPE__
+# ifndef __int8_t_defined /* glibc sys/types.h also defines int16_t*/
+   typedef __INT16_TYPE__ int16_t;
+# endif /* __int8_t_defined */
+  typedef __UINT16_TYPE__ uint16_t;
+
+# undef __int16_c_suffix
+# undef  __int8_c_suffix
+# ifdef __INT16_C_SUFFIX__
+#  define __int16_c_suffix __INT16_C_SUFFIX__
+#  define  __int8_c_suffix __INT16_C_SUFFIX__
+# endif /* __INT16_C_SUFFIX__ */
+
+# ifdef __int16_c_suffix
+#  define INT16_C(v) (__stdint_int_c(v, __int16_c_suffix))
+#  define UINT16_C(v) (__stdint_uint_c(v, __int16_c_suffix))
+# else
+#  define INT16_C(v) (v)
+#  define UINT16_C(v) (v ## U)
+# endif /* __int16_c_suffix */
+
+# define INT16_MAX           INT16_C( 32767)
+# define INT16_MIN         (-INT16_C( 32767)-1)
+# define UINT16_MAX         UINT16_C(65535)
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#  define UINT16_WIDTH         16
+#  define INT16_WIDTH          UINT16_WIDTH
+# endif /* __STDC_VERSION__ */
+
+#endif /* __INT16_TYPE__ */
+
+#ifdef __INT8_TYPE__
+# ifndef __int8_t_defined /* glibc sys/types.h also defines int8_t*/
+   typedef __INT8_TYPE__ int8_t;
+# endif /* __int8_t_defined */
+  typedef __UINT8_TYPE__ uint8_t;
+
+# undef  __int8_c_suffix
+# ifdef __INT8_C_SUFFIX__
+#  define  __int8_c_suffix __INT8_C_SUFFIX__
+# endif /* __INT8_C_SUFFIX__ */
+
+# ifdef __int8_c_suffix
+#  define INT8_C(v) (__stdint_int_c(v, __int8_c_suffix))
+#  define UINT8_C(v) (__stdint_uint_c(v, __int8_c_suffix))
+# else
+#  define INT8_C(v) (v)
+#  define UINT8_C(v) (v ## U)
+# endif /* __int8_c_suffix */
+
+# define INT8_MAX           INT8_C(127)
+# define INT8_MIN         (-INT8_C(127)-1)
+# define UINT8_MAX         UINT8_C(255)
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#  define UINT8_WIDTH         8
+#  define INT8_WIDTH          UINT8_WIDTH
+# endif /* __STDC_VERSION__ */
+
+#endif /* __INT8_TYPE__ */
 
 #endif /* __STDC_HOSTED__ && __has_include_next(<stdint.h>) */

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -1,0 +1,88 @@
+/* <stdint.h> for the Aro C compiler */
+
+#pragma once
+
+
+#if __STDC_HOSTED__ && __has_include_next(<stdint.h>)
+
+# include_next <stdint.h>
+
+#else
+
+#define __stdint_int_c_cat(X, Y) X ## Y
+#define __stdint_int_c(V, SUFFIX) __stdint_int_c_cat(V, SUFFIX)
+#define __stdint_uint_c(V, SUFFIX) __stdint_int_c_cat(V##U, SUFFIX)
+
+#define INTPTR_MIN   (-__INTPTR_MAX__-1)
+#define INTPTR_MAX   __INTPTR_MAX__
+#define UINTPTR_MAX  __UINTPTR_MAX__
+#define PTRDIFF_MIN  (-__PTRDIFF_MAX__-1)
+#define PTRDIFF_MAX  __PTRDIFF_MAX__
+#define SIZE_MAX     __SIZE_MAX__
+#define INTMAX_MIN   (-__INTMAX_MAX__-1)
+#define INTMAX_MAX   __INTMAX_MAX__
+#define UINTMAX_MAX  __UINTMAX_MAX__
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+# define INTPTR_WIDTH  __INTPTR_WIDTH__
+# define UINTPTR_WIDTH __UINTPTR_WIDTH__
+# define INTMAX_WIDTH __INTMAX_WIDTH__
+# define UINTMAX_WIDTH __UINTMAX_WIDTH__
+# define PTRDIFF_WIDTH    __PTRDIFF_WIDTH__
+# define SIZE_WIDTH       __SIZE_WIDTH__
+# define WCHAR_WIDTH      __WCHAR_WIDTH__
+#endif
+
+typedef __INTMAX_TYPE__  intmax_t;
+typedef __UINTMAX_TYPE__ uintmax_t;
+
+#ifndef _INTPTR_T
+# ifndef __intptr_t_defined
+   typedef __INTPTR_TYPE__ intptr_t;
+#  define __intptr_t_defined
+#  define _INTPTR_T
+# endif
+#endif
+
+#ifndef _UINTPTR_T
+  typedef __UINTPTR_TYPE__ uintptr_t;
+# define _UINTPTR_T
+#endif
+
+
+#ifdef __INT64_TYPE__
+# ifndef __int8_t_defined /* glibc sys/types.h also defines int64_t*/
+   typedef __INT64_TYPE__ int64_t;
+# endif /* __int8_t_defined */
+  typedef __UINT64_TYPE__ uint64_t;
+
+# undef __int64_c_suffix
+# undef __int32_c_suffix
+# undef __int16_c_suffix
+# undef  __int8_c_suffix
+# ifdef __INT64_C_SUFFIX__
+#  define __int64_c_suffix __INT64_C_SUFFIX__
+#  define __int32_c_suffix __INT64_C_SUFFIX__
+#  define __int16_c_suffix __INT64_C_SUFFIX__
+#  define  __int8_c_suffix __INT64_C_SUFFIX__
+# endif /* __INT64_C_SUFFIX__ */
+
+# ifdef __int64_c_suffix
+#  define INT64_C(v) (__stdint_int_c(v, __int64_c_suffix))
+#  define UINT64_C(v) (__stdint_uint_c(v, __int64_c_suffix))
+# else
+#  define INT64_C(v) (v)
+#  define UINT64_C(v) (v ## U)
+# endif /* __int64_c_suffix */
+
+# define INT64_MAX           INT64_C( 9223372036854775807)
+# define INT64_MIN         (-INT64_C( 9223372036854775807)-1)
+# define UINT64_MAX         UINT64_C(18446744073709551615)
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#  define UINT64_WIDTH         64
+#  define INT64_WIDTH          UINT64_WIDTH
+# endif /* __STDC_VERSION__ */
+
+#endif /* __INT64_TYPE__ */
+
+
+#endif /* __STDC_HOSTED__ && __has_include_next(<stdint.h>) */

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -346,9 +346,9 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     try comp.generateIntMaxAndWidth(w, "WCHAR", comp.types.wchar);
     // try comp.generateIntMax(w, "WINT", comp.types.wchar);
     try comp.generateIntMaxAndWidth(w, "INTMAX", comp.types.intmax);
-    try comp.generateIntMax(w, "SIZE", comp.types.size);
+    try comp.generateIntMaxAndWidth(w, "SIZE", comp.types.size);
     try comp.generateIntMaxAndWidth(w, "UINTMAX", comp.types.intmax.makeIntegerUnsigned());
-    try comp.generateIntMax(w, "PTRDIFF", comp.types.ptrdiff);
+    try comp.generateIntMaxAndWidth(w, "PTRDIFF", comp.types.ptrdiff);
     try comp.generateIntMaxAndWidth(w, "INTPTR", comp.types.intptr);
     try comp.generateIntMaxAndWidth(w, "UINTPTR", comp.types.intptr.makeIntegerUnsigned());
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -57,6 +57,8 @@ types: struct {
     uintmax: Type = .{ .specifier = .invalid },
     intptr: Type = .{ .specifier = .invalid },
     uintptr: Type = .{ .specifier = .invalid },
+    int16: Type = .{ .specifier = .invalid },
+    uint16: Type = .{ .specifier = .invalid },
     int64: Type = .{ .specifier = .invalid },
     uint64: Type = .{ .specifier = .invalid },
 } = .{},
@@ -534,6 +536,9 @@ fn generateBuiltinTypes(comp: *Compilation) !void {
     const intptr = target.intPtrType(comp.target);
     const uintptr = intptr.makeIntegerUnsigned();
 
+    const int16 = target.int16Type(comp.target);
+    const uint16 = int16.makeIntegerUnsigned();
+
     const int64 = target.int64Type(comp.target);
     const uint64 = int64.makeIntegerUnsigned();
 
@@ -547,6 +552,8 @@ fn generateBuiltinTypes(comp: *Compilation) !void {
         .uintmax = uintmax,
         .intptr = intptr,
         .uintptr = uintptr,
+        .int16 = int16,
+        .uint16 = uint16,
         .int64 = int64,
         .uint64 = uint64,
     };
@@ -625,11 +632,12 @@ fn generateExactWidthType(comp: *const Compilation, w: anytype, mapper: StringIn
     const width = 8 * ty.sizeof(comp).?;
     const unsigned = ty.isUnsignedInt(comp);
 
-    if (width == 64) {
+    if (width == 16) {
+        ty = if (unsigned) comp.types.uint16 else comp.types.int16;
+    } else if (width == 64) {
         ty = if (unsigned) comp.types.uint64 else comp.types.int64;
     }
 
-    // TODO: Use target-specific int16 types when appropriate
     var prefix = std.BoundedArray(u8, 16).init(0) catch unreachable;
     prefix.writer().print("{s}{d}", .{ if (unsigned) "__UINT" else "__INT", width }) catch return error.OutOfMemory;
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -373,8 +373,13 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     const mapper = comp.string_interner.getSlowTypeMapper();
     try generateTypeMacro(w, mapper, "__INTPTR_TYPE__", comp.types.intptr, comp.langopts);
     try generateTypeMacro(w, mapper, "__UINTPTR_TYPE__", comp.types.intptr.makeIntegerUnsigned(), comp.langopts);
+
     try generateTypeMacro(w, mapper, "__INTMAX_TYPE__", comp.types.intmax, comp.langopts);
+    try comp.generateSuffixMacro("__INTMAX", w, comp.types.intptr);
+
     try generateTypeMacro(w, mapper, "__UINTMAX_TYPE__", comp.types.intmax.makeIntegerUnsigned(), comp.langopts);
+    try comp.generateSuffixMacro("__UINTMAX", w, comp.types.intptr.makeIntegerUnsigned());
+
     try generateTypeMacro(w, mapper, "__PTRDIFF_TYPE__", comp.types.ptrdiff, comp.langopts);
     try generateTypeMacro(w, mapper, "__SIZE_TYPE__", comp.types.size, comp.langopts);
     try generateTypeMacro(w, mapper, "__WCHAR_TYPE__", comp.types.wchar, comp.langopts);
@@ -612,6 +617,10 @@ fn generateFmt(comp: *const Compilation, prefix: []const u8, w: anytype, ty: Typ
     }
 }
 
+fn generateSuffixMacro(comp: *const Compilation, prefix: []const u8, w: anytype, ty: Type) !void {
+    return w.print("#define {s}_C_SUFFIX__ {s}\n", .{ prefix, ty.intValueSuffix(comp) });
+}
+
 /// Generate the following for ty:
 ///     Name macro (e.g. #define __UINT32_TYPE__ unsigned int)
 ///     Format strings (e.g. #define __UINT32_FMTu__ "u")
@@ -638,7 +647,7 @@ fn generateExactWidthType(comp: *const Compilation, w: anytype, mapper: StringIn
     }
 
     try comp.generateFmt(prefix.constSlice(), w, ty);
-    try w.print("#define {s}_C_SUFFIX__ {s}\n", .{ prefix.constSlice(), ty.intValueSuffix(comp) });
+    try comp.generateSuffixMacro(prefix.constSlice(), w, ty);
 }
 
 pub fn hasHalfPrecisionFloatABI(comp: *const Compilation) bool {

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -371,6 +371,10 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
 
     // various int types
     const mapper = comp.string_interner.getSlowTypeMapper();
+    try generateTypeMacro(w, mapper, "__INTPTR_TYPE__", comp.types.intptr, comp.langopts);
+    try generateTypeMacro(w, mapper, "__UINTPTR_TYPE__", comp.types.intptr.makeIntegerUnsigned(), comp.langopts);
+    try generateTypeMacro(w, mapper, "__INTMAX_TYPE__", comp.types.intmax, comp.langopts);
+    try generateTypeMacro(w, mapper, "__UINTMAX_TYPE__", comp.types.intmax.makeIntegerUnsigned(), comp.langopts);
     try generateTypeMacro(w, mapper, "__PTRDIFF_TYPE__", comp.types.ptrdiff, comp.langopts);
     try generateTypeMacro(w, mapper, "__SIZE_TYPE__", comp.types.size, comp.langopts);
     try generateTypeMacro(w, mapper, "__WCHAR_TYPE__", comp.types.wchar, comp.langopts);

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -6967,14 +6967,14 @@ fn primaryExpr(p: *Parser) Error!Result {
         => return p.charLiteral(),
         .zero => {
             p.tok_i += 1;
-            var res: Result = .{ .val = Value.int(0), .ty = if (p.in_macro) p.comp.intMaxType() else Type.int };
+            var res: Result = .{ .val = Value.int(0), .ty = if (p.in_macro) p.comp.types.intmax else Type.int };
             res.node = try p.addNode(.{ .tag = .int_literal, .ty = res.ty, .data = undefined });
             if (!p.in_macro) try p.value_map.put(res.node, res.val);
             return res;
         },
         .one => {
             p.tok_i += 1;
-            var res: Result = .{ .val = Value.int(1), .ty = if (p.in_macro) p.comp.intMaxType() else Type.int };
+            var res: Result = .{ .val = Value.int(1), .ty = if (p.in_macro) p.comp.types.intmax else Type.int };
             res.node = try p.addNode(.{ .tag = .int_literal, .ty = res.ty, .data = undefined });
             if (!p.in_macro) try p.value_map.put(res.node, res.val);
             return res;
@@ -7266,9 +7266,9 @@ fn charLiteral(p: *Parser) Error!Result {
 
     // This is the type the literal will have if we're in a macro; macros always operate on intmax_t/uintmax_t values
     const macro_ty = if (ty.isUnsignedInt(p.comp) or (p.tok_ids[p.tok_i] == .char_literal and p.comp.getCharSignedness() == .unsigned))
-        p.comp.uintMaxType()
+        p.comp.types.uintmax
     else
-        p.comp.intMaxType();
+        p.comp.types.intmax;
 
     var res = Result{
         .ty = if (p.in_macro) macro_ty else ty,
@@ -7402,7 +7402,7 @@ fn fixedSizeInt(p: *Parser, base: u8, buf: []const u8, suffix: NumberSuffix, tok
         return res;
     }
     if (suffix.isSignedInteger()) {
-        if (val > p.comp.intMaxType().maxInt(p.comp)) {
+        if (val > p.comp.types.intmax.maxInt(p.comp)) {
             try p.errTok(.implicitly_unsigned_literal, tok_i);
         }
     }
@@ -7590,7 +7590,7 @@ fn ppNum(p: *Parser) Error!Result {
             try p.errTok(.float_literal_in_pp_expr, p.tok_i);
             return error.ParsingFailed;
         }
-        res.ty = if (res.ty.isUnsignedInt(p.comp)) p.comp.uintMaxType() else p.comp.intMaxType();
+        res.ty = if (res.ty.isUnsignedInt(p.comp)) p.comp.types.uintmax else p.comp.types.intmax;
     } else {
         try p.value_map.put(res.node, res.val);
     }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7266,7 +7266,7 @@ fn charLiteral(p: *Parser) Error!Result {
 
     // This is the type the literal will have if we're in a macro; macros always operate on intmax_t/uintmax_t values
     const macro_ty = if (ty.isUnsignedInt(p.comp) or (p.tok_ids[p.tok_i] == .char_literal and p.comp.getCharSignedness() == .unsigned))
-        p.comp.types.uintmax
+        p.comp.types.intmax.makeIntegerUnsigned()
     else
         p.comp.types.intmax;
 
@@ -7590,7 +7590,7 @@ fn ppNum(p: *Parser) Error!Result {
             try p.errTok(.float_literal_in_pp_expr, p.tok_i);
             return error.ParsingFailed;
         }
-        res.ty = if (res.ty.isUnsignedInt(p.comp)) p.comp.types.uintmax else p.comp.types.intmax;
+        res.ty = if (res.ty.isUnsignedInt(p.comp)) p.comp.types.intmax.makeIntegerUnsigned() else p.comp.types.intmax;
     } else {
         try p.value_map.put(res.node, res.val);
     }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -2326,7 +2326,7 @@ pub fn intValueSuffix(ty: Type, comp: *const Compilation) []const u8 {
             if (ty.specifier == .char and comp.getCharSignedness() == .signed) return "";
             // Only 8-bit char supported currently;
             // TODO: handle platforms with 16-bit int + 16-bit char
-            std.debug.assert(ty.sizeof(comp).? == 8);
+            std.debug.assert(ty.sizeof(comp).? == 1);
             return "";
         },
         .ushort => {

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -2316,6 +2316,18 @@ pub fn hasAttribute(ty: Type, tag: Attribute.Tag) bool {
     return false;
 }
 
+/// printf format modifier
+pub fn formatModifier(ty: Type) []const u8 {
+    return switch (ty.specifier) {
+        .schar, .uchar => "hh",
+        .short, .ushort => "h",
+        .int, .uint => "",
+        .long, .ulong => "l",
+        .long_long, .ulong_long => "ll",
+        else => unreachable,
+    };
+}
+
 /// Suffix for integer values of this type
 pub fn intValueSuffix(ty: Type, comp: *const Compilation) []const u8 {
     return switch (ty.specifier) {

--- a/src/target.zig
+++ b/src/target.zig
@@ -117,7 +117,7 @@ pub fn int64Type(target: std.Target) Type {
 
         .sparc64 => return intMaxType(target),
 
-        .x86 => return intMaxType(target),
+        .x86, .x86_64 => return intMaxType(target),
         .aarch64, .aarch64_be => if (!target.isDarwin() and target.os.tag != .openbsd and target.os.tag != .windows) return .{ .specifier = .long },
         else => {},
     }

--- a/src/target.zig
+++ b/src/target.zig
@@ -8,6 +8,7 @@ const TargetSet = @import("builtins/Properties.zig").TargetSet;
 pub fn intMaxType(target: std.Target) Type {
     switch (target.cpu.arch) {
         .aarch64,
+        .aarch64_be,
         .sparc64,
         => if (target.os.tag != .openbsd) return .{ .specifier = .long },
 
@@ -44,7 +45,7 @@ pub fn intPtrType(target: std.Target) Type {
     }
 
     switch (target.cpu.arch) {
-        .aarch64 => switch (target.os.tag) {
+        .aarch64, .aarch64_be => switch (target.os.tag) {
             .windows => return .{ .specifier = .long_long },
             else => {},
         },
@@ -92,6 +93,27 @@ pub fn intPtrType(target: std.Target) Type {
     }
 
     return .{ .specifier = .long };
+}
+
+/// int64_t for this target
+pub fn int64Type(target: std.Target) Type {
+    switch (target.cpu.arch) {
+        .loongarch64,
+        .ve,
+        .riscv64,
+        .powerpc64,
+        .powerpc64le,
+        .bpfel,
+        .bpfeb,
+        => return .{ .specifier = .long },
+
+        .sparc64 => return intMaxType(target),
+
+        .x86 => return intMaxType(target),
+        .aarch64, .aarch64_be => if (!target.isDarwin() and target.os.tag != .openbsd and target.os.tag != .windows) return .{ .specifier = .long },
+        else => {},
+    }
+    return .{ .specifier = .long_long };
 }
 
 pub fn getCharSignedness(target: std.Target) std.builtin.Signedness {

--- a/src/target.zig
+++ b/src/target.zig
@@ -35,6 +35,65 @@ pub fn intMaxType(target: std.Target) Type {
     return .{ .specifier = .long_long };
 }
 
+/// intptr_t for this target
+pub fn intPtrType(target: std.Target) Type {
+    switch (target.os.tag) {
+        .haiku => return .{ .specifier = .long },
+        .nacl => return .{ .specifier = .int },
+        else => {},
+    }
+
+    switch (target.cpu.arch) {
+        .aarch64 => switch (target.os.tag) {
+            .windows => return .{ .specifier = .long_long },
+            else => {},
+        },
+
+        .msp430,
+        .csky,
+        .loongarch32,
+        .riscv32,
+        .xcore,
+        .hexagon,
+        .tce,
+        .tcele,
+        .m68k,
+        .spir,
+        .spirv32,
+        .arc,
+        .avr,
+        => return .{ .specifier = .int },
+
+        .sparc, .sparcel => switch (target.os.tag) {
+            .netbsd, .openbsd => {},
+            else => return .{ .specifier = .int },
+        },
+
+        .powerpc, .powerpcle => switch (target.os.tag) {
+            .linux, .freebsd, .netbsd => return .{ .specifier = .int },
+            else => {},
+        },
+
+        // 32-bit x86 Darwin, OpenBSD, and RTEMS use long (the default); others use int
+        .x86 => switch (target.os.tag) {
+            .openbsd, .rtems => {},
+            else => if (!target.os.tag.isDarwin()) return .{ .specifier = .int },
+        },
+
+        .x86_64 => switch (target.os.tag) {
+            .windows => return .{ .specifier = .long_long },
+            else => switch (target.abi) {
+                .gnux32, .muslx32 => return .{ .specifier = .int },
+                else => {},
+            },
+        },
+
+        else => {},
+    }
+
+    return .{ .specifier = .long };
+}
+
 pub fn getCharSignedness(target: std.Target) std.builtin.Signedness {
     switch (target.cpu.arch) {
         .aarch64,

--- a/src/target.zig
+++ b/src/target.zig
@@ -95,6 +95,14 @@ pub fn intPtrType(target: std.Target) Type {
     return .{ .specifier = .long };
 }
 
+/// int16_t for this target
+pub fn int16Type(target: std.Target) Type {
+    return switch (target.cpu.arch) {
+        .avr => .{ .specifier = .int },
+        else => .{ .specifier = .short },
+    };
+}
+
 /// int64_t for this target
 pub fn int64Type(target: std.Target) Type {
     switch (target.cpu.arch) {

--- a/src/target.zig
+++ b/src/target.zig
@@ -117,7 +117,7 @@ pub fn int64Type(target: std.Target) Type {
 
         .sparc64 => return intMaxType(target),
 
-        .x86, .x86_64 => return intMaxType(target),
+        .x86, .x86_64 => if (!target.isDarwin()) return intMaxType(target),
         .aarch64, .aarch64_be => if (!target.isDarwin() and target.os.tag != .openbsd and target.os.tag != .windows) return .{ .specifier = .long },
         else => {},
     }

--- a/test/cases/fixed size integer constants x86_64-linux-gnu.c
+++ b/test/cases/fixed size integer constants x86_64-linux-gnu.c
@@ -1,0 +1,47 @@
+//aro-args --target=x86_64-linux-gnu -std=c2x
+
+#define CAT(X, Y) XCAT(X, Y)
+#define XCAT(X, Y) X ## Y
+
+#define STR(X) XSTR(X)
+#define XSTR(X) #X
+
+_Static_assert(__INT8_MAX__ == 127);
+_Static_assert(__builtin_types_compatible_p(__INT8_TYPE__, signed char));
+_Static_assert(__builtin_types_compatible_p(__UINT8_TYPE__, unsigned char));
+_Static_assert(sizeof(STR(__INT8_C_SUFFIX__)) == 1); // Empty string, null terminator only
+_Static_assert(sizeof(STR(__UINT8_C_SUFFIX__)) == 1); // Empty string, null terminator only
+
+_Static_assert(__INT16_MAX__ == 32767);
+_Static_assert(__UINT16_MAX__ == 65535);
+_Static_assert(__builtin_types_compatible_p(__INT16_TYPE__, short));
+_Static_assert(__builtin_types_compatible_p(__UINT16_TYPE__, unsigned short));
+_Static_assert(sizeof(STR(__INT16_C_SUFFIX__)) == 1); // Empty string, null terminator only
+_Static_assert(sizeof(STR(__UINT16_C_SUFFIX__)) == 1); // Empty string, null terminator only
+
+_Static_assert(__INT32_MAX__ == 2147483647);
+_Static_assert(__UINT32_MAX__ == 4294967295U);
+_Static_assert(__builtin_types_compatible_p(__INT32_TYPE__, int));
+_Static_assert(__builtin_types_compatible_p(__UINT32_TYPE__, unsigned));
+_Static_assert(__builtin_types_compatible_p(typeof(__INT32_MAX__), int));
+_Static_assert(__builtin_types_compatible_p(typeof(__UINT32_MAX__), unsigned));
+_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __INT32_C_SUFFIX__)), int));
+_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __UINT32_C_SUFFIX__)), unsigned));
+
+_Static_assert(__INT64_MAX__ == 9223372036854775807LL);
+_Static_assert(__UINT64_MAX__ == 18446744073709551615ULL);
+_Static_assert(__builtin_types_compatible_p(__INT64_TYPE__, long));
+_Static_assert(__builtin_types_compatible_p(__UINT64_TYPE__, unsigned long));
+_Static_assert(__builtin_types_compatible_p(typeof(__INT64_MAX__), long));
+_Static_assert(__builtin_types_compatible_p(typeof(__UINT64_MAX__), unsigned long));
+_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __INT64_C_SUFFIX__)), long));
+_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __UINT64_C_SUFFIX__)), unsigned long));
+
+_Static_assert(__INT64_MAX__ == 9223372036854775807LL);
+_Static_assert(__UINT64_MAX__ == 18446744073709551615ULL);
+_Static_assert(__builtin_types_compatible_p(__INT64_TYPE__, long));
+_Static_assert(__builtin_types_compatible_p(__UINT64_TYPE__, unsigned long));
+_Static_assert(__builtin_types_compatible_p(typeof(__INT64_MAX__), long));
+_Static_assert(__builtin_types_compatible_p(typeof(__UINT64_MAX__), unsigned long));
+_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __INT64_C_SUFFIX__)), long));
+_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __UINT64_C_SUFFIX__)), unsigned long));

--- a/test/cases/fixed size integer constants x86_64-linux-gnu.c
+++ b/test/cases/fixed size integer constants x86_64-linux-gnu.c
@@ -1,47 +1,34 @@
 //aro-args --target=x86_64-linux-gnu -std=c2x
 
-#define CAT(X, Y) XCAT(X, Y)
-#define XCAT(X, Y) X ## Y
-
-#define STR(X) XSTR(X)
-#define XSTR(X) #X
+#include "test_helpers.h"
 
 _Static_assert(__INT8_MAX__ == 127);
-_Static_assert(__builtin_types_compatible_p(__INT8_TYPE__, signed char));
-_Static_assert(__builtin_types_compatible_p(__UINT8_TYPE__, unsigned char));
+EXPECT_TYPE(__INT8_TYPE__, signed char);
+EXPECT_TYPE(__UINT8_TYPE__, unsigned char);
 _Static_assert(sizeof(STR(__INT8_C_SUFFIX__)) == 1); // Empty string, null terminator only
 _Static_assert(sizeof(STR(__UINT8_C_SUFFIX__)) == 1); // Empty string, null terminator only
 
 _Static_assert(__INT16_MAX__ == 32767);
 _Static_assert(__UINT16_MAX__ == 65535);
-_Static_assert(__builtin_types_compatible_p(__INT16_TYPE__, short));
-_Static_assert(__builtin_types_compatible_p(__UINT16_TYPE__, unsigned short));
+EXPECT_TYPE(__INT16_TYPE__, short);
+EXPECT_TYPE(__UINT16_TYPE__, unsigned short);
 _Static_assert(sizeof(STR(__INT16_C_SUFFIX__)) == 1); // Empty string, null terminator only
 _Static_assert(sizeof(STR(__UINT16_C_SUFFIX__)) == 1); // Empty string, null terminator only
 
 _Static_assert(__INT32_MAX__ == 2147483647);
 _Static_assert(__UINT32_MAX__ == 4294967295U);
-_Static_assert(__builtin_types_compatible_p(__INT32_TYPE__, int));
-_Static_assert(__builtin_types_compatible_p(__UINT32_TYPE__, unsigned));
-_Static_assert(__builtin_types_compatible_p(typeof(__INT32_MAX__), int));
-_Static_assert(__builtin_types_compatible_p(typeof(__UINT32_MAX__), unsigned));
-_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __INT32_C_SUFFIX__)), int));
-_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __UINT32_C_SUFFIX__)), unsigned));
+EXPECT_TYPE(__INT32_TYPE__, int);
+EXPECT_TYPE(__UINT32_TYPE__, unsigned);
+EXPECT_TYPE(__INT32_MAX__, int);
+EXPECT_TYPE(__UINT32_MAX__, unsigned);
+EXPECT_TYPE(CAT(0, __INT32_C_SUFFIX__), int);
+EXPECT_TYPE(CAT(0, __UINT32_C_SUFFIX__), unsigned);
 
 _Static_assert(__INT64_MAX__ == 9223372036854775807LL);
 _Static_assert(__UINT64_MAX__ == 18446744073709551615ULL);
-_Static_assert(__builtin_types_compatible_p(__INT64_TYPE__, long));
-_Static_assert(__builtin_types_compatible_p(__UINT64_TYPE__, unsigned long));
-_Static_assert(__builtin_types_compatible_p(typeof(__INT64_MAX__), long));
-_Static_assert(__builtin_types_compatible_p(typeof(__UINT64_MAX__), unsigned long));
-_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __INT64_C_SUFFIX__)), long));
-_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __UINT64_C_SUFFIX__)), unsigned long));
-
-_Static_assert(__INT64_MAX__ == 9223372036854775807LL);
-_Static_assert(__UINT64_MAX__ == 18446744073709551615ULL);
-_Static_assert(__builtin_types_compatible_p(__INT64_TYPE__, long));
-_Static_assert(__builtin_types_compatible_p(__UINT64_TYPE__, unsigned long));
-_Static_assert(__builtin_types_compatible_p(typeof(__INT64_MAX__), long));
-_Static_assert(__builtin_types_compatible_p(typeof(__UINT64_MAX__), unsigned long));
-_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __INT64_C_SUFFIX__)), long));
-_Static_assert(__builtin_types_compatible_p(typeof(CAT(0, __UINT64_C_SUFFIX__)), unsigned long));
+EXPECT_TYPE(__INT64_TYPE__, long);
+EXPECT_TYPE(__UINT64_TYPE__, unsigned long);
+EXPECT_TYPE(__INT64_MAX__, long);
+EXPECT_TYPE(__UINT64_MAX__, unsigned long);
+EXPECT_TYPE(CAT(0, __INT64_C_SUFFIX__), long);
+EXPECT_TYPE(CAT(0, __UINT64_C_SUFFIX__), unsigned long);

--- a/test/cases/include/test_helpers.h
+++ b/test/cases/include/test_helpers.h
@@ -1,3 +1,9 @@
 #pragma once
 
 #define EXPECT_TYPE(EXPR, TYPE) _Static_assert(__builtin_types_compatible_p(__typeof__(EXPR), TYPE), "")
+
+#define CAT(X, Y) XCAT(X, Y)
+#define XCAT(X, Y) X ## Y
+
+#define STR(X) XSTR(X)
+#define XSTR(X) #X

--- a/test/cases/intmax_t.c
+++ b/test/cases/intmax_t.c
@@ -2,6 +2,8 @@
 
 _Static_assert(__INTMAX_MAX__ == 9223372036854775807L, "");
 _Static_assert(__INTMAX_WIDTH__ == 64, "");
+_Static_assert(__builtin_types_compatible_p(__INTMAX_TYPE__, long), "");
 
 _Static_assert(__UINTMAX_MAX__ == 18446744073709551615UL, "");
 _Static_assert(__UINTMAX_WIDTH__ == 64, "");
+_Static_assert(__builtin_types_compatible_p(__UINTMAX_TYPE__, unsigned long), "");

--- a/test/cases/intmax_t.c
+++ b/test/cases/intmax_t.c
@@ -1,9 +1,13 @@
 //aro-args --target=x86_64-linux-gnu
 
+#include "test_helpers.h"
+
 _Static_assert(__INTMAX_MAX__ == 9223372036854775807L, "");
 _Static_assert(__INTMAX_WIDTH__ == 64, "");
-_Static_assert(__builtin_types_compatible_p(__INTMAX_TYPE__, long), "");
+EXPECT_TYPE(__INTMAX_TYPE__, long);
+EXPECT_TYPE(CAT(0, __INTMAX_C_SUFFIX__), long);
 
 _Static_assert(__UINTMAX_MAX__ == 18446744073709551615UL, "");
 _Static_assert(__UINTMAX_WIDTH__ == 64, "");
-_Static_assert(__builtin_types_compatible_p(__UINTMAX_TYPE__, unsigned long), "");
+EXPECT_TYPE(__UINTMAX_TYPE__, unsigned long);
+EXPECT_TYPE(CAT(0, __UINTMAX_C_SUFFIX__), unsigned long);

--- a/test/cases/intptr_t.c
+++ b/test/cases/intptr_t.c
@@ -2,6 +2,8 @@
 
 _Static_assert(__INTPTR_MAX__ == 9223372036854775807L, "");
 _Static_assert(__INTPTR_WIDTH__ == 64, "");
+_Static_assert(__builtin_types_compatible_p(__INTPTR_TYPE__, long), "");
 
 _Static_assert(__UINTPTR_MAX__ == 18446744073709551615UL, "");
 _Static_assert(__UINTPTR_WIDTH__ == 64, "");
+_Static_assert(__builtin_types_compatible_p(__UINTPTR_TYPE__, unsigned long), "");

--- a/test/cases/intptr_t.c
+++ b/test/cases/intptr_t.c
@@ -1,9 +1,11 @@
 //aro-args --target=x86_64-linux-gnu
 
+#include "test_helpers.h"
+
 _Static_assert(__INTPTR_MAX__ == 9223372036854775807L, "");
 _Static_assert(__INTPTR_WIDTH__ == 64, "");
-_Static_assert(__builtin_types_compatible_p(__INTPTR_TYPE__, long), "");
+EXPECT_TYPE(__INTPTR_TYPE__, long);
 
 _Static_assert(__UINTPTR_MAX__ == 18446744073709551615UL, "");
 _Static_assert(__UINTPTR_WIDTH__ == 64, "");
-_Static_assert(__builtin_types_compatible_p(__UINTPTR_TYPE__, unsigned long), "");
+EXPECT_TYPE(__UINTPTR_TYPE__, unsigned long);

--- a/test/cases/intptr_t.c
+++ b/test/cases/intptr_t.c
@@ -1,0 +1,7 @@
+//aro-args --target=x86_64-linux-gnu
+
+_Static_assert(__INTPTR_MAX__ == 9223372036854775807L, "");
+_Static_assert(__INTPTR_WIDTH__ == 64, "");
+
+_Static_assert(__UINTPTR_MAX__ == 18446744073709551615UL, "");
+_Static_assert(__UINTPTR_WIDTH__ == 64, "");

--- a/test/cases/stdint c2x.c
+++ b/test/cases/stdint c2x.c
@@ -1,6 +1,7 @@
 //aro-args -std=c2x
 
 #include <stdint.h>
+#include "test_helpers.h"
 
 #ifndef INTPTR_WIDTH
 #error INTPTR_WIDTH
@@ -47,6 +48,8 @@ void int64(void) {
     _Static_assert(UINT64_MAX == 18446744073709551615ULL);
     _Static_assert(INT64_WIDTH == 64);
     _Static_assert(UINT64_WIDTH == 64);
+    EXPECT_TYPE(INT64_C(0), __INT64_TYPE__);
+    EXPECT_TYPE(UINT64_C(0), __UINT64_TYPE__);
 }
 
 void int32(void) {
@@ -61,6 +64,8 @@ void int32(void) {
     _Static_assert(UINT32_MAX == 4294967295U);
     _Static_assert(INT32_WIDTH == 32);
     _Static_assert(UINT32_WIDTH == 32);
+    EXPECT_TYPE(INT32_C(0), __INT32_TYPE__);
+    EXPECT_TYPE(UINT32_C(0), __UINT32_TYPE__);
 }
 
 void int16(void) {

--- a/test/cases/stdint c2x.c
+++ b/test/cases/stdint c2x.c
@@ -1,0 +1,92 @@
+//aro-args -std=c2x
+
+#include <stdint.h>
+
+#ifndef INTPTR_WIDTH
+#error INTPTR_WIDTH
+#endif
+
+#ifndef UINTPTR_WIDTH
+#error UINTPTR_WIDTH
+#endif
+
+#ifndef INTMAX_WIDTH
+#error INTMAX_WIDTH
+#endif
+
+#ifndef UINTMAX_WIDTH
+#error UINTMAX_WIDTH
+#endif
+
+#ifndef PTRDIFF_WIDTH
+#error PTRDIFF_WIDTH
+#endif
+
+#ifndef SIZE_WIDTH
+#error SIZE_WIDTH
+#endif
+
+#ifndef WCHAR_WIDTH
+#error WCHAR_WIDTH
+#endif
+
+intmax_t intmax = SIZE_MAX;
+uintmax_t uintmax = UINTMAX_MAX;
+intptr_t intprt = INTPTR_MAX;
+uintptr_t uintptr = UINTPTR_MAX;
+
+void int64(void) {
+    int64_t x = INT64_MAX;
+    uint64_t y = UINT64_MAX;
+
+    x = INT64_MIN;
+    x = INT64_C(0);
+    y = UINT64_C(0);
+    _Static_assert(INT64_MAX == 9223372036854775807LL);
+    _Static_assert(INT64_MIN == -9223372036854775807LL - 1LL);
+    _Static_assert(UINT64_MAX == 18446744073709551615ULL);
+    _Static_assert(INT64_WIDTH == 64);
+    _Static_assert(UINT64_WIDTH == 64);
+}
+
+void int32(void) {
+    int32_t x = INT32_MAX;
+    uint32_t y = UINT32_MAX;
+
+    x = INT32_MIN;
+    x = INT32_C(0);
+    y = UINT32_C(0);
+    _Static_assert(INT32_MAX == 2147483647);
+    _Static_assert(INT32_MIN == -2147483648);
+    _Static_assert(UINT32_MAX == 4294967295U);
+    _Static_assert(INT32_WIDTH == 32);
+    _Static_assert(UINT32_WIDTH == 32);
+}
+
+void int16(void) {
+    int16_t x = INT16_MAX;
+    uint16_t y = UINT16_MAX;
+
+    x = INT16_MIN;
+    x = INT16_C(0);
+    y = UINT16_C(0);
+    _Static_assert(INT16_MAX == 32767);
+    _Static_assert(INT16_MIN == -32768);
+    _Static_assert(UINT16_MAX == 65535U);
+    _Static_assert(INT16_WIDTH == 16);
+    _Static_assert(UINT16_WIDTH == 16);
+}
+
+void int8(void) {
+    int8_t x = INT8_MAX;
+    uint8_t y = UINT8_MAX;
+
+    x = INT8_MIN;
+    x = INT8_C(0);
+    y = UINT8_C(0);
+    _Static_assert(INT8_MAX == 127);
+    _Static_assert(INT8_MIN == -128);
+    _Static_assert(UINT8_MAX == 255U);
+    _Static_assert(INT8_WIDTH == 8);
+    _Static_assert(UINT8_WIDTH == 8);
+}


### PR DESCRIPTION
Adds `intptr_t` and fixed-size integers (`int8_t`, `int16_t`, etc) as well as associated constants, suffixes, and format strings.

Optional `least` and `fast` types are currently not implemented.