### PR TITLE
Improve pointer coercion

### DIFF
--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -12,6 +12,8 @@ const is_windows = @import("builtin").os.tag == .windows;
 
 const Diagnostics = @This();
 
+const PointerSignMessage = " converts between pointers to integer types with different sign";
+
 pub const Message = struct {
     tag: Tag,
     kind: Kind = undefined,
@@ -162,6 +164,7 @@ pub const Options = packed struct {
     @"string-conversion": Kind = .default,
     @"gnu-auto-type": Kind = .default,
     @"gnu-union-cast": Kind = .default,
+    @"pointer-sign": Kind = .default,
 };
 
 const messages = struct {
@@ -979,6 +982,12 @@ const messages = struct {
         const extra = .str;
         const kind = .@"error";
     };
+    pub const incompatible_return_sign = struct {
+        const msg = "returning {s}" ++ PointerSignMessage;
+        const extra = .str;
+        const kind = .warning;
+        const opt = "pointer-sign";
+    };
     pub const implicit_int_to_ptr = struct {
         const msg = "implicit integer to pointer conversion from {s}";
         const extra = .str;
@@ -1009,6 +1018,12 @@ const messages = struct {
         const extra = .str;
         const kind = .warning;
         const opt = "incompatible-pointer-types";
+    };
+    pub const incompatible_ptr_arg_sign = struct {
+        const msg = "passing {s}" ++ PointerSignMessage;
+        const extra = .str;
+        const kind = .warning;
+        const opt = "pointer-sign";
     };
     pub const parameter_here = struct {
         const msg = "passing argument to parameter here";
@@ -1124,10 +1139,22 @@ const messages = struct {
         const opt = "incompatible-pointer-types";
         const kind = .warning;
     };
+    pub const incompatible_ptr_init_sign = struct {
+        const msg = "incompatible pointer types initializing {s}" ++ PointerSignMessage;
+        const extra = .str;
+        const opt = "pointer-sign";
+        const kind = .warning;
+    };
     pub const incompatible_ptr_assign = struct {
         const msg = "incompatible pointer types assigning to {s}";
         const extra = .str;
         const opt = "incompatible-pointer-types";
+        const kind = .warning;
+    };
+    pub const incompatible_ptr_assign_sign = struct {
+        const msg = "incompatible pointer types assigning to {s} " ++ PointerSignMessage;
+        const extra = .str;
+        const opt = "pointer-sign";
         const kind = .warning;
     };
     pub const vla_init = struct {

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -1004,6 +1004,12 @@ const messages = struct {
         const extra = .str;
         const kind = .@"error";
     };
+    pub const incompatible_ptr_arg = struct {
+        const msg = "passing {s}";
+        const extra = .str;
+        const kind = .warning;
+        const opt = "incompatible-pointer-types";
+    };
     pub const parameter_here = struct {
         const msg = "passing argument to parameter here";
         const kind = .note;

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -4949,6 +4949,7 @@ const Result = struct {
         }
     }
 
+    /// Converts a bool or integer to a pointer
     fn ptrCast(res: *Result, p: *Parser, ptr_ty: Type) Error!void {
         if (res.ty.is(.bool)) {
             res.ty = ptr_ty;
@@ -4958,6 +4959,12 @@ const Result = struct {
             res.ty = ptr_ty;
             try res.implicitCast(p, .int_to_pointer);
         }
+    }
+
+    /// Convert pointer to one with a different child type
+    fn ptrChildTypeCast(res: *Result, p: *Parser, ptr_ty: Type) Error!void {
+        res.ty = ptr_ty;
+        return res.implicitCast(p, .bitcast);
     }
 
     fn toVoid(res: *Result, p: *Parser) Error!void {
@@ -5416,11 +5423,11 @@ const Result = struct {
                     .assign => .incompatible_ptr_assign,
                     .init => .incompatible_ptr_init,
                     .ret => .incompatible_return,
-                    .arg => .incompatible_arg,
+                    .arg => .incompatible_ptr_arg,
                     .test_coerce => return error.CoercionFailed,
                 }, tok, try ctx.typePairStr(p, dest_ty, res.ty));
                 try ctx.note(p);
-                try res.ptrCast(p, unqual_ty);
+                try res.ptrChildTypeCast(p, unqual_ty);
                 return;
             }
         } else if (unqual_ty.isRecord()) {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -5389,13 +5389,15 @@ const Result = struct {
             if (res.ty.is(.nullptr_t) or res.val.isZero()) {
                 try res.nullCast(p, dest_ty);
                 return;
-            } else if (res.ty.isInt()) {
+            } else if (res.ty.isInt() and res.ty.isReal()) {
                 if (ctx == .test_coerce) return error.CoercionFailed;
                 try p.errStr(.implicit_int_to_ptr, tok, try p.typePairStrExtra(res.ty, " to ", dest_ty));
                 try ctx.note(p);
                 try res.ptrCast(p, unqual_ty);
                 return;
-            } else if (res.ty.isVoidStar() or unqual_ty.isVoidStar() or unqual_ty.eql(res.ty, p.comp, true)) {
+            } else if (res.ty.isVoidStar() or unqual_ty.eql(res.ty, p.comp, true)) {
+                return; // ok
+            } else if (unqual_ty.isVoidStar() and res.ty.isPtr() or (res.ty.isInt() and res.ty.isReal())) {
                 return; // ok
             } else if (unqual_ty.eql(res.ty, p.comp, false)) {
                 if (!unqual_ty.elemType().qual.hasQuals(res.ty.elemType().qual)) {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -5419,11 +5419,12 @@ const Result = struct {
                 try res.ptrCast(p, unqual_ty);
                 return;
             } else if (res.ty.isPtr()) {
+                const different_sign_only = unqual_ty.elemType().sameRankDifferentSign(res.ty.elemType(), p.comp);
                 try p.errStr(switch (ctx) {
-                    .assign => .incompatible_ptr_assign,
-                    .init => .incompatible_ptr_init,
-                    .ret => .incompatible_return,
-                    .arg => .incompatible_ptr_arg,
+                    .assign => ([2]Diagnostics.Tag{ .incompatible_ptr_assign, .incompatible_ptr_assign_sign })[@intFromBool(different_sign_only)],
+                    .init => ([2]Diagnostics.Tag{ .incompatible_ptr_init, .incompatible_ptr_init_sign })[@intFromBool(different_sign_only)],
+                    .ret => ([2]Diagnostics.Tag{ .incompatible_return, .incompatible_return_sign })[@intFromBool(different_sign_only)],
+                    .arg => ([2]Diagnostics.Tag{ .incompatible_ptr_arg, .incompatible_ptr_arg_sign })[@intFromBool(different_sign_only)],
                     .test_coerce => return error.CoercionFailed,
                 }, tok, try ctx.typePairStr(p, dest_ty, res.ty));
                 try ctx.note(p);

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -1308,6 +1308,13 @@ pub fn integerRank(ty: Type, comp: *const Compilation) usize {
     });
 }
 
+/// Returns true if `a` and `b` are integer types that differ only in sign
+pub fn sameRankDifferentSign(a: Type, b: Type, comp: *const Compilation) bool {
+    if (!a.isInt() or !b.isInt()) return false;
+    if (a.integerRank(comp) != b.integerRank(comp)) return false;
+    return a.isUnsignedInt(comp) != b.isUnsignedInt(comp);
+}
+
 pub fn makeReal(ty: Type) Type {
     // TODO discards attributed/typeof
     var base = ty.canonicalize(.standard);

--- a/test/cases/assignment.c
+++ b/test/cases/assignment.c
@@ -80,6 +80,12 @@ int qux(void) {
     return a;
 }
 
+void different_sign(void) {
+    int x = 0;
+    unsigned int *y;
+    y = &x;
+}
+
 #define EXPECTED_ERRORS "assignment.c:2:7: error: expression is not assignable" \
     "assignment.c:4:7: error: expression is not assignable" \
     "assignment.c:6:7: warning: implicit conversion from 'float' to '_Bool' changes value from 5.5 to true [-Wfloat-conversion]" \
@@ -102,3 +108,5 @@ int qux(void) {
     "assignment.c:61:9: error: expression is not assignable" \
     "assignment.c:72:12: error: variable has incomplete type 'enum E'" \
     "assignment.c:79:7: error: expression is not assignable" \
+    "assignment.c:86:7: warning: incompatible pointer types assigning to 'unsigned int *' from incompatible type 'int *'  converts between pointers to integer types with different sign [-Wpointer-sign]" \
+

--- a/test/cases/call.c
+++ b/test/cases/call.c
@@ -45,6 +45,8 @@ void call_void_star(void) {
     void_star_param(s);
     void_star_param(&s);
     void_star_param((_Complex int)42);
+    long x;
+    ip(&x);
 }
 
 
@@ -68,4 +70,6 @@ void call_void_star(void) {
     "call.c:37:28: note: passing argument to parameter here" \
     "call.c:47:21: error: passing '_Complex int' to parameter of incompatible type 'void *'" \
     "call.c:37:28: note: passing argument to parameter here" \
+    "call.c:49:8: warning: passing 'long *' to parameter of incompatible type 'int *' [-Wincompatible-pointer-types]" \
+    "call.c:8:20: note: passing argument to parameter here" \
 

--- a/test/cases/call.c
+++ b/test/cases/call.c
@@ -34,6 +34,20 @@ void bar(enum E e) {
     baz(e);
 }
 
+void void_star_param(void *p) {}
+
+void call_void_star(void) {
+    void_star_param(0);
+    void_star_param(4.0);
+    struct S {
+        int x;
+    } s;
+    void_star_param(s);
+    void_star_param(&s);
+    void_star_param((_Complex int)42);
+}
+
+
 #define EXPECTED_ERRORS "call.c:16:7: error: passing 'void' to parameter of incompatible type '_Bool'" \
     "call.c:5:21: note: passing argument to parameter here" \
     "call.c:19:7: warning: implicit pointer to integer conversion from 'int *' to 'int' [-Wint-conversion]" \
@@ -48,3 +62,10 @@ void bar(enum E e) {
     "call.c:9:25: note: passing argument to parameter here" \
     "call.c:33:17: error: parameter has incomplete type 'enum E'" \
     "call.c:34:5: warning: implicit declaration of function 'baz' is invalid in C99 [-Wimplicit-function-declaration]" \
+    "call.c:41:21: error: passing 'double' to parameter of incompatible type 'void *'" \
+    "call.c:37:28: note: passing argument to parameter here" \
+    "call.c:45:21: error: passing 'struct S' to parameter of incompatible type 'void *'" \
+    "call.c:37:28: note: passing argument to parameter here" \
+    "call.c:47:21: error: passing '_Complex int' to parameter of incompatible type 'void *'" \
+    "call.c:37:28: note: passing argument to parameter here" \
+

--- a/test/cases/call.c
+++ b/test/cases/call.c
@@ -49,6 +49,12 @@ void call_void_star(void) {
     ip(&x);
 }
 
+void signed_int(int *p) {}
+
+void call_with_unsigned(void) {
+    unsigned int x = 0;
+    signed_int(&x);
+}
 
 #define EXPECTED_ERRORS "call.c:16:7: error: passing 'void' to parameter of incompatible type '_Bool'" \
     "call.c:5:21: note: passing argument to parameter here" \
@@ -72,4 +78,6 @@ void call_void_star(void) {
     "call.c:37:28: note: passing argument to parameter here" \
     "call.c:49:8: warning: passing 'long *' to parameter of incompatible type 'int *' [-Wincompatible-pointer-types]" \
     "call.c:8:20: note: passing argument to parameter here" \
+    "call.c:56:16: warning: passing 'unsigned int *' to parameter of incompatible type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]" \
+    "call.c:52:22: note: passing argument to parameter here" \
 

--- a/test/cases/initializers.c
+++ b/test/cases/initializers.c
@@ -124,6 +124,9 @@ void quux(void) {
     struct Bar {
         struct Foo a;
     } b = {a};
+
+    void *vp1 = 1.0;
+    void *vp2 = a;
 }
 
 #define TESTS_SKIPPED 3
@@ -174,3 +177,6 @@ void quux(void) {
     "initializers.c:115:13: note: previous initialization" \
     "initializers.c:115:12: warning: excess elements in struct initializer [-Wexcess-initializers]" \
     "initializers.c:117:22: error: array initializer must be an initializer list or wide string literal" \
+    "initializers.c:128:17: error: initializing 'void *' from incompatible type 'double'" \
+    "initializers.c:129:17: error: initializing 'void *' from incompatible type 'struct Foo'" \
+

--- a/test/cases/initializers.c
+++ b/test/cases/initializers.c
@@ -127,6 +127,8 @@ void quux(void) {
 
     void *vp1 = 1.0;
     void *vp2 = a;
+    int x;
+    long *y = &x;
 }
 
 #define TESTS_SKIPPED 3
@@ -179,4 +181,5 @@ void quux(void) {
     "initializers.c:117:22: error: array initializer must be an initializer list or wide string literal" \
     "initializers.c:128:17: error: initializing 'void *' from incompatible type 'double'" \
     "initializers.c:129:17: error: initializing 'void *' from incompatible type 'struct Foo'" \
+    "initializers.c:131:15: warning: incompatible pointer types initializing 'long *' from incompatible type 'int *' [-Wincompatible-pointer-types]" \
 

--- a/test/cases/initializers.c
+++ b/test/cases/initializers.c
@@ -129,6 +129,7 @@ void quux(void) {
     void *vp2 = a;
     int x;
     long *y = &x;
+    unsigned int *z = &x;
 }
 
 #define TESTS_SKIPPED 3
@@ -182,4 +183,5 @@ void quux(void) {
     "initializers.c:128:17: error: initializing 'void *' from incompatible type 'double'" \
     "initializers.c:129:17: error: initializing 'void *' from incompatible type 'struct Foo'" \
     "initializers.c:131:15: warning: incompatible pointer types initializing 'long *' from incompatible type 'int *' [-Wincompatible-pointer-types]" \
+    "initializers.c:132:23: warning: incompatible pointer types initializing 'unsigned int *' from incompatible type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]" \
 

--- a/test/cases/return.c
+++ b/test/cases/return.c
@@ -96,6 +96,15 @@ void *void_star_return(void) {
     return 4.2;
 }
 
+int *return_signed(unsigned int *x) {
+    return x;
+}
+
+void call_return_signed(void) {
+    unsigned int x = 0;
+    int *y = return_signed(&x);
+}
+
 #define EXPECTED_ERRORS "return.c:2:5: error: non-void function 'b' should return a value [-Wreturn-type]" \
     "return.c:3:5: warning: unreachable code [-Wunreachable-code]" \
     "return.c:6:12: error: returning 'void' from a function with incompatible result type '_Bool'" \
@@ -113,4 +122,5 @@ void *void_star_return(void) {
     "return.c:38:17: error: function cannot return a function" \
     "return.c:74:5: warning: unreachable code [-Wunreachable-code]" \
     "return.c:96:12: error: returning 'double' from a function with incompatible result type 'void *'" \
+    "warning: returning 'unsigned int *' from a function with incompatible result type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]" \
 

--- a/test/cases/return.c
+++ b/test/cases/return.c
@@ -92,6 +92,10 @@ int else_noreturn(int arg) {
     return 1; // reachable; no warning
 }
 
+void *void_star_return(void) {
+    return 4.2;
+}
+
 #define EXPECTED_ERRORS "return.c:2:5: error: non-void function 'b' should return a value [-Wreturn-type]" \
     "return.c:3:5: warning: unreachable code [-Wunreachable-code]" \
     "return.c:6:12: error: returning 'void' from a function with incompatible result type '_Bool'" \
@@ -108,3 +112,5 @@ int else_noreturn(int arg) {
     "return.c:35:12: error: void function 'baz' should not return a value [-Wreturn-type]" \
     "return.c:38:17: error: function cannot return a function" \
     "return.c:74:5: warning: unreachable code [-Wunreachable-code]" \
+    "return.c:96:12: error: returning 'double' from a function with incompatible result type 'void *'" \
+


### PR DESCRIPTION
Note: With these changes, `ReleaseFast` and `ReleaseSmall` fail to build on Linux, see https://github.com/Vexu/arocc/issues/490

Fixes non-ints/pointers coercing to `void *`

Allows pointers to different child types to coerce to each other with a warning instead of error

Adds a special warning for coercing between pointers where only the signedness of the child type differs