### PR TITLE
Improve character literal handling

### DIFF
--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -65,7 +65,7 @@ pub const Kind = enum {
     fn maxInt(kind: Kind, comp: *const Compilation) u32 {
         return @intCast(switch (kind) {
             .char, .utf_8 => std.math.maxInt(u8),
-            .wide => comp.types.wchar.sizeof(comp).?,
+            .wide => comp.types.wchar.maxInt(comp),
             .utf_16 => std.math.maxInt(u16),
             .utf_32 => std.math.maxInt(u32),
         });

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -141,7 +141,7 @@ pub const Parser = struct {
 
         self.i += 2;
         if (self.i >= self.literal.len or !std.ascii.isHex(self.literal[self.i])) {
-            self.err(.non_hex_ucn, .{ .ascii = @intCast(kind) });
+            self.err(.missing_hex_escape, .{ .ascii = @intCast(kind) });
             return null;
         }
         const expected_len: usize = if (kind == 'u') 4 else 8;
@@ -263,7 +263,7 @@ pub const Parser = struct {
         }
         if (count == 0) {
             std.debug.assert(base == .hex);
-            self.err(.missing_hex_escape, .{ .none = {} });
+            self.err(.missing_hex_escape, .{ .ascii = 'x' });
         }
         return val;
     }

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -1,0 +1,142 @@
+const std = @import("std");
+const CParser = @import("Parser.zig");
+const Diagnostics = @import("Diagnostics.zig");
+const mem = std.mem;
+
+pub const Item = union(enum) {
+    /// escaped char
+    codepoint: u21,
+    /// Char literal in the source text is not utf8 encoded
+    improperly_encoded: []const u8,
+    /// 1 or more unescaped bytes
+    utf8_text: std.unicode.Utf8View,
+
+    const replacement: Item = .{ .codepoint = 0xFFFD };
+};
+
+pub const Parser = struct {
+    literal: []const u8,
+    i: usize = 0,
+    /// We only want to issue a max of 1 error per char literal
+    errored: bool = false,
+
+    pub fn init(literal: []const u8) Parser {
+        const start = mem.indexOfScalar(u8, literal, '\'').? + 1; // trim leading quote + specifier if any
+        return .{
+            .literal = literal[start .. literal.len - 1], // trim trailing quote
+            .i = 0,
+        };
+    }
+
+    pub fn next(self: *Parser, p: *CParser) !?Item {
+        if (self.i >= self.literal.len) return null;
+
+        const start = self.i;
+        if (self.literal[start] != '\\') {
+            self.i = mem.indexOfScalarPos(u8, self.literal, start + 1, '\\') orelse self.literal.len;
+            const unescaped_slice = self.literal[start..self.i];
+
+            const view = std.unicode.Utf8View.init(unescaped_slice) catch {
+                return .{ .improperly_encoded = self.literal[start..self.i] };
+            };
+            return .{ .utf8_text = view };
+        }
+        switch (self.literal[start + 1]) {
+            'u', 'U' => return try self.parseUnicodeEscape(p),
+            else => return try self.parseEscapedChar(p),
+        }
+    }
+
+    fn parseUnicodeEscape(self: *Parser, p: *CParser) !Item {
+        const start = self.i;
+
+        std.debug.assert(self.literal[self.i] == '\\');
+
+        const kind = self.literal[self.i + 1];
+        std.debug.assert(kind == 'u' or kind == 'U');
+
+        self.i += 2;
+        if (self.i >= self.literal.len or !std.ascii.isHex(self.literal[self.i])) {
+            self.errored = true;
+            try p.errExtra(.non_hex_ucn, p.tok_i, .{ .ascii = @intCast(kind) });
+            return Item.replacement;
+        }
+        const expected_len: usize = if (kind == 'u') 4 else 8;
+        var overflowed = false;
+        var count: usize = 0;
+        var val: u32 = 0;
+
+        for (self.literal[self.i..], 0..) |c, i| {
+            if (i == expected_len) break;
+
+            const char = std.fmt.charToDigit(c, 16) catch {
+                break;
+            };
+
+            val, const overflow = @shlWithOverflow(val, 4);
+            overflowed = overflowed or overflow != 0;
+            val |= char;
+            count += 1;
+        }
+        self.i += expected_len;
+
+        if (overflowed) {
+            self.errored = true;
+            try p.errExtra(.escape_sequence_overflow, p.tok_i, .{ .unsigned = start });
+            return Item.replacement;
+        }
+
+        if (count != expected_len) {
+            self.errored = true;
+            try p.err(.incomplete_universal_character);
+            return Item.replacement;
+        }
+
+        if (val > std.math.maxInt(u21) or !std.unicode.utf8ValidCodepoint(@intCast(val))) {
+            self.errored = true;
+            try p.errExtra(.invalid_universal_character, p.tok_i, .{ .unsigned = start });
+            return Item.replacement;
+        }
+
+        if (val < 0xA0 and (val != '$' and val != '@' and val != '`')) {
+            const is_error = !p.comp.langopts.standard.atLeast(.c2x);
+            if (val >= 0x20 and val <= 0x7F) {
+                const tag: Diagnostics.Tag = if (is_error) .ucn_basic_char_error else .ucn_basic_char_warning;
+                try p.errExtra(tag, p.tok_i, .{ .ascii = @intCast(val) });
+            } else {
+                const tag: Diagnostics.Tag = if (is_error) .ucn_control_char_error else .ucn_control_char_warning;
+                try p.err(tag);
+            }
+        }
+
+        try p.err(.c89_ucn_in_literal);
+
+        return .{ .codepoint = @intCast(val) };
+    }
+
+    fn parseEscapedChar(self: *Parser, p: *CParser) !Item {
+        self.i += 1;
+        defer self.i += 1;
+
+        switch (self.literal[self.i]) {
+            '\n' => unreachable, // removed by line splicing
+            '\r' => unreachable, // removed by line splicing
+            '\'', '\"', '\\', '?' => |c| return .{ .codepoint = c },
+            'n' => return .{ .codepoint = '\n' },
+            'r' => return .{ .codepoint = '\r' },
+            't' => return .{ .codepoint = '\t' },
+            'a' => return .{ .codepoint = 0x07 },
+            'b' => return .{ .codepoint = 0x08 },
+            'e' => {
+                try p.errExtra(.non_standard_escape_char, p.tok_i, .{ .unsigned = self.i });
+                return .{ .codepoint = 0x1B };
+            },
+            'f' => return .{ .codepoint = 0x0C },
+            'v' => return .{ .codepoint = 0x0B },
+            'x' => return .{ .codepoint = try p.parseNumberEscape(p.tok_i, 16, self.literal, &self.i) },
+            '0'...'7' => return .{ .codepoint = try p.parseNumberEscape(p.tok_i, 8, self.literal, &self.i) },
+            'u', 'U' => unreachable, // handled by parseUnicodeEscape
+            else => unreachable,
+        }
+    }
+};

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -29,10 +29,8 @@ pub const Parser = struct {
     codepoint_buf: [4]u8,
 
     pub fn init(literal: []const u8, standard: LangOpts.Standard) Parser {
-        const start = mem.indexOfScalar(u8, literal, '\'').? + 1; // trim leading quote + specifier if any
         return .{
-            .literal = literal[start .. literal.len - 1], // trim trailing quote
-            .i = 0,
+            .literal = literal,
             .standard = standard,
             .codepoint_buf = undefined,
         };

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -165,7 +165,7 @@ pub const Parser = struct {
         }
         self.i += expected_len;
 
-        if (overflowed or val > self.max_codepoint) {
+        if (overflowed) {
             self.err(.escape_sequence_overflow, .{ .unsigned = start });
             return Item.replacement;
         }
@@ -178,6 +178,10 @@ pub const Parser = struct {
         if (val > std.math.maxInt(u21) or !std.unicode.utf8ValidCodepoint(@intCast(val))) {
             self.err(.invalid_universal_character, .{ .unsigned = start });
             return Item.replacement;
+        }
+
+        if (val > self.max_codepoint) {
+            self.err(.char_too_large, .{ .none = {} });
         }
 
         if (val < 0xA0 and (val != '$' and val != '@' and val != '`')) {

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -219,9 +219,13 @@ pub const Parser = struct {
             't' => return .{ .value = '\t' },
             'a' => return .{ .value = 0x07 },
             'b' => return .{ .value = 0x08 },
-            'e' => {
+            'e', 'E' => {
                 self.warn(.non_standard_escape_char, .{ .unsigned = self.i });
                 return .{ .value = 0x1B };
+            },
+            '(', '{', '[', '%' => {
+                self.warn(.non_standard_escape_char, .{ .unsigned = self.i });
+                return .{ .value = c };
             },
             'f' => return .{ .value = 0x0C },
             'v' => return .{ .value = 0x0B },

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -73,7 +73,7 @@ pub const Kind = enum {
 
     pub fn charLiteralType(kind: Kind, comp: *const Compilation) Type {
         return switch (kind) {
-            .char => .{ .specifier = .int },
+            .char => Type.int,
             .wide => comp.types.wchar,
             .utf_8 => .{ .specifier = .uchar },
             .utf_16 => comp.types.uint_least16_t,

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -80,6 +80,19 @@ pub const Kind = enum {
             .utf_32 => comp.types.uint_least32_t,
         };
     }
+
+    /// Return the actual contents of the string literal with leading / trailing quotes and
+    /// specifiers removed
+    pub fn contentSlice(kind: Kind, delimited: []const u8) []const u8 {
+        const end = delimited.len - 1;  // remove trailing quote
+        return switch (kind) {
+            .char => delimited[1..end],
+            .wide => delimited[2..end],
+            .utf_8 => delimited[3..end],
+            .utf_16 => delimited[2..end],
+            .utf_32 => delimited[2..end],
+        };
+    }
 };
 
 pub const Parser = struct {

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -236,11 +236,11 @@ pub const Parser = struct {
             'a' => return .{ .value = 0x07 },
             'b' => return .{ .value = 0x08 },
             'e', 'E' => {
-                self.warn(.non_standard_escape_char, .{ .unsigned = self.i });
+                self.warn(.non_standard_escape_char, .{ .invalid_escape = .{ .char = c, .offset = @intCast(self.i) } });
                 return .{ .value = 0x1B };
             },
             '(', '{', '[', '%' => {
-                self.warn(.non_standard_escape_char, .{ .unsigned = self.i });
+                self.warn(.non_standard_escape_char, .{ .invalid_escape = .{ .char = c, .offset = @intCast(self.i) } });
                 return .{ .value = c };
             },
             'f' => return .{ .value = 0x0C },
@@ -249,7 +249,7 @@ pub const Parser = struct {
             '0'...'7' => return .{ .value = self.parseNumberEscape(.octal) },
             'u', 'U' => unreachable, // handled by parseUnicodeEscape
             else => {
-                self.warn(.unknown_escape_sequence, .{ .maybe_unprintable = c });
+                self.warn(.unknown_escape_sequence, .{ .invalid_escape = .{ .char = c, .offset = @intCast(self.i) } });
                 return .{ .value = c };
             },
         }

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -203,7 +203,6 @@ pub const Parser = struct {
 
     fn parseEscapedChar(self: *Parser) Item {
         self.i += 1;
-        defer self.i += 1;
 
         switch (self.literal[self.i]) {
             '\n' => unreachable, // removed by line splicing
@@ -220,44 +219,47 @@ pub const Parser = struct {
             },
             'f' => return .{ .value = 0x0C },
             'v' => return .{ .value = 0x0B },
-            'x' => return .{ .value = self.parseHexEscape() },
-            '0'...'7' => return .{ .value = self.parseOctalEscape() },
+            'x' => return .{ .value = self.parseNumberEscape(.hex) },
+            '0'...'7' => return .{ .value = self.parseNumberEscape(.octal) },
             'u', 'U' => unreachable, // handled by parseUnicodeEscape
             else => unreachable,
         }
     }
 
-    fn parseHexEscape(self: *Parser) u32 {
+    fn parseNumberEscape(self: *Parser, base: EscapeBase) u32 {
         var val: u32 = 0;
         var count: usize = 0;
         var overflowed = false;
         defer self.i += count;
-
-        for (self.literal[self.i + 1 ..]) |c| {
-            const char = std.fmt.charToDigit(c, 16) catch break;
-            val, const overflow = @shlWithOverflow(val, 4);
+        const slice = switch (base) {
+            .octal => self.literal[self.i..@min(self.literal.len, self.i + 3)], // max 3 chars
+            .hex => blk: {
+                self.i += 1;
+                break :blk self.literal[self.i..]; // skip over 'x'; could have an arbitrary number of chars
+            },
+        };
+        for (slice) |c| {
+            const char = std.fmt.charToDigit(c, @intFromEnum(base)) catch break;
+            val, const overflow = @shlWithOverflow(val, base.log2());
             if (overflow != 0) overflowed = true;
             val += char;
             count += 1;
         }
-        if (overflowed) {
-            std.debug.print("overflowed!\n", .{});
+        if (overflowed or val > self.max_int) {
+            self.err(.escape_sequence_overflow, .{ .unsigned = 0 });
         }
         return val;
     }
+};
 
-    fn parseOctalEscape(self: *Parser) u32 {
-        var val: u32 = 0;
-        var count: usize = 0;
-        defer self.i += count - 1;
+const EscapeBase = enum(u8) {
+    octal = 8,
+    hex = 16,
 
-        for (self.literal[self.i..], 0..) |c, i| {
-            if (i == 3) break;
-            const char = std.fmt.charToDigit(c, 8) catch break;
-            val <<= 3;
-            val += char;
-            count += 1;
-        }
-        return val;
+    fn log2(base: EscapeBase) u4 {
+        return switch (base) {
+            .octal => 3,
+            .hex => 4,
+        };
     }
 };

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -84,7 +84,7 @@ pub const Kind = enum {
     /// Return the actual contents of the string literal with leading / trailing quotes and
     /// specifiers removed
     pub fn contentSlice(kind: Kind, delimited: []const u8) []const u8 {
-        const end = delimited.len - 1;  // remove trailing quote
+        const end = delimited.len - 1; // remove trailing quote
         return switch (kind) {
             .char => delimited[1..end],
             .wide => delimited[2..end],

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -1,17 +1,24 @@
 const std = @import("std");
-const CParser = @import("Parser.zig");
 const Diagnostics = @import("Diagnostics.zig");
+const LangOpts = @import("LangOpts.zig");
 const mem = std.mem;
 
 pub const Item = union(enum) {
-    /// escaped char
+    /// unicode escape
     codepoint: u21,
+    /// hex/octal escape
+    value: u32,
     /// Char literal in the source text is not utf8 encoded
     improperly_encoded: []const u8,
     /// 1 or more unescaped bytes
     utf8_text: std.unicode.Utf8View,
 
-    const replacement: Item = .{ .codepoint = 0xFFFD };
+    const replacement: Item = .{ .value = 0xFFFD };
+};
+
+const CharDiagnostic = struct {
+    tag: Diagnostics.Tag,
+    extra: Diagnostics.Message.Extra,
 };
 
 pub const Parser = struct {
@@ -19,16 +26,25 @@ pub const Parser = struct {
     i: usize = 0,
     /// We only want to issue a max of 1 error per char literal
     errored: bool = false,
+    errors: std.BoundedArray(CharDiagnostic, 4) = .{},
+    standard: LangOpts.Standard,
 
-    pub fn init(literal: []const u8) Parser {
+    pub fn init(literal: []const u8, standard: LangOpts.Standard) Parser {
         const start = mem.indexOfScalar(u8, literal, '\'').? + 1; // trim leading quote + specifier if any
         return .{
             .literal = literal[start .. literal.len - 1], // trim trailing quote
             .i = 0,
+            .standard = standard,
         };
     }
 
-    pub fn next(self: *Parser, p: *CParser) !?Item {
+    fn err(self: *Parser, tag: Diagnostics.Tag, extra: Diagnostics.Message.Extra) void {
+        if (self.errored) return;
+        self.errored = true;
+        self.errors.append(.{ .tag = tag, .extra = extra }) catch {};
+    }
+
+    pub fn next(self: *Parser) ?Item {
         if (self.i >= self.literal.len) return null;
 
         const start = self.i;
@@ -42,12 +58,12 @@ pub const Parser = struct {
             return .{ .utf8_text = view };
         }
         switch (self.literal[start + 1]) {
-            'u', 'U' => return try self.parseUnicodeEscape(p),
-            else => return try self.parseEscapedChar(p),
+            'u', 'U' => return self.parseUnicodeEscape(),
+            else => return self.parseEscapedChar(),
         }
     }
 
-    fn parseUnicodeEscape(self: *Parser, p: *CParser) !Item {
+    fn parseUnicodeEscape(self: *Parser) Item {
         const start = self.i;
 
         std.debug.assert(self.literal[self.i] == '\\');
@@ -57,8 +73,7 @@ pub const Parser = struct {
 
         self.i += 2;
         if (self.i >= self.literal.len or !std.ascii.isHex(self.literal[self.i])) {
-            self.errored = true;
-            try p.errExtra(.non_hex_ucn, p.tok_i, .{ .ascii = @intCast(kind) });
+            self.err(.non_hex_ucn, .{ .ascii = @intCast(kind) });
             return Item.replacement;
         }
         const expected_len: usize = if (kind == 'u') 4 else 8;
@@ -81,62 +96,93 @@ pub const Parser = struct {
         self.i += expected_len;
 
         if (overflowed) {
-            self.errored = true;
-            try p.errExtra(.escape_sequence_overflow, p.tok_i, .{ .unsigned = start });
+            self.err(.escape_sequence_overflow, .{ .unsigned = start });
             return Item.replacement;
         }
 
         if (count != expected_len) {
-            self.errored = true;
-            try p.err(.incomplete_universal_character);
+            self.err(.incomplete_universal_character, .{ .none = {} });
             return Item.replacement;
         }
 
         if (val > std.math.maxInt(u21) or !std.unicode.utf8ValidCodepoint(@intCast(val))) {
-            self.errored = true;
-            try p.errExtra(.invalid_universal_character, p.tok_i, .{ .unsigned = start });
+            self.err(.invalid_universal_character, .{ .unsigned = start });
             return Item.replacement;
         }
 
         if (val < 0xA0 and (val != '$' and val != '@' and val != '`')) {
-            const is_error = !p.comp.langopts.standard.atLeast(.c2x);
+            const is_error = !self.standard.atLeast(.c2x);
             if (val >= 0x20 and val <= 0x7F) {
                 const tag: Diagnostics.Tag = if (is_error) .ucn_basic_char_error else .ucn_basic_char_warning;
-                try p.errExtra(tag, p.tok_i, .{ .ascii = @intCast(val) });
+                self.err(tag, .{ .ascii = @intCast(val) });
             } else {
                 const tag: Diagnostics.Tag = if (is_error) .ucn_control_char_error else .ucn_control_char_warning;
-                try p.err(tag);
+                self.err(tag, .{ .none = {} });
             }
         }
 
-        try p.err(.c89_ucn_in_literal);
+        self.err(.c89_ucn_in_literal, .{ .none = {} });
 
         return .{ .codepoint = @intCast(val) };
     }
 
-    fn parseEscapedChar(self: *Parser, p: *CParser) !Item {
+    fn parseEscapedChar(self: *Parser) Item {
         self.i += 1;
         defer self.i += 1;
 
         switch (self.literal[self.i]) {
             '\n' => unreachable, // removed by line splicing
             '\r' => unreachable, // removed by line splicing
-            '\'', '\"', '\\', '?' => |c| return .{ .codepoint = c },
-            'n' => return .{ .codepoint = '\n' },
-            'r' => return .{ .codepoint = '\r' },
-            't' => return .{ .codepoint = '\t' },
-            'a' => return .{ .codepoint = 0x07 },
-            'b' => return .{ .codepoint = 0x08 },
+            '\'', '\"', '\\', '?' => |c| return .{ .value = c },
+            'n' => return .{ .value = '\n' },
+            'r' => return .{ .value = '\r' },
+            't' => return .{ .value = '\t' },
+            'a' => return .{ .value = 0x07 },
+            'b' => return .{ .value = 0x08 },
             'e' => {
-                try p.errExtra(.non_standard_escape_char, p.tok_i, .{ .unsigned = self.i });
-                return .{ .codepoint = 0x1B };
+                self.err(.non_standard_escape_char, .{ .unsigned = self.i });
+                return .{ .value = 0x1B };
             },
-            'f' => return .{ .codepoint = 0x0C },
-            'v' => return .{ .codepoint = 0x0B },
-            'x' => return .{ .codepoint = try p.parseNumberEscape(p.tok_i, 16, self.literal, &self.i) },
-            '0'...'7' => return .{ .codepoint = try p.parseNumberEscape(p.tok_i, 8, self.literal, &self.i) },
+            'f' => return .{ .value = 0x0C },
+            'v' => return .{ .value = 0x0B },
+            'x' => return .{ .value = self.parseHexEscape() },
+            '0'...'7' => return .{ .value = self.parseOctalEscape() },
             'u', 'U' => unreachable, // handled by parseUnicodeEscape
             else => unreachable,
         }
+    }
+
+    fn parseHexEscape(self: *Parser) u32 {
+        var val: u32 = 0;
+        var count: usize = 0;
+        var overflowed = false;
+        defer self.i += count;
+
+        for (self.literal[self.i + 1 ..]) |c| {
+            const char = std.fmt.charToDigit(c, 16) catch break;
+            val, const overflow = @shlWithOverflow(val, 4);
+            if (overflow != 0) overflowed = true;
+            val += char;
+            count += 1;
+        }
+        if (overflowed) {
+            std.debug.print("overflowed!\n", .{});
+        }
+        return val;
+    }
+
+    fn parseOctalEscape(self: *Parser) u32 {
+        var val: u32 = 0;
+        var count: usize = 0;
+        defer self.i += count - 1;
+
+        for (self.literal[self.i..], 0..) |c, i| {
+            if (i == 3) break;
+            const char = std.fmt.charToDigit(c, 8) catch break;
+            val <<= 3;
+            val += char;
+            count += 1;
+        }
+        return val;
     }
 };

--- a/src/CharLiteral.zig
+++ b/src/CharLiteral.zig
@@ -107,7 +107,7 @@ pub const Parser = struct {
         self.errors.append(.{ .tag = tag, .extra = extra }) catch {};
     }
 
-    fn warn(self: *Parser, tag: Diagnostics.Tag, extra: Diagnostics.Message.Extra) void {
+    pub fn warn(self: *Parser, tag: Diagnostics.Tag, extra: Diagnostics.Message.Extra) void {
         if (self.errored) return;
         self.errors.append(.{ .tag = tag, .extra = extra }) catch {};
     }
@@ -249,6 +249,10 @@ pub const Parser = struct {
         }
         if (overflowed or val > self.max_int) {
             self.err(.escape_sequence_overflow, .{ .unsigned = 0 });
+        }
+        if (count == 0) {
+            std.debug.assert(base == .hex);
+            self.err(.missing_hex_escape, .{ .none = {} });
         }
         return val;
     }

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2457,10 +2457,6 @@ const messages = struct {
         const msg = "illegal character encoding in character literal";
         const kind = .@"error";
     };
-    pub const non_hex_ucn = struct {
-        const msg = "\\{c} used with no following hex digits";
-        const kind = .@"error";
-    };
     pub const ucn_basic_char_error = struct {
         const msg = "character '{c}' cannot be specified by a universal character name";
         const kind = .@"error";
@@ -2499,8 +2495,9 @@ const messages = struct {
         const kind = .off;
     };
     pub const missing_hex_escape = struct {
-        const msg = "\\x used with no following hex digits";
+        const msg = "\\{c} used with no following hex digits";
         const kind = .@"error";
+        const extra = .ascii;
     };
     pub const unknown_escape_sequence = struct {
         const msg = "unknown escape sequence '\\{s}'";

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -1823,7 +1823,7 @@ const messages = struct {
         const kind = .warning;
     };
     pub const non_standard_escape_char = struct {
-        const msg = "use of non-standard escape character '\\e'";
+        const msg = "use of non-standard escape character";
         const kind = .off;
         const opt = "pedantic";
     };

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2496,6 +2496,10 @@ const messages = struct {
         const msg = "multi-character character constant";
         const kind = .off;
     };
+    pub const missing_hex_escape = struct {
+        const msg = "\\x used with no following hex digits";
+        const kind = .@"error";
+    };
 };
 
 list: std.ArrayListUnmanaged(Message) = .{},

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -114,6 +114,7 @@ pub const Options = packed struct {
     @"c99-compat": Kind = .default,
     @"unicode-zero-width": Kind = .default,
     @"unicode-homoglyph": Kind = .default,
+    unicode: Kind = .default,
     @"return-type": Kind = .default,
     @"dollar-in-identifier-extension": Kind = .default,
     @"unknown-pragmas": Kind = .default,
@@ -170,6 +171,8 @@ pub const Options = packed struct {
     @"complex-component-init": Kind = .default,
     @"microsoft-include": Kind = .default,
     @"microsoft-end-of-file": Kind = .default,
+    @"invalid-source-encoding": Kind = .default,
+    @"four-char-constants": Kind = .default,
 };
 
 const messages = struct {
@@ -837,15 +840,20 @@ const messages = struct {
         const msg = "invalid universal character";
         const kind = .@"error";
     };
-    pub const multichar_literal = struct {
+    pub const incomplete_universal_character = struct {
+        const msg = "incomplete universal character name";
+        const kind = .@"error";
+    };
+    pub const multichar_literal_warning = struct {
         const msg = "multi-character character constant";
         const opt = "multichar";
         const kind = .warning;
         const all = true;
     };
-    pub const unicode_multichar_literal = struct {
-        const msg = "Unicode character literals may not contain multiple characters";
+    pub const invalid_multichar_literal = struct {
+        const msg = "{s} character literals may not contain multiple characters";
         const kind = .@"error";
+        const extra = .str;
     };
     pub const wide_multichar_literal = struct {
         const msg = "extraneous characters in character constant ignored";
@@ -2437,6 +2445,56 @@ const messages = struct {
         const opt = "microsoft-end-of-file";
         const kind = .off;
         const pedantic = true;
+    };
+    pub const illegal_char_encoding_warning = struct {
+        const msg = "illegal character encoding in character literal";
+        const opt = "invalid-source-encoding";
+        const kind = .warning;
+    };
+    pub const illegal_char_encoding_error = struct {
+        const msg = "illegal character encoding in character literal";
+        const kind = .@"error";
+    };
+    pub const non_hex_ucn = struct {
+        const msg = "\\{c} used with no following hex digits";
+        const kind = .@"error";
+    };
+    pub const ucn_basic_char_error = struct {
+        const msg = "character '{c}' cannot be specified by a universal character name";
+        const kind = .@"error";
+        const extra = .ascii;
+    };
+    pub const ucn_basic_char_warning = struct {
+        const msg = "specifying character '{c}' with a universal character name is incompatible with C standards before C2x";
+        const kind = .off;
+        const extra = .ascii;
+        const suppress_unless_version = .c2x;
+        const opt = "pre-c2x-compat";
+    };
+    pub const ucn_control_char_error = struct {
+        const msg = "universal character name refers to a control character";
+        const kind = .@"error";
+    };
+    pub const ucn_control_char_warning = struct {
+        const msg = "universal character name referring to a control character is incompatible with C standards before C2x";
+        const kind = .off;
+        const suppress_unless_version = .c2x;
+        const opt = "pre-c2x-compat";
+    };
+    pub const c89_ucn_in_literal = struct {
+        const msg = "universal character names are only valid in C99 or later";
+        const suppress_version = .c99;
+        const kind = .warning;
+        const opt = "unicode";
+    };
+    pub const four_char_char_literal = struct {
+        const msg = "multi-character character constant";
+        const opt = "four-char-constants";
+        const kind = .off;
+    };
+    pub const multi_char_char_literal = struct {
+        const msg = "multi-character character constant";
+        const kind = .off;
     };
 };
 

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7645,11 +7645,7 @@ fn charLiteral(p: *Parser) Error!Result {
         // fast path: single unescaped ASCII char
         val = slice[0];
     } else {
-        var char_literal_parser = CharLiteral.Parser.init(
-            slice,
-            char_kind,
-            p.comp,
-        );
+        var char_literal_parser = CharLiteral.Parser.init(slice, char_kind, p.comp);
 
         const max_chars_expected = 4;
         var stack_fallback = std.heap.stackFallback(max_chars_expected * @sizeOf(u32), p.comp.gpa);

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7640,8 +7640,8 @@ fn charLiteral(p: *Parser) Error!Result {
         .char_literal => .{ .specifier = .int },
         .char_literal_utf_8 => .{ .specifier = .uchar },
         .char_literal_wide => p.comp.types.wchar,
-        .char_literal_utf_16 => .{ .specifier = .ushort },
-        .char_literal_utf_32 => .{ .specifier = .ulong },
+        .char_literal_utf_16 => p.comp.types.uint_least16_t,
+        .char_literal_utf_32 => p.comp.types.uint_least32_t,
         else => unreachable,
     };
     const max: u32 = switch (tok_id) {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7653,7 +7653,10 @@ fn charLiteral(p: *Parser) Error!Result {
         else => unreachable,
     };
 
-    var char_literal_parser = CharLiteral.Parser.init(p.tokSlice(p.tok_i), p.comp.langopts.standard);
+    const slice = p.tokSlice(p.tok_i);
+    const start = mem.indexOf(u8, slice, "\'").? + 1;
+
+    var char_literal_parser = CharLiteral.Parser.init(slice[start .. slice.len - 1], p.comp.langopts.standard);
 
     const max_chars_expected = 4;
     var stack_fallback = std.heap.stackFallback(max_chars_expected * @sizeOf(u32), p.comp.gpa);

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7638,11 +7638,10 @@ fn charLiteral(p: *Parser) Error!Result {
     const tok_id = p.tok_ids[p.tok_i];
     const char_kind = CharLiteral.Kind.classify(tok_id);
 
-    const slice = p.tokSlice(p.tok_i);
-    const start = mem.indexOf(u8, slice, "\'").? + 1;
+    const slice = char_kind.contentSlice(p.tokSlice(p.tok_i));
 
     var char_literal_parser = CharLiteral.Parser.init(
-        slice[start .. slice.len - 1],
+        slice,
         char_kind,
         p.comp,
     );

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7676,23 +7676,20 @@ fn charLiteral(p: *Parser) Error!Result {
             }
         },
     };
-    for (char_literal_parser.errors.constSlice()) |item| {
-        try p.errExtra(item.tag, p.tok_i, item.extra);
-    }
 
     const is_multichar = chars.items.len > 1;
     if (is_multichar) {
         if (char_kind == .char and chars.items.len == 4) {
-            try p.err(.four_char_char_literal);
+            char_literal_parser.warn(.four_char_char_literal, .{ .none = {} });
         } else if (char_kind == .char) {
-            try p.err(.multichar_literal_warning);
+            char_literal_parser.warn(.multichar_literal_warning, .{ .none = {} });
         } else {
             const kind = switch (char_kind) {
                 .wide => "wide",
                 .utf_8, .utf_16, .utf_32 => "Unicode",
                 else => unreachable,
             };
-            try p.errExtra(.invalid_multichar_literal, p.tok_i, .{ .str = kind });
+            char_literal_parser.err(.invalid_multichar_literal, .{ .str = kind });
         }
     }
 
@@ -7709,7 +7706,11 @@ fn charLiteral(p: *Parser) Error!Result {
     }
 
     if (multichar_overflow) {
-        try p.err(.char_lit_too_wide);
+        char_literal_parser.err(.char_lit_too_wide, .{ .none = {} });
+    }
+
+    for (char_literal_parser.errors.constSlice()) |item| {
+        try p.errExtra(item.tag, p.tok_i, item.extra);
     }
 
     const ty = char_kind.charLiteralType(p.comp);

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7569,7 +7569,7 @@ fn stringLiteral(p: *Parser) Error!Result {
                         'a' => p.retained_strings.appendAssumeCapacity(0x07),
                         'b' => p.retained_strings.appendAssumeCapacity(0x08),
                         'e' => {
-                            try p.errExtra(.non_standard_escape_char, start, .{ .unsigned = i - 1 });
+                            try p.errExtra(.non_standard_escape_char, start, .{ .invalid_escape = .{ .char = 'e', .offset = @intCast(i) } });
                             p.retained_strings.appendAssumeCapacity(0x1B);
                         },
                         'f' => p.retained_strings.appendAssumeCapacity(0x0C),

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7661,14 +7661,7 @@ fn charLiteral(p: *Parser) Error!Result {
     defer chars.deinit();
 
     while (char_literal_parser.next()) |item| switch (item) {
-        .codepoint => |c| {
-            if (c > max) {
-                try p.err(.char_too_large);
-            }
-            try chars.append(c);
-        },
         .value => |c| try chars.append(c),
-
         .improperly_encoded => |s| {
             const should_error = tok_id != .char_literal;
             const tag: Diagnostics.Tag = if (should_error) .illegal_char_encoding_error else .illegal_char_encoding_warning;
@@ -7685,7 +7678,7 @@ fn charLiteral(p: *Parser) Error!Result {
             var it = view.iterator();
             while (it.nextCodepoint()) |c| {
                 if (c > max) {
-                    try p.err(.char_too_large);
+                    char_literal_parser.err(.char_too_large, .{ .none = {} });
                 }
                 try chars.append(c);
             }

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7661,9 +7661,10 @@ fn charLiteral(p: *Parser) Error!Result {
             .utf8_text => |view| {
                 var it = view.iterator();
                 var max_codepoint: u21 = 0;
+                try chars.ensureUnusedCapacity(view.bytes.len);
                 while (it.nextCodepoint()) |c| {
                     max_codepoint = @max(max_codepoint, c);
-                    try chars.append(c);
+                    chars.appendAssumeCapacity(c);
                 }
                 if (max_codepoint > char_kind.maxCodepoint(p.comp)) {
                     char_literal_parser.err(.char_too_large, .{ .none = {} });

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -7667,11 +7667,13 @@ fn charLiteral(p: *Parser) Error!Result {
         },
         .utf8_text => |view| {
             var it = view.iterator();
+            var max_codepoint: u21 = 0;
             while (it.nextCodepoint()) |c| {
-                if (c > char_literal_parser.max_codepoint) {
-                    char_literal_parser.err(.char_too_large, .{ .none = {} });
-                }
+                max_codepoint = @max(max_codepoint, c);
                 try chars.append(c);
+            }
+            if (max_codepoint > char_literal_parser.max_codepoint) {
+                char_literal_parser.err(.char_too_large, .{ .none = {} });
             }
         },
     };

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -1264,10 +1264,7 @@ pub fn next(self: *Tokenizer) Token {
                 '\'', '"', '?', '\\', 'a', 'b', 'e', 'f', 'n', 'r', 't', 'v' => {
                     state = return_state;
                 },
-                '\n' => {
-                    state = return_state;
-                    self.line += 1;
-                },
+                '\r', '\n' => unreachable, // removed by line splicing
                 '0'...'7' => {
                     counter = 1;
                     state = .octal_escape;

--- a/test/cases/strings.c
+++ b/test/cases/strings.c
@@ -23,4 +23,4 @@ _Static_assert(1, "aaァ\e[1;");
     "strings.c:9:20: error: invalid universal character" \
     "strings.c:10:20: error: invalid universal character" \
     "strings.c:11:20: error: invalid universal character" \
-    "strings.c:15:23: warning: use of non-standard escape character [-Wpedantic]" \
+    "strings.c:15:24: warning: use of non-standard escape character '\\e' [-Wpedantic]" \

--- a/test/cases/strings.c
+++ b/test/cases/strings.c
@@ -23,4 +23,4 @@ _Static_assert(1, "aaァ\e[1;");
     "strings.c:9:20: error: invalid universal character" \
     "strings.c:10:20: error: invalid universal character" \
     "strings.c:11:20: error: invalid universal character" \
-    "strings.c:15:23: warning: use of non-standard escape character '\\e' [-Wpedantic]" \
+    "strings.c:15:23: warning: use of non-standard escape character [-Wpedantic]" \

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -40,6 +40,11 @@ int S = '\x';
 int T = '\xg';
 int U = '\8';
 int V = '\	'; // tab character
+_Static_assert('\(' == '(', "");
+_Static_assert('\[' == '[', "");
+_Static_assert('\{' == '{', "");
+_Static_assert('\%' == '%', "");
+
 
 #define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
     "wide character constants.c:10:16: error: wide character literals may not contain multiple characters" \
@@ -58,4 +63,5 @@ int V = '\	'; // tab character
     "wide character constants.c:39:9: error: \\x used with no following hex digits" \
     "wide character constants.c:40:9: error: \\x used with no following hex digits" \
     "wide character constants.c:41:9: warning: unknown escape sequence '\\8' [-Wunknown-escape-sequence]" \
+    "wide character constants.c:42:9: warning: unknown escape sequence '\\x09' [-Wunknown-escape-sequence]" \
 

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -44,6 +44,8 @@ _Static_assert('\(' == '(', "");
 _Static_assert('\[' == '[', "");
 _Static_assert('\{' == '{', "");
 _Static_assert('\%' == '%', "");
+int W = '\u';
+int X = '\U';
 
 
 #define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
@@ -64,4 +66,6 @@ _Static_assert('\%' == '%', "");
     "wide character constants.c:40:9: error: \\x used with no following hex digits" \
     "wide character constants.c:41:9: warning: unknown escape sequence '\\8' [-Wunknown-escape-sequence]" \
     "wide character constants.c:42:9: warning: unknown escape sequence '\\x09' [-Wunknown-escape-sequence]" \
+    "wide character constants.c:47:9: error: \\u used with no following hex digits" \
+    "wide character constants.c:48:9: error: \\U used with no following hex digits" \
 

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -29,6 +29,14 @@ unsigned long J = u'ab';
 unsigned long K = '\777';
 wchar_t L = L'\777';
 
+_Static_assert(sizeof(u8'a') == sizeof(char), "");
+int M = u8'ab';
+int N = u8'\xFF';
+int O = u8'™';
+int P = u8'\u0041';
+int Q = u8'\x41';
+int R = u8'\u0024';
+
 #define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
     "wide character constants.c:10:16: error: wide character literals may not contain multiple characters" \
     "wide character constants.c:11:16: error: Unicode character literals may not contain multiple characters" \
@@ -40,4 +48,7 @@ wchar_t L = L'\777';
     "wide character constants.c:27:19: error: Unicode character literals may not contain multiple characters" \
     "wide character constants.c:28:19: error: Unicode character literals may not contain multiple characters" \
     "wide character constants.c:29:19: error: escape sequence out of range" \
+    "wide character constants.c:33:9: error: Unicode character literals may not contain multiple characters" \
+    "wide character constants.c:35:9: error: character too large for enclosing character literal type" \
+    "wide character constants.c:36:9: error: character 'A' cannot be specified by a universal character name" \
 

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -26,6 +26,8 @@ unsigned long G = U'\UFFFFFFFF';
 unsigned long H = u'\U0001D4B5';
 unsigned long I = U'ab';
 unsigned long J = u'ab';
+unsigned long K = '\777';
+wchar_t L = L'\777';
 
 #define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
     "wide character constants.c:10:16: error: wide character literals may not contain multiple characters" \
@@ -37,3 +39,5 @@ unsigned long J = u'ab';
     "wide character constants.c:26:19: error: character too large for enclosing character literal type" \
     "wide character constants.c:27:19: error: Unicode character literals may not contain multiple characters" \
     "wide character constants.c:28:19: error: Unicode character literals may not contain multiple characters" \
+    "wide character constants.c:29:19: error: escape sequence out of range" \
+

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -1,3 +1,4 @@
+//aro-args -Wfour-char-constants
 /*
 
     A multiline comment to test that the linenumber is correct.
@@ -13,8 +14,8 @@ _Static_assert('\1' == 0x01, "");
 _Static_assert('\1\2\3\4' == 0x01020304, "");
 #endif
 
-#define EXPECTED_ERRORS "wide character constants.c:8:27: error: character too large for enclosing character literal type" \
-    "wide character constants.c:9:16: warning: extraneous characters in character constant ignored" \
-    "wide character constants.c:10:16: error: Unicode character literals may not contain multiple characters" \
-    "wide character constants.c:13:16: warning: multi-character character constant [-Wmultichar]" \
+#define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
+    "wide character constants.c:10:16: error: wide character literals may not contain multiple characters" \
+    "wide character constants.c:11:16: error: Unicode character literals may not contain multiple characters" \
+    "wide character constants.c:14:16: warning: multi-character character constant [-Wfour-char-constants]" \
 

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -36,6 +36,8 @@ int O = u8'™';
 int P = u8'\u0041';
 int Q = u8'\x41';
 int R = u8'\u0024';
+int S = '\x';
+int T = '\xg';
 
 #define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
     "wide character constants.c:10:16: error: wide character literals may not contain multiple characters" \
@@ -51,4 +53,5 @@ int R = u8'\u0024';
     "wide character constants.c:33:9: error: Unicode character literals may not contain multiple characters" \
     "wide character constants.c:35:9: error: character too large for enclosing character literal type" \
     "wide character constants.c:36:9: error: character 'A' cannot be specified by a universal character name" \
-
+    "wide character constants.c:39:9: error: \\x used with no following hex digits" \
+    "wide character constants.c:40:9: error: \\x used with no following hex digits" \

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -46,7 +46,10 @@ _Static_assert('\{' == '{', "");
 _Static_assert('\%' == '%', "");
 int W = '\u';
 int X = '\U';
-
+#pragma GCC diagnostic warning "-Wpedantic"
+int Y = 'abc\E';
+#pragma GCC diagnostic pop
+int Z = 'ABC\D';
 
 #define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
     "wide character constants.c:10:16: error: wide character literals may not contain multiple characters" \
@@ -64,8 +67,12 @@ int X = '\U';
     "wide character constants.c:36:9: error: character 'A' cannot be specified by a universal character name" \
     "wide character constants.c:39:9: error: \\x used with no following hex digits" \
     "wide character constants.c:40:9: error: \\x used with no following hex digits" \
-    "wide character constants.c:41:9: warning: unknown escape sequence '\\8' [-Wunknown-escape-sequence]" \
-    "wide character constants.c:42:9: warning: unknown escape sequence '\\x09' [-Wunknown-escape-sequence]" \
+    "wide character constants.c:41:10: warning: unknown escape sequence '\\8' [-Wunknown-escape-sequence]" \
+    "wide character constants.c:42:10: warning: unknown escape sequence '\\x09' [-Wunknown-escape-sequence]" \
     "wide character constants.c:47:9: error: \\u used with no following hex digits" \
     "wide character constants.c:48:9: error: \\U used with no following hex digits" \
+    "wide character constants.c:50:13: warning: use of non-standard escape character '\\E' [-Wpedantic]" \
+    "wide character constants.c:50:9: warning: multi-character character constant [-Wfour-char-constants]" \
+    "wide character constants.c:52:13: warning: unknown escape sequence '\\D' [-Wunknown-escape-sequence]" \
+    "wide character constants.c:52:9: warning: multi-character character constant [-Wfour-char-constants]" \
 

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -38,6 +38,8 @@ int Q = u8'\x41';
 int R = u8'\u0024';
 int S = '\x';
 int T = '\xg';
+int U = '\8';
+int V = '\	'; // tab character
 
 #define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
     "wide character constants.c:10:16: error: wide character literals may not contain multiple characters" \
@@ -55,3 +57,5 @@ int T = '\xg';
     "wide character constants.c:36:9: error: character 'A' cannot be specified by a universal character name" \
     "wide character constants.c:39:9: error: \\x used with no following hex digits" \
     "wide character constants.c:40:9: error: \\x used with no following hex digits" \
+    "wide character constants.c:41:9: warning: unknown escape sequence '\\8' [-Wunknown-escape-sequence]" \
+

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -14,8 +14,26 @@ _Static_assert('\1' == 0x01, "");
 _Static_assert('\1\2\3\4' == 0x01020304, "");
 #endif
 
+_Static_assert(sizeof(u'a') == 2, "");
+_Static_assert(sizeof(U'a') == 4, "");
+unsigned long A = U'\xFFFFFFFF';
+unsigned long B = u'\xFFFFFFFF';
+unsigned long C = U'𝒵';  // U+1D4B5
+unsigned long D = u'𝒵';  // U+1D4B5
+unsigned long E = U'ℤ';  // U+2124
+unsigned long F = u'ℤ';  // U+2124
+unsigned long G = U'\UFFFFFFFF';
+unsigned long H = u'\U0001D4B5';
+unsigned long I = U'ab';
+unsigned long J = u'ab';
+
 #define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
     "wide character constants.c:10:16: error: wide character literals may not contain multiple characters" \
     "wide character constants.c:11:16: error: Unicode character literals may not contain multiple characters" \
     "wide character constants.c:14:16: warning: multi-character character constant [-Wfour-char-constants]" \
-
+    "wide character constants.c:20:19: error: escape sequence out of range" \
+    "wide character constants.c:22:19: error: character too large for enclosing character literal type" \
+    "wide character constants.c:25:19: error: invalid universal character" \
+    "wide character constants.c:26:19: error: character too large for enclosing character literal type" \
+    "wide character constants.c:27:19: error: Unicode character literals may not contain multiple characters" \
+    "wide character constants.c:28:19: error: Unicode character literals may not contain multiple characters" \


### PR DESCRIPTION
Summary of changes:

1) Move char literal validation to the parser instead of tokenizer. This means that ill-formed char literals can be diagnosed as such, instead of just being treated as invalid tokens.
2) Allow arbitrarily-long hex escapes. Previously they were limited to a 2-digit maximum
3) Use correct size for char literals (`char16_t` aka `uint_least16_t` for utf16 literals, `char32_t` aka `uint_least32_t` for utf32 literals; previously these unconditionally used `unsigned short` and `unsigned long`)
4) Proper range checking for numeric escapes (e.g. `L'\777'` is valid because `511` fits into a wide character)
5) Added `\E` escape as well as `'\('`, `'\{'`, `'\['`, and `'\%'` (non-standard GNU escapes)

There are some redundancies with how string literals are handled; my plan if these changes look good is to use them as a basis for updating string literal handling as well (including adding unicode string literal support).

My expectation is that these changes would have neutral or slightly positive performance implications because of the fast-path check (single ASCII char) which I suspect is the majority of character literals in real programs. My standard sqlite3.c benchmark has about a 1,000 char literals and they're all ASCII.

```
(master branch on top, this branch below)

Benchmark 1 (16 runs): /home/ehaas/source/arocc/zig-out/bin/arocc -I. -fsyntax-only sqlite3.c
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           326ms ±  974us     324ms …  329ms          1 ( 6%)        0%
  peak_rss           63.9MB ± 38.5KB    63.8MB … 64.0MB          3 (19%)        0%
  cpu_cycles         1.24G  ± 1.95M     1.24G  … 1.24G           0 ( 0%)        0%
  instructions       3.23G  ± 2.17      3.23G  … 3.23G           0 ( 0%)        0%
  cache_references   2.05M  ± 23.3K     2.00M  … 2.08M           0 ( 0%)        0%
  cache_misses        591K  ± 15.5K      576K  …  630K           0 ( 0%)        0%
  branch_misses      11.0M  ± 8.91K     11.0M  … 11.0M           2 (13%)        0%
Benchmark 2 (16 runs): /home/ehaas/source/charparser/zig-out/bin/arocc -I. -fsyntax-only sqlite3.c
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           326ms ±  306us     326ms …  327ms          0 ( 0%)          +  0.1% ±  0.2%
  peak_rss           63.9MB ± 45.3KB    63.8MB … 63.9MB          0 ( 0%)          -  0.1% ±  0.0%
  cpu_cycles         1.24G  ± 1.28M     1.24G  … 1.24G           2 (13%)          +  0.2% ±  0.1%
  instructions       3.23G  ± 3.47      3.23G  … 3.23G           0 ( 0%)          -  0.0% ±  0.0%
  cache_references   2.07M  ± 21.3K     2.03M  … 2.12M           0 ( 0%)          +  1.1% ±  0.8%
  cache_misses        590K  ± 7.81K      576K  …  605K           0 ( 0%)          -  0.2% ±  1.5%
  branch_misses      10.7M  ± 7.64K     10.7M  … 10.7M           0 ( 0%)        ⚡-  2.5% ±  0.1%
```