### PR TITLE
Zig workaround: don't use packed structs larger than 128 bits.

### DIFF
--- a/deps/zig/codegen/x86_64.zig
+++ b/deps/zig/codegen/x86_64.zig
@@ -176,19 +176,21 @@ pub const Encoder = struct {
 
     /// Directly write a number to the code array with big endianness
     pub fn writeIntBig(self: Self, comptime T: type, value: T) void {
-        mem.writeIntBig(
+        mem.writeInt(
             T,
             self.code.addManyAsArrayAssumeCapacity(@divExact(@typeInfo(T).Int.bits, 8)),
             value,
+            .big,
         );
     }
 
     /// Directly write a number to the code array with little endianness
     pub fn writeIntLittle(self: Self, comptime T: type, value: T) void {
-        mem.writeIntLittle(
+        mem.writeInt(
             T,
             self.code.addManyAsArrayAssumeCapacity(@divExact(@typeInfo(T).Int.bits, 8)),
             value,
+            .little,
         );
     }
 

--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -404,7 +404,7 @@ pub fn generateBuiltinMacros(comp: *Compilation) !Source {
         \\#define __ORDER_PDP_ENDIAN__ 3412
         \\
     );
-    if (comp.target.cpu.arch.endian() == .Little) try w.writeAll(
+    if (comp.target.cpu.arch.endian() == .little) try w.writeAll(
         \\#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
         \\#define __LITTLE_ENDIAN__ 1
         \\

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -70,10 +70,9 @@ pub const Message = struct {
 
 pub const Tag = std.meta.DeclEnum(messages);
 
-// u4 to avoid any possible packed struct issues
-pub const Kind = enum(u4) { @"fatal error", @"error", note, warning, off, default };
+pub const Kind = enum { @"fatal error", @"error", note, warning, off, default };
 
-pub const Options = packed struct {
+pub const Options = struct {
     // do not directly use these, instead add `const NAME = true;`
     all: Kind = .default,
     extra: Kind = .default,

--- a/src/object/Elf.zig
+++ b/src/object/Elf.zig
@@ -20,7 +20,7 @@ const Symbol = struct {
     info: u8,
 };
 
-const Relocation = packed struct {
+const Relocation = struct {
     symbol: *Symbol,
     addend: i64,
     offset: u48,

--- a/src/target.zig
+++ b/src/target.zig
@@ -397,8 +397,8 @@ pub fn ldEmulationOption(target: std.Target, arm_endianness: ?std.builtin.Endian
         .thumb,
         .thumbeb,
         => switch (arm_endianness orelse target.cpu.arch.endian()) {
-            .Little => "armelf_linux_eabi",
-            .Big => "armelfb_linux_eabi",
+            .little => "armelf_linux_eabi",
+            .big => "armelfb_linux_eabi",
         },
         .aarch64 => "aarch64linux",
         .aarch64_be => "aarch64linuxb",


### PR DESCRIPTION
The C backend currently can't handle them. This is the only thing preventing the CBE from being able to produce valid C code from aro (I have not verified that the produced code actually works, however). 

If the produced code works as expected, this will unblock https://github.com/ziglang/zig/pull/17771

Does `Relocation` even need to be packed? It looks like we aren't bitcasting it, and it's 32 bytes regardless of whether it's packed or not (the bitsize is 184 when packed vs 256 when not packed, but if we're only using it in `ArrayListUnmanaged` then that shouldn't matter, right?)

`Options` goes from 64 bytes -> 104 bytes when not packed, but we only have 1 of those per Compilation.