### PR TITLE
Zig update: builtin rename: xToY -> yFromX

### DIFF
--- a/deps/zig/codegen/x86_64.zig
+++ b/deps/zig/codegen/x86_64.zig
@@ -45,7 +45,7 @@ pub const Register = enum(u8) {
 
     /// Returns the bit-width of the register.
     pub fn size(self: Register) u7 {
-        return switch (@enumToInt(self)) {
+        return switch (@intFromEnum(self)) {
             0...15 => 64,
             16...31 => 32,
             32...47 => 16,
@@ -60,7 +60,7 @@ pub const Register = enum(u8) {
     /// on. This is needed because access to these registers requires special
     /// handling via the REX prefix, via the B or R bits, depending on context.
     pub fn isExtended(self: Register) bool {
-        return @enumToInt(self) & 0x08 != 0;
+        return @intFromEnum(self) & 0x08 != 0;
     }
 
     /// This returns the 4-bit register ID, which is used in practically every
@@ -69,12 +69,12 @@ pub const Register = enum(u8) {
     /// lower three bits are often embedded directly in instructions (such as
     /// the B8 variant of moves), or used in R/M bytes.
     pub fn id(self: Register) u4 {
-        return @truncate(u4, @enumToInt(self));
+        return @truncate(u4, @intFromEnum(self));
     }
 
     /// Like id, but only returns the lower 3 bits.
     pub fn low_id(self: Register) u3 {
-        return @truncate(u3, @enumToInt(self));
+        return @truncate(u3, @intFromEnum(self));
     }
 
     /// Returns the index into `callee_preserved_regs`.
@@ -95,22 +95,22 @@ pub const Register = enum(u8) {
 
     /// Convert from any register to its 64 bit alias.
     pub fn to64(self: Register) Register {
-        return @intToEnum(Register, self.id());
+        return @enumFromInt(Register, self.id());
     }
 
     /// Convert from any register to its 32 bit alias.
     pub fn to32(self: Register) Register {
-        return @intToEnum(Register, @as(u8, self.id()) + 16);
+        return @enumFromInt(Register, @as(u8, self.id()) + 16);
     }
 
     /// Convert from any register to its 16 bit alias.
     pub fn to16(self: Register) Register {
-        return @intToEnum(Register, @as(u8, self.id()) + 32);
+        return @enumFromInt(Register, @as(u8, self.id()) + 32);
     }
 
     /// Convert from any register to its 8 bit alias.
     pub fn to8(self: Register) Register {
-        return @intToEnum(Register, @as(u8, self.id()) + 48);
+        return @enumFromInt(Register, @as(u8, self.id()) + 48);
     }
 
     pub fn dwarfLocOp(self: Register) u8 {

--- a/src/Attribute.zig
+++ b/src/Attribute.zig
@@ -162,7 +162,7 @@ pub const Formatting = struct {
 
                 const enum_fields = @typeInfo(Unwrapped).Enum.fields;
                 @setEvalBranchQuota(3000);
-                const quote = comptime quoteChar(@intToEnum(Tag, @enumToInt(tag)));
+                const quote = comptime quoteChar(@enumFromInt(Tag, @intFromEnum(tag)));
                 comptime var values: []const u8 = quote ++ enum_fields[0].name ++ quote;
                 inline for (enum_fields[1..]) |enum_field| {
                     values = values ++ ", ";
@@ -300,7 +300,7 @@ fn diagnoseField(
 pub fn diagnose(attr: Tag, arguments: *Arguments, arg_idx: u32, val: Value, node: Tree.Node) ?Diagnostics.Message {
     switch (attr) {
         inline else => |tag| {
-            const decl = @typeInfo(attributes).Struct.decls[@enumToInt(tag)];
+            const decl = @typeInfo(attributes).Struct.decls[@intFromEnum(tag)];
             const max_arg_count = comptime maxArgCount(tag);
             if (arg_idx >= max_arg_count) return Diagnostics.Message{
                 .tag = .attribute_too_many_args,
@@ -916,7 +916,7 @@ pub const Arguments = blk: {
 };
 
 pub fn ArgumentsForTag(comptime tag: Tag) type {
-    const decl = @typeInfo(attributes).Struct.decls[@enumToInt(tag)];
+    const decl = @typeInfo(attributes).Struct.decls[@intFromEnum(tag)];
     return if (@hasDecl(@field(attributes, decl.name), "Args")) @field(attributes, decl.name).Args else void;
 }
 
@@ -947,7 +947,7 @@ fn fromStringGnu(name: []const u8) ?Tag {
     inline for (decls, 0..) |decl, i| {
         if (@hasDecl(@field(attributes, decl.name), "gnu")) {
             if (mem.eql(u8, @field(attributes, decl.name).gnu, normalized)) {
-                return @intToEnum(Tag, i);
+                return @enumFromInt(Tag, i);
             }
         }
     }
@@ -967,7 +967,7 @@ fn fromStringC2X(namespace: ?[]const u8, name: []const u8) ?Tag {
     inline for (decls, 0..) |decl, i| {
         if (@hasDecl(@field(attributes, decl.name), "c2x")) {
             if (mem.eql(u8, @field(attributes, decl.name).c2x, normalized)) {
-                return @intToEnum(Tag, i);
+                return @enumFromInt(Tag, i);
             }
         }
     }
@@ -979,7 +979,7 @@ fn fromStringDeclspec(name: []const u8) ?Tag {
     inline for (decls, 0..) |decl, i| {
         if (@hasDecl(@field(attributes, decl.name), "declspec")) {
             if (mem.eql(u8, @field(attributes, decl.name).declspec, name)) {
-                return @intToEnum(Tag, i);
+                return @enumFromInt(Tag, i);
             }
         }
     }

--- a/src/Builtins.zig
+++ b/src/Builtins.zig
@@ -302,7 +302,7 @@ test "All builtins" {
     const type_arena = arena.allocator();
 
     for (0..@typeInfo(BuiltinFunction.Tag).Enum.fields.len) |i| {
-        const tag = @intToEnum(BuiltinFunction.Tag, i);
+        const tag = @enumFromInt(BuiltinFunction.Tag, i);
         const name = @tagName(tag);
         if (try comp.builtins.getOrCreate(&comp, name, type_arena)) |func_ty| {
             const get_again = (try comp.builtins.getOrCreate(&comp, name, std.testing.failing_allocator)).?;
@@ -326,7 +326,7 @@ test "Allocation failures" {
 
             const num_builtins = 40;
             for (0..num_builtins) |i| {
-                const tag = @intToEnum(BuiltinFunction.Tag, i);
+                const tag = @enumFromInt(BuiltinFunction.Tag, i);
                 const name = @tagName(tag);
                 _ = try comp.builtins.getOrCreate(&comp, name, type_arena);
             }

--- a/src/Codegen_legacy.zig
+++ b/src/Codegen_legacy.zig
@@ -29,7 +29,7 @@ pub fn generateTree(comp: *Compilation, tree: Tree) Compilation.Error!*Object {
 
     const node_tags = tree.nodes.items(.tag);
     for (tree.root_decls) |decl| {
-        switch (node_tags[@enumToInt(decl)]) {
+        switch (node_tags[@intFromEnum(decl)]) {
             // these produce no code
             .static_assert,
             .typedef,
@@ -52,7 +52,7 @@ pub fn generateTree(comp: *Compilation, tree: Tree) Compilation.Error!*Object {
             .extern_var,
             .threadlocal_extern_var,
             => {
-                const name = c.tree.tokSlice(c.node_data[@enumToInt(decl)].decl.name);
+                const name = c.tree.tokSlice(c.node_data[@intFromEnum(decl)].decl.name);
                 _ = try c.obj.declareSymbol(.undefined, name, .Strong, .external, 0, 0);
             },
 
@@ -93,7 +93,7 @@ fn genFn(c: *Codegen, decl: NodeIndex) Error!void {
         .x86_64 => try x86_64.genFn(c, decl, data),
         else => unreachable,
     }
-    const name = c.tree.tokSlice(c.node_data[@enumToInt(decl)].decl.name);
+    const name = c.tree.tokSlice(c.node_data[@intFromEnum(decl)].decl.name);
     _ = try c.obj.declareSymbol(section, name, .Strong, .func, start_len, data.items.len - start_len);
 }
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -396,7 +396,7 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
     // TODO: clang treats __FLT_EVAL_METHOD__ as a special-cased macro because evaluating it within a scope
     // where `#pragma clang fp eval_method(X)` has been called produces an error diagnostic.
     const flt_eval_method = comp.langopts.fp_eval_method orelse target_util.defaultFpEvalMethod(comp.target);
-    try w.print("#define __FLT_EVAL_METHOD__ {d}\n", .{@enumToInt(flt_eval_method)});
+    try w.print("#define __FLT_EVAL_METHOD__ {d}\n", .{@intFromEnum(flt_eval_method)});
 
     try w.writeAll(
         \\#define __FLT_RADIX__ 2
@@ -858,7 +858,7 @@ pub fn getSource(comp: *const Compilation, id: Source.Id) Source {
         .id = .generated,
         .splice_locs = &.{},
     };
-    return comp.sources.values()[@enumToInt(id) - 2];
+    return comp.sources.values()[@intFromEnum(id) - 2];
 }
 
 /// Creates a Source from the contents of `reader` and adds it to the Compilation
@@ -878,7 +878,7 @@ pub fn addSourceFromReader(comp: *Compilation, reader: anytype, path: []const u8
     var splice_list = std.ArrayList(u32).init(comp.gpa);
     defer splice_list.deinit();
 
-    const source_id = @intToEnum(Source.Id, comp.sources.count() + 2);
+    const source_id = @enumFromInt(Source.Id, comp.sources.count() + 2);
 
     var i: u32 = 0;
     var backslash_loc: u32 = undefined;

--- a/src/Interner.zig
+++ b/src/Interner.zig
@@ -54,7 +54,7 @@ pub const Key = union(enum) {
                 }
             },
             .record => |info| {
-                std.hash.autoHash(&hasher, @ptrToInt(info.user_ptr));
+                std.hash.autoHash(&hasher, @intFromPtr(info.user_ptr));
             },
             inline else => |info| {
                 std.hash.autoHash(&hasher, info);
@@ -148,13 +148,13 @@ pub fn deinit(ip: *Interner, gpa: Allocator) void {
 pub fn put(ip: *Interner, gpa: Allocator, key: Key) !Ref {
     if (key.toRef()) |some| return some;
     const gop = try ip.map.getOrPut(gpa, key);
-    return @intToEnum(Ref, gop.index);
+    return @enumFromInt(Ref, gop.index);
 }
 
 pub fn has(ip: *Interner, key: Key) ?Ref {
     if (key.toRef()) |some| return some;
     if (ip.map.getIndex(key)) |index| {
-        return @intToEnum(Ref, index);
+        return @enumFromInt(Ref, index);
     }
     return null;
 }
@@ -178,5 +178,5 @@ pub fn get(ip: Interner, ref: Ref) Key {
         .f128 => return .{ .float = 128 },
         else => {},
     }
-    return ip.map.keys()[@enumToInt(ref)];
+    return ip.map.keys()[@intFromEnum(ref)];
 }

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -59,7 +59,7 @@ pub const Standard = enum {
     });
 
     pub fn atLeast(self: Standard, other: Standard) bool {
-        return @enumToInt(self) >= @enumToInt(other);
+        return @intFromEnum(self) >= @intFromEnum(other);
     }
 
     pub fn isGNU(standard: Standard) bool {

--- a/src/Preprocessor.zig
+++ b/src/Preprocessor.zig
@@ -1410,7 +1410,7 @@ fn expandFuncMacro(
                     break :blk false;
                 } else try pp.handleBuiltinMacro(raw.id, arg, loc);
                 const start = pp.comp.generated_buf.items.len;
-                try pp.comp.generated_buf.writer().print("{}\n", .{@boolToInt(result)});
+                try pp.comp.generated_buf.writer().print("{}\n", .{@intFromBool(result)});
                 try buf.append(try pp.makeGeneratedToken(start, .pp_num, tokFromRaw(raw)));
             },
             .macro_param_pragma_operator => {

--- a/src/StringInterner.zig
+++ b/src/StringInterner.zig
@@ -24,7 +24,7 @@ pub const TypeMapper = struct {
     pub fn lookup(self: TypeMapper, string_id: StringInterner.StringId) []const u8 {
         if (string_id == .empty) return "";
         switch (self.data) {
-            .fast => |arr| return arr[@enumToInt(string_id)],
+            .fast => |arr| return arr[@intFromEnum(string_id)],
             .slow => |map| {
                 var it = map.iterator();
                 while (it.next()) |entry| {
@@ -44,7 +44,7 @@ pub const TypeMapper = struct {
 };
 
 string_table: StringToIdMap = .{},
-next_id: StringId = @intToEnum(StringId, @enumToInt(StringId.empty) + 1),
+next_id: StringId = @enumFromInt(StringId, @intFromEnum(StringId.empty) + 1),
 
 pub fn deinit(self: *StringInterner, allocator: mem.Allocator) void {
     self.string_table.deinit(allocator);
@@ -56,7 +56,7 @@ pub fn intern(self: *StringInterner, allocator: mem.Allocator, str: []const u8) 
     const gop = try self.string_table.getOrPut(allocator, str);
     if (gop.found_existing) return gop.value_ptr.*;
 
-    defer self.next_id = @intToEnum(StringId, @enumToInt(self.next_id) + 1);
+    defer self.next_id = @enumFromInt(StringId, @intFromEnum(self.next_id) + 1);
     gop.value_ptr.* = self.next_id;
     return self.next_id;
 }
@@ -68,11 +68,11 @@ pub fn getSlowTypeMapper(self: *const StringInterner) TypeMapper {
 
 /// Caller must call `deinit` on the returned TypeMapper
 pub fn getFastTypeMapper(self: *const StringInterner, allocator: mem.Allocator) !TypeMapper {
-    var strings = try allocator.alloc([]const u8, @enumToInt(self.next_id));
+    var strings = try allocator.alloc([]const u8, @intFromEnum(self.next_id));
     var it = self.string_table.iterator();
     strings[0] = "";
     while (it.next()) |entry| {
-        strings[@enumToInt(entry.value_ptr.*)] = entry.key_ptr.*;
+        strings[@intFromEnum(entry.value_ptr.*)] = entry.key_ptr.*;
     }
     return TypeMapper{ .data = .{ .fast = strings } };
 }

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -739,14 +739,14 @@ pub fn makeIntegerUnsigned(ty: Type) Type {
         // zig fmt: on
 
         .char, .complex_char => {
-            base.specifier = @intToEnum(Type.Specifier, @enumToInt(base.specifier) + 2);
+            base.specifier = @enumFromInt(Type.Specifier, @intFromEnum(base.specifier) + 2);
             return base;
         },
 
         // zig fmt: off
         .schar, .short, .int, .long, .long_long, .int128,
         .complex_schar, .complex_short, .complex_int, .complex_long, .complex_long_long, .complex_int128 => {
-            base.specifier = @intToEnum(Type.Specifier, @enumToInt(base.specifier) + 1);
+            base.specifier = @enumFromInt(Type.Specifier, @intFromEnum(base.specifier) + 1);
             return base;
         },
         // zig fmt: on
@@ -1254,13 +1254,13 @@ pub fn eql(a_param: Type, b_param: Type, comp: *const Compilation, check_qualifi
 /// Decays an array to a pointer
 pub fn decayArray(ty: *Type) void {
     // the decayed array type is the current specifier +1
-    ty.specifier = @intToEnum(Type.Specifier, @enumToInt(ty.specifier) + 1);
+    ty.specifier = @enumFromInt(Type.Specifier, @intFromEnum(ty.specifier) + 1);
 }
 
 pub fn originalTypeOfDecayedArray(ty: Type) Type {
     std.debug.assert(ty.isDecayed());
     var copy = ty;
-    copy.specifier = @intToEnum(Type.Specifier, @enumToInt(ty.specifier) - 1);
+    copy.specifier = @enumFromInt(Type.Specifier, @intFromEnum(ty.specifier) - 1);
     return copy;
 }
 
@@ -1305,11 +1305,11 @@ pub fn makeReal(ty: Type) Type {
     var base = ty.canonicalize(.standard);
     switch (base.specifier) {
         .complex_float, .complex_double, .complex_long_double, .complex_float80, .complex_float128 => {
-            base.specifier = @intToEnum(Type.Specifier, @enumToInt(base.specifier) - 5);
+            base.specifier = @enumFromInt(Type.Specifier, @intFromEnum(base.specifier) - 5);
             return base;
         },
         .complex_char, .complex_schar, .complex_uchar, .complex_short, .complex_ushort, .complex_int, .complex_uint, .complex_long, .complex_ulong, .complex_long_long, .complex_ulong_long, .complex_int128, .complex_uint128 => {
-            base.specifier = @intToEnum(Type.Specifier, @enumToInt(base.specifier) - 13);
+            base.specifier = @enumFromInt(Type.Specifier, @intFromEnum(base.specifier) - 13);
             return base;
         },
         .complex_bit_int => {
@@ -1325,11 +1325,11 @@ pub fn makeComplex(ty: Type) Type {
     var base = ty.canonicalize(.standard);
     switch (base.specifier) {
         .float, .double, .long_double, .float80, .float128 => {
-            base.specifier = @intToEnum(Type.Specifier, @enumToInt(base.specifier) + 5);
+            base.specifier = @enumFromInt(Type.Specifier, @intFromEnum(base.specifier) + 5);
             return base;
         },
         .char, .schar, .uchar, .short, .ushort, .int, .uint, .long, .ulong, .long_long, .ulong_long, .int128, .uint128 => {
-            base.specifier = @intToEnum(Type.Specifier, @enumToInt(base.specifier) + 13);
+            base.specifier = @enumFromInt(Type.Specifier, @intFromEnum(base.specifier) + 13);
             return base;
         },
         .bit_int => {

--- a/src/Value.zig
+++ b/src/Value.zig
@@ -224,9 +224,9 @@ pub fn intToFloat(v: *Value, old_ty: Type, new_ty: Type, comp: *Compilation) voi
     if (!new_ty.isReal() or new_ty.sizeof(comp).? > 8) {
         v.tag = .unavailable;
     } else if (old_ty.isUnsignedInt(comp)) {
-        v.* = float(@intToFloat(f64, v.data.int));
+        v.* = float(@floatFromInt(f64, v.data.int));
     } else {
-        v.* = float(@intToFloat(f64, @bitCast(i64, v.data.int)));
+        v.* = float(@floatFromInt(f64, @bitCast(i64, v.data.int)));
     }
 }
 
@@ -265,7 +265,7 @@ pub fn floatCast(v: *Value, old_ty: Type, new_ty: Type, comp: *Compilation) void
 pub fn toBool(v: *Value) void {
     if (v.tag == .unavailable) return;
     const res = v.getBool();
-    v.* = int(@boolToInt(res));
+    v.* = int(@intFromBool(res));
 }
 
 pub fn isZero(v: Value) bool {

--- a/src/codegen/x86_64.zig
+++ b/src/codegen/x86_64.zig
@@ -32,7 +32,7 @@ pub fn genFn(c: *Codegen, decl: NodeIndex, data: *std.ArrayList(u8)) Codegen.Err
         0x55, // push rbp
         0x48, 0x89, 0xe5, // mov rbp,rsp
     });
-    _ = try func.genNode(c.node_data[@enumToInt(decl)].decl.node);
+    _ = try func.genNode(c.node_data[@intFromEnum(decl)].decl.node);
     // all functions are guaranteed to end in a return statement so no extra work required here
 }
 
@@ -126,8 +126,8 @@ fn genNode(func: *Fn, node: NodeIndex) Codegen.Error!Value {
             return Value{ .immediate = @bitCast(i64, some.data.int) };
     }
 
-    const data = func.c.node_data[@enumToInt(node)];
-    switch (func.c.node_tag[@enumToInt(node)]) {
+    const data = func.c.node_data[@intFromEnum(node)];
+    switch (func.c.node_tag[@intFromEnum(node)]) {
         .static_assert => return Value{ .none = {} },
         .compound_stmt_two => {
             if (data.bin.lhs != .none) _ = try func.genNode(data.bin.lhs);
@@ -183,7 +183,7 @@ fn genNode(func: *Fn, node: NodeIndex) Codegen.Error!Value {
             const symbol_name = try func.c.obj.declareSymbol(.strings, null, .Internal, .variable, start, str_bytes.len);
             return Value{ .symbol = symbol_name };
         },
-        else => return func.c.comp.diag.fatalNoSrc("TODO x86_64 genNode {}\n", .{func.c.node_tag[@enumToInt(node)]}),
+        else => return func.c.comp.diag.fatalNoSrc("TODO x86_64 genNode {}\n", .{func.c.node_tag[@intFromEnum(node)]}),
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -61,8 +61,8 @@ pub fn main() u8 {
             return 1;
         },
     };
-    if (fast_exit) std.process.exit(@boolToInt(comp.diag.errors != 0));
-    return @boolToInt(comp.diag.errors != 0);
+    if (fast_exit) std.process.exit(@intFromBool(comp.diag.errors != 0));
+    return @intFromBool(comp.diag.errors != 0);
 }
 
 test {

--- a/src/object/Elf.zig
+++ b/src/object/Elf.zig
@@ -183,7 +183,7 @@ pub fn finish(elf: *Elf, file: std.fs.File) !void {
             relocations_len += sect.*.relocations.items.len * @sizeOf(std.elf.Elf64_Rela);
             sect.*.index = num_sections;
             num_sections += 1;
-            num_sections += @boolToInt(sect.*.relocations.items.len != 0);
+            num_sections += @intFromBool(sect.*.relocations.items.len != 0);
         }
     }
     const symtab_len = (elf.local_symbols.count() + elf.global_symbols.count() + 1) * @sizeOf(std.elf.Elf64_Sym);

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -284,7 +284,7 @@ pub fn main() !void {
 
         if (expected_types) |types| {
             const test_fn = for (tree.root_decls) |decl| {
-                if (tree.nodes.items(.tag)[@enumToInt(decl)] == .fn_def) break tree.nodes.items(.data)[@enumToInt(decl)];
+                if (tree.nodes.items(.tag)[@intFromEnum(decl)] == .fn_def) break tree.nodes.items(.data)[@intFromEnum(decl)];
             } else {
                 fail_count += 1;
                 progress.log("EXPECTED_TYPES requires a function to be defined\n", .{});
@@ -537,9 +537,9 @@ const StmtTypeDumper = struct {
 
     fn dumpNode(self: *StmtTypeDumper, tree: *const aro.Tree, mapper: aro.TypeMapper, node: NodeIndex, m: *MsgWriter) AllocatorError!void {
         if (node == .none) return;
-        const tag = tree.nodes.items(.tag)[@enumToInt(node)];
+        const tag = tree.nodes.items(.tag)[@intFromEnum(node)];
         if (tag == .implicit_return) return;
-        const ty = tree.nodes.items(.ty)[@enumToInt(node)];
+        const ty = tree.nodes.items(.ty)[@intFromEnum(node)];
         ty.dump(mapper, tree.comp.langopts, m.buf.writer()) catch {};
         const owned = try m.buf.toOwnedSlice();
         errdefer m.buf.allocator.free(owned);
@@ -550,7 +550,7 @@ const StmtTypeDumper = struct {
         var m = MsgWriter.init(allocator);
         defer m.deinit();
 
-        const idx = @enumToInt(decl_idx);
+        const idx = @intFromEnum(decl_idx);
 
         const tag = tree.nodes.items(.tag)[idx];
         const data = tree.nodes.items(.data)[idx];


### PR DESCRIPTION
e.g. `@intToEnum` -> `@enumToInt`