### PR TITLE
Parser: set kind to param in old style parameter declarations

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -987,7 +987,7 @@ fn decl(p: *Parser) Error!bool {
                     const attr_buf_top_declarator = p.attr_buf.len;
                     defer p.attr_buf.len = attr_buf_top_declarator;
 
-                    var d = (try p.declarator(param_decl_spec.ty, .normal)) orelse {
+                    var d = (try p.declarator(param_decl_spec.ty, .param)) orelse {
                         try p.errTok(.missing_declaration, first_tok);
                         _ = try p.expectToken(.semicolon);
                         continue :param_loop;

--- a/test/cases/functions.c
+++ b/test/cases/functions.c
@@ -62,6 +62,10 @@ void unspecified_variable_len(int n, int x[][n]) { }
 
 static func_pointer p = unspecified_variable_len;
 
+void static_array_parameter(x)
+	int x[static 5];
+{}
+
 
 #define EXPECTED_ERRORS "functions.c:10:12: error: parameter named 'quux' is missing" \
     "functions.c:20:14: error: illegal initializer (only variables can be initialized)" \


### PR DESCRIPTION
resolve #351
When parsing old style parameter declarations, declarator kind was not initialized as param but as normal, that generate an error for K&R style function definition when using static.
Added a test in cases/functions.c