### PR TITLE
Driver: handle different debug/release error sets for processSource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           version: master
 
+      - name: Fmt
+        run: zig fmt . --check
+        if: matrix.os == 'ubuntu-latest'
+
       - name: Build
         run: zig build
 
@@ -32,9 +36,8 @@ jobs:
         run: zig build -Dtarget=arm-linux
         if: matrix.os == 'ubuntu-latest'
 
-      - name: Fmt
-        run: zig fmt . --check
-        if: matrix.os == 'ubuntu-latest'
+      - name: Build release
+        run: zig build -Doptimize=ReleaseSafe
 
       - name: Run Tests
         run: zig build test

--- a/src/Driver.zig
+++ b/src/Driver.zig
@@ -479,21 +479,21 @@ pub fn main(d: *Driver, tc: *Toolchain, args: []const []const u8) !void {
 
     if (fast_exit and d.inputs.items.len == 1) {
         d.processSource(tc, d.inputs.items[0], builtin, user_macros, fast_exit) catch |e| switch (e) {
-            error.OutOfMemory => return error.OutOfMemory,
             error.FatalError => {
                 d.comp.renderErrors();
                 d.exitWithCleanup(1);
             },
+            else => |er| return er,
         };
         unreachable;
     }
 
     for (d.inputs.items) |source| {
         d.processSource(tc, source, builtin, user_macros, fast_exit) catch |e| switch (e) {
-            error.OutOfMemory => return error.OutOfMemory,
             error.FatalError => {
                 d.comp.renderErrors();
             },
+            else => |er| return er,
         };
     }
     if (d.comp.diag.errors != 0) {


### PR DESCRIPTION
If fast_exit is enabled (non-debug build) then processSource can invoke the linker

Fixes #501