### PR TITLE
Parser: implement __auto_type

### DIFF
--- a/src/Attribute.zig
+++ b/src/Attribute.zig
@@ -1277,12 +1277,13 @@ pub fn applyEnumeratorAttributes(p: *Parser, ty: Type, attr_buf_start: usize) !T
 
 fn applyAligned(attr: Attribute, p: *Parser, ty: Type, tag: ?Diagnostics.Tag) !void {
     const base = ty.canonicalize(.standard);
-    const default_align = base.alignof(p.comp);
     if (attr.args.aligned.alignment) |alignment| alignas: {
         if (attr.syntax != .keyword) break :alignas;
 
         const align_tok = attr.args.aligned.__name_tok;
         if (tag) |t| try p.errTok(t, align_tok);
+
+        const default_align = base.alignof(p.comp);
         if (ty.isFunc()) {
             try p.errTok(.alignas_on_func, align_tok);
         } else if (alignment.requested < default_align) {

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -160,6 +160,7 @@ pub const Options = packed struct {
     @"pre-c2x-compat": Kind = .default,
     @"pointer-bool-conversion": Kind = .default,
     @"string-conversion": Kind = .default,
+    @"gnu-auto-type": Kind = .default,
 };
 
 const messages = struct {
@@ -2240,6 +2241,47 @@ const messages = struct {
         const opt = "c2x-extensions";
         const kind = .warning;
         const suppress_version = .c2x;
+    };
+    const auto_type_extension = struct {
+        const msg = "'__auto_type' is a GNU extension";
+        const opt = "gnu-auto-type";
+        const kind = .off;
+        const pedantic = true;
+    };
+    const auto_type_not_allowed = struct {
+        const msg = "'__auto_type' not allowed in {s}";
+        const kind = .@"error";
+        const extra = .str;
+    };
+    const auto_type_requires_initializer = struct {
+        const msg = "declaration of variable '{s}' with deduced type requires an initializer";
+        const kind = .@"error";
+        const extra = .str;
+    };
+    const auto_type_requires_single_declarator = struct {
+        const msg = "'__auto_type' may only be used with a single declarator";
+        const kind = .@"error";
+    };
+    const auto_type_requires_plain_declarator = struct {
+        const msg = "'__auto_type' requires a plain identifier as declarator";
+        const kind = .@"error";
+    };
+    const invalid_cast_to_auto_type = struct {
+        const msg = "Invalid cast to '__auto_type'";
+        const kind = .@"error";
+    };
+    const auto_type_from_bitfield = struct {
+        const msg = "cannot use bit-field as '__auto_type' initializer";
+        const kind = .@"error";
+    };
+    const array_of_auto_type = struct {
+        const msg = "'{s}' declared as array of '__auto_type'";
+        const kind = .@"error";
+        const extra = .str;
+    };
+    const auto_type_with_init_list = struct {
+        const msg = "cannot use '__auto_type' with initializer list";
+        const kind = .@"error";
     };
 };
 

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -139,6 +139,7 @@ pub const Token = struct {
         macro_pretty_func,
 
         keyword_auto,
+        keyword_auto_type,
         keyword_break,
         keyword_case,
         keyword_char,
@@ -313,6 +314,7 @@ pub const Token = struct {
                 .macro_function,
                 .macro_pretty_func,
                 .keyword_auto,
+                .keyword_auto_type,
                 .keyword_break,
                 .keyword_case,
                 .keyword_char,
@@ -555,6 +557,7 @@ pub const Token = struct {
                 .hash_hash => "##",
 
                 .keyword_auto => "auto",
+                .keyword_auto_type => "__auto_type",
                 .keyword_break => "break",
                 .keyword_case => "case",
                 .keyword_char => "char",
@@ -908,6 +911,7 @@ pub const Token = struct {
         .{ "__PRETTY_FUNCTION__", .macro_pretty_func },
 
         // gcc keywords
+        .{ "__auto_type", .keyword_auto_type },
         .{ "__const", .keyword_const1 },
         .{ "__const__", .keyword_const2 },
         .{ "__inline", .keyword_inline1 },
@@ -1819,7 +1823,7 @@ test "operators" {
 
 test "keywords" {
     try expectTokens(
-        \\auto break case char const continue default do 
+        \\auto __auto_type break case char const continue default do
         \\double else enum extern float for goto if int 
         \\long register return short signed sizeof static 
         \\struct switch typedef union unsigned void volatile 
@@ -1829,6 +1833,7 @@ test "keywords" {
         \\
     , &.{
         .keyword_auto,
+        .keyword_auto_type,
         .keyword_break,
         .keyword_case,
         .keyword_char,

--- a/test/cases/__auto_type.c
+++ b/test/cases/__auto_type.c
@@ -1,0 +1,82 @@
+//aro-args -Wno-gnu-alignof-expression
+#include "test_helpers.h"
+__auto_type foo(void);
+__auto_type foo1(void) {}
+
+void bar(__auto_type);
+void bar1(__auto_type x) {}
+
+typedef __auto_type my_auto_type;
+int __auto_type a = 5;
+
+struct S {
+    unsigned bitfield: 5;
+};
+struct BadStruct {
+    __auto_type y;
+};
+union BadUnion {
+    __auto_type x;
+};
+
+int myfunc(int x) { return x; }
+
+void baz(void) {
+
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic warning "-Wgnu-auto-type"
+#   pragma GCC diagnostic ignored "-Wsizeof-array-argument"
+    __auto_type decayed_arr = (double[]){1.,2.,3.,4.,5.};
+    _Static_assert(sizeof(decayed_arr) == sizeof(double *), "");
+#   pragma GCC diagnostic pop
+
+    __auto_type b = 5U;
+    EXPECT_TYPE(b, unsigned);
+    int c = (__auto_type)5;
+
+    __auto_type d;
+
+    __auto_type e = 1, f = 2;
+
+    struct S s = {};
+    __auto_type g = s.bitfield;
+
+    const int const_int = 5;
+    __auto_type h = const_int;
+    h = 100;
+
+    const __auto_type i = 0;
+    i += 1;
+
+    __auto_type func_ptr = myfunc;
+    EXPECT_TYPE(func_ptr, __typeof__(&myfunc));
+    EXPECT_TYPE(func_ptr, int (*)(int));
+
+    __auto_type my_struct = (struct S){.bitfield = 10 };
+    EXPECT_TYPE(my_struct, struct S);
+
+    __auto_type auto_array[2] = {1, 2};
+
+    __auto_type init_list = {1,2};
+
+    __attribute__((aligned(128))) __auto_type aligned_var = 0ULL;
+    _Static_assert(_Alignof(aligned_var) == 128, "");
+}
+
+#define EXPECTED_ERRORS "__auto_type.c:3:1: error: '__auto_type' not allowed in function return type" \
+    "__auto_type.c:4:1: error: '__auto_type' not allowed in function return type" \
+    "__auto_type.c:6:10: error: '__auto_type' not allowed in function prototype" \
+    "__auto_type.c:7:11: error: '__auto_type' not allowed in function prototype" \
+    "__auto_type.c:9:9: error: '__auto_type' not allowed in typedef" \
+    "__auto_type.c:10:5: error: cannot combine with previous 'int' specifier" \
+    "__auto_type.c:16:17: error: '__auto_type' not allowed in struct member" \
+    "__auto_type.c:19:17: error: '__auto_type' not allowed in union member" \
+    "__auto_type.c:29:5: warning: '__auto_type' is a GNU extension [-Wgnu-auto-type]" \
+    "__auto_type.c:35:13: error: Invalid cast to '__auto_type'" \
+    "__auto_type.c:37:17: error: declaration of variable 'd' with deduced type requires an initializer" \
+    "__auto_type.c:39:5: error: '__auto_type' may only be used with a single declarator" \
+    "__auto_type.c:42:21: error: cannot use bit-field as '__auto_type' initializer" \
+    "__auto_type.c:49:7: error: expression is not assignable" \
+    "__auto_type.c:58:17: error: 'auto_array' declared as array of '__auto_type'" \
+    "__auto_type.c:60:29: error: cannot use '__auto_type' with initializer list" \
+


### PR DESCRIPTION
This implements GCC-style `__auto_type` as a type specifier. Clang implements it as C++ `auto` which is more powerful in that it allows multiple declarators and non-simple declarators. C23 auto is based on the GCC variant.

Closes #173