### PR TITLE
Assembly statement parsing 

### DIFF
--- a/src/Codegen_legacy.zig
+++ b/src/Codegen_legacy.zig
@@ -78,6 +78,9 @@ pub fn generateTree(comp: *Compilation, tree: Tree) Compilation.Error!*Object {
                 error.CodegenFailed => continue,
             },
 
+            // TODO
+            .file_scope_asm => {},
+
             else => unreachable,
         }
     }

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -166,6 +166,7 @@ pub const Options = packed struct {
     @"gnu-union-cast": Kind = .default,
     @"pointer-sign": Kind = .default,
     @"fuse-ld-path": Kind = .default,
+    @"language-extension-token": Kind = .default,
 };
 
 const messages = struct {
@@ -2379,6 +2380,12 @@ const messages = struct {
     pub const gnu_asm_disabled = struct {
         const msg = "GNU-style inline assembly is disabled";
         const kind = .@"error";
+    };
+    pub const extension_token_used = struct {
+        const msg = "extension used";
+        const kind = .off;
+        const pedantic = true;
+        const opt = "language-extension-token";
     };
 };
 

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2376,6 +2376,10 @@ const messages = struct {
         const msg = "--rtlib=libgcc requires --unwindlib=libgcc";
         const kind = .@"error";
     };
+    pub const gnu_asm_disabled = struct {
+        const msg = "GNU-style inline assembly is disabled";
+        const kind = .@"error";
+    };
 };
 
 list: std.ArrayListUnmanaged(Message) = .{},

--- a/src/Driver.zig
+++ b/src/Driver.zig
@@ -91,6 +91,8 @@ pub const usage =
     \\  -fno-declspec           Disable support for __declspec attributes
     \\  -ffp-eval-method=[source|double|extended]
     \\                          Evaluation method to use for floating-point arithmetic
+    \\  -fgnu-inline-asm        Enable GNU style inline asm (default: enabled)
+    \\  -fno-gnu-inline-asm     Disable GNU style inline asm
     \\  -fms-extensions         Enable support for Microsoft extensions
     \\  -fno-ms-extensions      Disable support for Microsoft extensions
     \\  -fdollars-in-identifiers        
@@ -225,6 +227,10 @@ pub fn parseArgs(
                 d.comp.langopts.dollars_in_identifiers = false;
             } else if (mem.eql(u8, arg, "-fdigraphs")) {
                 d.comp.langopts.digraphs = true;
+            } else if (mem.eql(u8, arg, "-fgnu-inline-asm")) {
+                d.comp.langopts.gnu_asm = true;
+            } else if (mem.eql(u8, arg, "-fno-gnu-inline-asm")) {
+                d.comp.langopts.gnu_asm = false;
             } else if (mem.eql(u8, arg, "-fno-digraphs")) {
                 d.comp.langopts.digraphs = false;
             } else if (option(arg, "-fmacro-backtrace-limit=")) |limit_str| {

--- a/src/LangOpts.zig
+++ b/src/LangOpts.zig
@@ -107,6 +107,9 @@ char_signedness_override: ?std.builtin.Signedness = null,
 /// If set, override the default availability of char8_t (by default, enabled in C2X and later; disabled otherwise)
 has_char8_t_override: ?bool = null,
 
+/// Whether to allow GNU-style inline assembly
+gnu_asm: bool = true,
+
 pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!void {
     self.standard = Standard.NameMap.get(name) orelse return error.InvalidStandard;
 }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -3678,6 +3678,13 @@ fn assembly(p: *Parser, kind: enum { global, decl_label, stmt }) Error!?NodeInde
         },
         .global => {
             const asm_str = try p.asmStr();
+            if (!p.comp.langopts.gnu_asm) {
+                const str = asm_str.val.data.bytes;
+                if (str.len > 1) {
+                    // Empty string (just a NUL byte) is ok because it does not emit any assembly
+                    try p.errTok(.gnu_asm_disabled, l_paren);
+                }
+            }
             result_node = try p.addNode(.{
                 .tag = .file_scope_asm,
                 .ty = .{ .specifier = .void },

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -3687,13 +3687,14 @@ fn parseGNUAsmStmt(p: *Parser, asm_str_node: NodeIndex, quals: Tree.GNUAssemblyQ
     var stack_fallback = std.heap.stackFallback(bytes_needed, p.comp.gpa);
     const allocator = stack_fallback.get();
 
-    var names = std.ArrayList(?TokenIndex).initCapacity(allocator, expected_items) catch unreachable;
+    // TODO: Consider using a TokenIndex of 0 instead of null if we need to store the names in the tree
+    var names = std.ArrayList(?TokenIndex).initCapacity(allocator, expected_items) catch unreachable; // stack allocation already succeeded
     defer names.deinit();
-    var constraints = NodeList.initCapacity(allocator, expected_items) catch unreachable;
+    var constraints = NodeList.initCapacity(allocator, expected_items) catch unreachable; // stack allocation already succeeded
     defer constraints.deinit();
-    var exprs = NodeList.initCapacity(allocator, expected_items) catch unreachable;
+    var exprs = NodeList.initCapacity(allocator, expected_items) catch unreachable; //stack allocation already succeeded
     defer exprs.deinit();
-    var clobbers = NodeList.initCapacity(allocator, expected_items) catch unreachable;
+    var clobbers = NodeList.initCapacity(allocator, expected_items) catch unreachable; //stack allocation already succeeded
     defer clobbers.deinit();
 
     // Outputs

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -3790,7 +3790,11 @@ fn parseGNUAsmStmt(p: *Parser, asm_str_node: NodeIndex, quals: Tree.GNUAssemblyQ
 fn assembly(p: *Parser, kind: enum { global, decl_label, stmt }) Error!?NodeIndex {
     const asm_tok = p.tok_i;
     switch (p.tok_ids[p.tok_i]) {
-        .keyword_asm, .keyword_asm1, .keyword_asm2 => p.tok_i += 1,
+        .keyword_asm => {
+            try p.err(.extension_token_used);
+            p.tok_i += 1;
+        },
+        .keyword_asm1, .keyword_asm2 => p.tok_i += 1,
         else => return null,
     }
 

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -759,6 +759,20 @@ pub const Token = struct {
                 else => false,
             };
         }
+
+        pub fn canOpenGCCAsmStmt(id: Id) bool {
+            return switch (id) {
+                .keyword_volatile, .keyword_volatile1, .keyword_volatile2, .keyword_inline, .keyword_inline1, .keyword_inline2, .keyword_goto, .l_paren => true,
+                else => false,
+            };
+        }
+
+        pub fn isStringLiteral(id: Id) bool {
+            return switch (id) {
+                .string_literal, .string_literal_utf_16, .string_literal_utf_8, .string_literal_utf_32, .string_literal_wide => true,
+                else => false,
+            };
+        }
     };
 
     /// double underscore and underscore + capital letter identifiers

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -273,6 +273,9 @@ pub const Tag = enum(u8) {
     threadlocal_extern_var,
     threadlocal_static_var,
 
+    /// __asm__("...") at file scope
+    file_scope_asm,
+
     // typedef declaration
     typedef,
 
@@ -764,6 +767,10 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, mapper: StringInterner.Type
 
     switch (tag) {
         .invalid => unreachable,
+        .file_scope_asm => {
+            try w.writeByteNTimes(' ', level + 1);
+            try tree.dumpNode(data.decl.node, level + delta, mapper, color, w);
+        },
         .static_assert => {
             try w.writeByteNTimes(' ', level + 1);
             try w.writeAll("condition:\n");

--- a/src/Tree.zig
+++ b/src/Tree.zig
@@ -104,6 +104,12 @@ pub fn deinit(tree: *Tree) void {
     tree.value_map.deinit();
 }
 
+pub const GNUAssemblyQualifiers = struct {
+    @"volatile": bool = false,
+    @"inline": bool = false,
+    goto: bool = false,
+};
+
 pub const Node = struct {
     tag: Tag,
     ty: Type = .{ .specifier = .void },
@@ -348,6 +354,8 @@ pub const Tag = enum(u8) {
     null_stmt,
     /// return first; first may be null
     return_stmt,
+    /// Assembly statement of the form __asm__("string literal")
+    gnu_asm_simple,
 
     // ====== Expr ======
 
@@ -770,6 +778,10 @@ fn dumpNode(tree: Tree, node: NodeIndex, level: u32, mapper: StringInterner.Type
         .file_scope_asm => {
             try w.writeByteNTimes(' ', level + 1);
             try tree.dumpNode(data.decl.node, level + delta, mapper, color, w);
+        },
+        .gnu_asm_simple => {
+            try w.writeByteNTimes(' ', level);
+            try tree.dumpNode(data.un, level, mapper, color, w);
         },
         .static_assert => {
             try w.writeByteNTimes(' ', level + 1);

--- a/test/cases/gnu inline assembly statements.c
+++ b/test/cases/gnu inline assembly statements.c
@@ -1,4 +1,4 @@
-//aro-args --target=x86-linux-gnu
+//aro-args --target=x86-linux-gnu -pedantic
 
 // Note: examples taken from here: https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html
 // Some examples do not use real instructions or register names, which may cause failures once we do
@@ -122,7 +122,12 @@ int missing_goto_label(int p1, int p2) {
     return 1;
 }
 
+void extension_token(unsigned Offset) {
+    asm volatile("some instructions" :: );
+}
+
 #define EXPECTED_ERRORS "gnu inline assembly statements.c:90:11: error: use of undeclared label 'carry_1'" \
     "gnu inline assembly statements.c:104:9: error: expected ')', found ':'" \
     "gnu inline assembly statements.c:118:10: error: expected ':', found ')'" \
+    "gnu inline assembly statements.c:126:5: warning: extension used [-Wlanguage-extension-token]" \
 

--- a/test/cases/gnu inline assembly statements.c
+++ b/test/cases/gnu inline assembly statements.c
@@ -1,0 +1,128 @@
+//aro-args --target=x86-linux-gnu
+
+// Note: examples taken from here: https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html
+// Some examples do not use real instructions or register names, which may cause failures once we do
+// validation of the assembly
+
+#include <stdbool.h>
+
+int add(void) {
+    int src = 1;
+    int dst;
+
+    __asm__("mov %1, %0\n\t"
+        "add $1, %0"
+        : "=r" (dst)
+        : "r" (src));
+    return dst;
+}
+
+void names(void) {
+    unsigned Mask = 1234;
+    unsigned Index;
+
+    __asm__ ("bsfl %[aMask], %[aIndex]"
+        : [aIndex] "=r" (Index)
+        : [aMask] "r" (Mask)
+        : "cc");
+}
+
+int with_goto(int p1, int p2) {
+    __asm__ goto(
+        "btl %1, %0\n\t"
+        "jc %l2"
+        : /* No outputs. */
+        : "r" (p1), "r" (p2)
+        : "cc"
+        : carry);
+
+    return 0;
+
+    carry:
+    return 1;
+}
+
+bool constraint_expr(int *Base, unsigned Offset) {
+    bool old;
+
+    __asm__ ("btsl %2,%1\n\t" // Turn on zero-based bit #Offset in Base.
+            "sbb %0,%0"      // Use the CF to calculate old.
+    : "=r" (old), "+rm" (*Base)
+    : "Ir" (Offset)
+    : "cc");
+
+    return old;
+}
+
+void foo(void) {
+    unsigned c = 1;
+    unsigned d;
+    unsigned *e = &c;
+
+    __asm__ ("mov %[e], %[d]"
+    : [d] "=rm" (d)
+    : [e] "rm" (*e));
+}
+
+void no_outputs(unsigned Offset) {
+    __asm__ ("some instructions" :: "r" (Offset / 8));
+}
+
+int frob(int x) {
+  int y;
+  __asm__ goto ("frob %%r5, %1; jc %l[error]; mov (%2), %%r5"
+            : /* No outputs. */
+            : "r"(x), "r"(&y)
+            : "r5", "memory"
+            : error);
+  return y;
+error:
+  return -1;
+}
+
+int bad_goto_label(int p1, int p2) {
+    __asm__ goto(
+        "btl %1, %0\n\t"
+        "jc %l2"
+        : /* No outputs. */
+        : "r" (p1), "r" (p2)
+        : "cc"
+        : carry_1);
+
+    return 0;
+    carry:
+    return 1;
+}
+
+int missing_goto_kw(int p1, int p2) {
+    __asm__(
+        "btl %1, %0\n\t"
+        "jc %l2"
+        : /* No outputs. */
+        : "r" (p1), "r" (p2)
+        : "cc"
+        : carry);
+
+    return 0;
+    carry:
+    return 1;
+}
+
+int missing_goto_label(int p1, int p2) {
+    __asm__ goto(
+        "btl %1, %0\n\t"
+        "jc %l2"
+        : /* No outputs. */
+        : "r" (p1), "r" (p2)
+        : "cc"
+         );
+
+    return 0;
+    carry:
+    return 1;
+}
+
+#define EXPECTED_ERRORS "gnu inline assembly statements.c:90:11: error: use of undeclared label 'carry_1'" \
+    "gnu inline assembly statements.c:104:9: error: expected ')', found ':'" \
+    "gnu inline assembly statements.c:118:10: error: expected ':', found ')'" \
+

--- a/test/cases/no inline asm.c
+++ b/test/cases/no inline asm.c
@@ -1,0 +1,7 @@
+//aro-args -fno-gnu-inline-asm
+
+__asm__("foo");
+__asm__("");
+
+#define EXPECTED_ERRORS "no inline asm.c:3:8: error: GNU-style inline assembly is disabled" \
+


### PR DESCRIPTION
Primary thing here is adding support for GNU inline assembly statements. Currently it just parses the statement, no attempt is made to validate it. There's also the question of how it should be added to the AST - any thought about how to structure that? There's a lot of data - the assembly template string, `volatile` flag, inputs, output, and label expressions, constraints, clobbers...