### PR TITLE
ci: use `fail-fast: false` for matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Setting `fail-fast` to false can allow the jobs for the other OSes to continue even when the CI fails for 1 OS: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures

Not sure if this is desired - feel free to close this if this isn't.