### PR TITLE
Parser: allow omitting the semicolon after the last declarator in a record

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2283,6 +2283,10 @@ const messages = struct {
         const msg = "cannot use '__auto_type' with initializer list";
         const kind = .@"error";
     };
+    const missing_semicolon = struct {
+        const msg = "expected ';' at end of declaration list";
+        const kind = .warning;
+    };
 };
 
 list: std.ArrayListUnmanaged(Message) = .{},

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -2187,7 +2187,15 @@ fn recordDeclarator(p: *Parser) Error!bool {
         }
         if (p.eatToken(.comma) == null) break;
     }
-    _ = try p.expectToken(.semicolon);
+
+    if (p.eatToken(.semicolon) == null) {
+        const tok_id = p.tok_ids[p.tok_i];
+        if (tok_id == .r_brace) {
+            try p.err(.missing_semicolon);
+        } else {
+            return p.errExpectedToken(.semicolon, tok_id);
+        }
+    }
 
     return true;
 }

--- a/test/cases/containers.c
+++ b/test/cases/containers.c
@@ -134,6 +134,11 @@ void qux(void) {
 struct A;
 struct A a2;
 
+struct NoTrailingSemicolon {
+    int a;
+    int b
+};
+
 #define EXPECTED_ERRORS "containers.c:15:8: error: use of 'Foo' with tag type that does not match previous definition" \
     "containers.c:9:6: note: previous definition is here" \
     "containers.c:15:12: error: variable has incomplete type 'struct Foo'" \
@@ -159,3 +164,5 @@ struct A a2;
     "containers.c:132:12: error: use of 'A' with tag type that does not match previous definition" \
     "containers.c:131:10: note: previous definition is here" \
     "containers.c:132:14: error: variable has incomplete type 'struct A'" \
+    "containers.c:140:1: warning: expected ';' at end of declaration list" \
+


### PR DESCRIPTION
GCC and clang allow this