### PR TITLE
Parser: allow tentative top-level records and enums

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2287,6 +2287,16 @@ const messages = struct {
         const msg = "expected ';' at end of declaration list";
         const kind = .warning;
     };
+    const tentative_definition_incomplete = struct {
+        const msg = "tentative definition has type '{s}' that is never completed";
+        const kind = .@"error";
+        const extra = .str;
+    };
+    const forward_declaration_here = struct {
+        const msg = "forward declaration of '{s}'";
+        const kind = .note;
+        const extra = .str;
+    };
 };
 
 list: std.ArrayListUnmanaged(Message) = .{},

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -289,11 +289,11 @@ pub const Tag = enum(u8) {
     union_decl,
     /// { range }
     enum_decl,
-    /// struct Name;
+    /// struct decl_ref;
     struct_forward_decl,
-    /// union Name;
+    /// union decl_ref;
     union_forward_decl,
-    /// enum Name;
+    /// enum decl_ref;
     enum_forward_decl,
 
     /// name = node

--- a/test/cases/containers.c
+++ b/test/cases/containers.c
@@ -141,7 +141,8 @@ struct NoTrailingSemicolon {
 
 #define EXPECTED_ERRORS "containers.c:15:8: error: use of 'Foo' with tag type that does not match previous definition" \
     "containers.c:9:6: note: previous definition is here" \
-    "containers.c:15:12: error: variable has incomplete type 'struct Foo'" \
+    "containers.c:15:12: error: tentative definition has type 'struct Foo' that is never completed" \
+    "containers.c:15:8: note: forward declaration of 'struct Foo'" \
     "containers.c:20:6: warning: declaration does not declare anything [-Wmissing-declaration]" \
     "containers.c:21:25: warning: declaration does not declare anything [-Wmissing-declaration]" \
     "containers.c:22:20: error: invalid application of 'sizeof' to an incomplete type 'struct StructTest'" \

--- a/test/cases/invalid types.c
+++ b/test/cases/invalid types.c
@@ -41,7 +41,8 @@ int qux[] = baz;
     "invalid types.c:6:1: error: atomic cannot be applied to incomplete type 'void'" \
     "invalid types.c:6:14: error: variable has incomplete type 'void'" \
     "invalid types.c:7:7: error: array has incomplete element type 'void'" \
-    "invalid types.c:8:12: error: variable has incomplete type 'struct Bar'" \
+    "invalid types.c:8:12: error: tentative definition has type 'struct Bar' that is never completed" \
+    "invalid types.c:8:8: note: forward declaration of 'struct Bar'" \
     "invalid types.c:9:6: error: array is too large" \
     "invalid types.c:11:1: warning: plain '_Complex' requires a type specifier; assuming '_Complex double'" \
     "invalid types.c:16:15: error: expected identifier or '('" \
@@ -51,3 +52,4 @@ int qux[] = baz;
     "invalid types.c:22:9: error: size of array has non-integer type 'char [4]'" \
     "invalid types.c:23:13: error: array initializer must be an initializer list or wide string literal" \
     "invalid types.c:24:13: error: array initializer must be an initializer list or wide string literal" \
+

--- a/test/cases/tentative definitions.c
+++ b/test/cases/tentative definitions.c
@@ -1,0 +1,53 @@
+struct Tentative;
+struct Tentative t1, t2;
+
+void foo(void) {
+    struct Tentative { // does not complete tentative definition in outer scope
+        int x;
+    };
+
+    struct S1 s1; // tentative definition not allowed in function
+    struct S1 {
+        int a,b,c,d;
+    };
+}
+
+enum E e;
+
+union __attribute__((aligned(32))) U;
+union __attribute__((aligned(64))) U u;
+
+struct S1 s1;
+struct S2;
+struct S2 s2;
+
+struct S1 {
+    int x;
+};
+
+struct S2 {
+    int x;
+    int y;
+};
+
+_Static_assert(sizeof(s1) == sizeof(struct S1), "");
+_Static_assert(sizeof(s2) == sizeof(struct S2), "");
+
+struct A {
+    struct B b;
+};
+struct B {
+    int x;
+};
+
+extern struct Tentative tentative_extern;
+
+#define EXPECTED_ERRORS "tentative definitions.c:9:15: error: variable has incomplete type 'struct S1'" \
+    "tentative definitions.c:37:14: error: field has incomplete type 'struct B'" \
+    "tentative definitions.c:2:18: error: tentative definition has type 'struct Tentative' that is never completed" \
+    "tentative definitions.c:1:8: note: forward declaration of 'struct Tentative'" \
+    "tentative definitions.c:15:8: error: tentative definition has type 'enum E' that is never completed" \
+    "tentative definitions.c:15:6: note: forward declaration of 'enum E'" \
+    "tentative definitions.c:18:38: error: tentative definition has type 'union U' that is never completed" \
+    "tentative definitions.c:17:36: note: forward declaration of 'union U'" \
+


### PR DESCRIPTION
Allow top-level definitions of symbols which have incomplete record or enum types, and only issue an error if the type is never completed.