### PR TITLE
Simplify library usage

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -176,6 +176,7 @@ pub fn build(b: *Build) !void {
         .root_source_file = .{ .path = "src/main.zig" },
         .optimize = mode,
         .target = target,
+        .single_threaded = true,
     });
     exe.addModule("aro", aro_module);
 

--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -720,7 +720,7 @@ fn ignoredAttrErr(p: *Parser, tok: TokenIndex, attr: Attribute.Tag, context: []c
     defer p.strings.items.len = strings_top;
 
     try p.strings.writer().print("attribute '{s}' ignored on {s}", .{ @tagName(attr), context });
-    const str = try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
+    const str = try p.comp.diagnostics.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
     try p.errStr(.ignored_attribute, tok, str);
 }
 
@@ -1030,7 +1030,11 @@ fn applyTransparentUnion(attr: Attribute, p: *Parser, tok: TokenIndex, ty: Type)
         const field_size = field.ty.bitSizeof(p.comp).?;
         if (field_size == first_field_size) continue;
         const mapper = p.comp.string_interner.getSlowTypeMapper();
-        const str = try std.fmt.allocPrint(p.comp.diag.arena.allocator(), "'{s}' ({d}", .{ mapper.lookup(field.name), field_size });
+        const str = try std.fmt.allocPrint(
+            p.comp.diagnostics.arena.allocator(),
+            "'{s}' ({d}",
+            .{ mapper.lookup(field.name), field_size },
+        );
         try p.errStr(.transparent_union_size, field.name_tok, str);
         return p.errExtra(.transparent_union_size_note, fields[0].name_tok, .{ .unsigned = first_field_size });
     }

--- a/src/aro/Builtins.zig
+++ b/src/aro/Builtins.zig
@@ -10,14 +10,14 @@ const Parser = @import("Parser.zig");
 const Properties = @import("Builtins/Properties.zig");
 pub const Builtin = @import("Builtins/Builtin.def").with(Properties);
 
-const Builtins = @This();
-
 const Expanded = struct {
     ty: Type,
     builtin: Builtin,
 };
 
 const NameToTypeMap = std.StringHashMapUnmanaged(Type);
+
+const Builtins = @This();
 
 _name_to_type_map: NameToTypeMap = .{},
 

--- a/src/aro/CodeGen.zig
+++ b/src/aro/CodeGen.zig
@@ -137,7 +137,7 @@ fn genType(c: *CodeGen, base_ty: Type) !Interner.Ref {
 
             for (ty.data.record.fields) |field| {
                 if (!field.isRegularField()) {
-                    return c.comp.diag.fatalNoSrc("TODO lower struct bitfields", .{});
+                    return c.comp.diagnostics.fatalNoSrc("TODO lower struct bitfields", .{});
                 }
                 // TODO handle padding bits
                 const field_ref = try c.genType(field.ty);
@@ -149,13 +149,13 @@ fn genType(c: *CodeGen, base_ty: Type) !Interner.Ref {
             });
         },
         .@"union" => {
-            return c.comp.diag.fatalNoSrc("TODO lower union types", .{});
+            return c.comp.diagnostics.fatalNoSrc("TODO lower union types", .{});
         },
         else => {},
     }
     if (ty.isPtr()) return .ptr;
     if (ty.isFunc()) return .func;
-    if (!ty.isReal()) return c.comp.diag.fatalNoSrc("TODO lower complex types", .{});
+    if (!ty.isReal()) return c.comp.diagnostics.fatalNoSrc("TODO lower complex types", .{});
     if (ty.isInt()) {
         const bits = ty.bitSizeof(c.comp).?;
         key = .{ .int_ty = @intCast(bits) };
@@ -169,7 +169,7 @@ fn genType(c: *CodeGen, base_ty: Type) !Interner.Ref {
         const elem = try c.genType(ty.elemType());
         key = .{ .vector_ty = .{ .child = elem, .len = @intCast(ty.data.array.len) } };
     } else if (ty.is(.nullptr_t)) {
-        return c.comp.diag.fatalNoSrc("TODO lower nullptr_t", .{});
+        return c.comp.diagnostics.fatalNoSrc("TODO lower nullptr_t", .{});
     }
     return c.builder.interner.put(c.builder.gpa, key);
 }
@@ -540,7 +540,7 @@ fn genExpr(c: *CodeGen, node: NodeIndex) Error!Ir.Ref {
         .goto_stmt,
         .computed_goto_stmt,
         .nullptr_literal,
-        => return c.comp.diag.fatalNoSrc("TODO CodeGen.genStmt {}\n", .{c.node_tag[@intFromEnum(node)]}),
+        => return c.comp.diagnostics.fatalNoSrc("TODO CodeGen.genStmt {}\n", .{c.node_tag[@intFromEnum(node)]}),
         .comma_expr => {
             _ = try c.genExpr(data.bin.lhs);
             return c.genExpr(data.bin.rhs);
@@ -734,7 +734,7 @@ fn genExpr(c: *CodeGen, node: NodeIndex) Error!Ir.Ref {
             .null_to_pointer,
             .union_cast,
             .vector_splat,
-            => return c.comp.diag.fatalNoSrc("TODO CodeGen gen CastKind {}\n", .{data.cast.kind}),
+            => return c.comp.diagnostics.fatalNoSrc("TODO CodeGen gen CastKind {}\n", .{data.cast.kind}),
         },
         .binary_cond_expr => {
             if (c.tree.value_map.get(data.if3.cond)) |cond| {
@@ -942,7 +942,7 @@ fn genExpr(c: *CodeGen, node: NodeIndex) Error!Ir.Ref {
         .real_expr,
         .sizeof_expr,
         .special_builtin_call_one,
-        => return c.comp.diag.fatalNoSrc("TODO CodeGen.genExpr {}\n", .{c.node_tag[@intFromEnum(node)]}),
+        => return c.comp.diagnostics.fatalNoSrc("TODO CodeGen.genExpr {}\n", .{c.node_tag[@intFromEnum(node)]}),
         else => unreachable, // Not an expression.
     }
     return .none;
@@ -997,7 +997,7 @@ fn genLval(c: *CodeGen, node: NodeIndex) Error!Ir.Ref {
         .static_compound_literal_expr,
         .thread_local_compound_literal_expr,
         .static_thread_local_compound_literal_expr,
-        => return c.comp.diag.fatalNoSrc("TODO CodeGen.genLval {}\n", .{c.node_tag[@intFromEnum(node)]}),
+        => return c.comp.diagnostics.fatalNoSrc("TODO CodeGen.genLval {}\n", .{c.node_tag[@intFromEnum(node)]}),
         else => unreachable, // Not an lval expression.
     }
 }
@@ -1157,7 +1157,7 @@ fn genBoolExpr(c: *CodeGen, base: NodeIndex, true_label: Ir.Ref, false_label: Ir
 fn genBuiltinCall(c: *CodeGen, builtin: Builtin, arg_nodes: []const NodeIndex, ty: Type) Error!Ir.Ref {
     _ = arg_nodes;
     _ = ty;
-    return c.comp.diag.fatalNoSrc("TODO CodeGen.genBuiltinCall {s}\n", .{Builtin.nameFromTag(builtin.tag).span()});
+    return c.comp.diagnostics.fatalNoSrc("TODO CodeGen.genBuiltinCall {s}\n", .{Builtin.nameFromTag(builtin.tag).span()});
 }
 
 fn genCall(c: *CodeGen, fn_node: NodeIndex, arg_nodes: []const NodeIndex, ty: Type) Error!Ir.Ref {
@@ -1263,12 +1263,12 @@ fn genInitializer(c: *CodeGen, ptr: Ir.Ref, dest_ty: Type, initializer: NodeInde
         .union_init_expr,
         .array_filler_expr,
         .default_init_expr,
-        => return c.comp.diag.fatalNoSrc("TODO CodeGen.genInitializer {}\n", .{c.node_tag[@intFromEnum(initializer)]}),
+        => return c.comp.diagnostics.fatalNoSrc("TODO CodeGen.genInitializer {}\n", .{c.node_tag[@intFromEnum(initializer)]}),
         .string_literal_expr => {
             const val = c.tree.value_map.get(initializer).?;
             const str_ptr = try c.builder.addConstant(val.ref(), .ptr);
             if (dest_ty.isArray()) {
-                return c.comp.diag.fatalNoSrc("TODO memcpy\n", .{});
+                return c.comp.diagnostics.fatalNoSrc("TODO memcpy\n", .{});
             } else {
                 try c.builder.addStore(ptr, str_ptr);
             }
@@ -1282,5 +1282,5 @@ fn genInitializer(c: *CodeGen, ptr: Ir.Ref, dest_ty: Type, initializer: NodeInde
 
 fn genVar(c: *CodeGen, decl: NodeIndex) Error!void {
     _ = decl;
-    return c.comp.diag.fatalNoSrc("TODO CodeGen.genVar\n", .{});
+    return c.comp.diagnostics.fatalNoSrc("TODO CodeGen.genVar\n", .{});
 }

--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -17,8 +17,6 @@ const StrInt = @import("StringInterner.zig");
 const record_layout = @import("record_layout.zig");
 const target_util = @import("target.zig");
 
-const Compilation = @This();
-
 pub const Error = error{
     /// A fatal error has ocurred and compilation has stopped.
     FatalError,
@@ -59,12 +57,12 @@ pub const Environment = struct {
 
     /// Load all of the environment variables using the std.process API. Do not use if using Aro as a shared library on Linux without libc
     /// See https://github.com/ziglang/zig/issues/4524
-    /// Assumes that `self` has been default-initialized
-    pub fn loadAll(self: *Environment, allocator: std.mem.Allocator) !void {
-        errdefer self.deinit(allocator);
+    pub fn loadAll(allocator: std.mem.Allocator) !Environment {
+        var env: Environment = .{};
+        errdefer env.deinit(allocator);
 
-        inline for (@typeInfo(@TypeOf(self.*)).Struct.fields) |field| {
-            std.debug.assert(@field(self, field.name) == null);
+        inline for (@typeInfo(@TypeOf(env)).Struct.fields) |field| {
+            std.debug.assert(@field(env, field.name) == null);
 
             var env_var_buf: [field.name.len]u8 = undefined;
             const env_var_name = std.ascii.upperString(&env_var_buf, field.name);
@@ -73,8 +71,9 @@ pub const Environment = struct {
                 error.EnvironmentVariableNotFound => null,
                 error.InvalidUtf8 => null,
             };
-            @field(self, field.name) = val;
+            @field(env, field.name) = val;
         }
+        return env;
     }
 
     /// Use this only if environment slices were allocated with `allocator` (such as via `loadAll`)
@@ -88,16 +87,19 @@ pub const Environment = struct {
     }
 };
 
+const Compilation = @This();
+
 gpa: Allocator,
-environment: Environment = .{},
-sources: std.StringArrayHashMap(Source),
 diag: Diagnostics,
-include_dirs: std.ArrayList([]const u8),
-system_include_dirs: std.ArrayList([]const u8),
+
+environment: Environment = .{},
+sources: std.StringArrayHashMapUnmanaged(Source) = .{},
+include_dirs: std.ArrayListUnmanaged([]const u8) = .{},
+system_include_dirs: std.ArrayListUnmanaged([]const u8) = .{},
 target: std.Target = @import("builtin").target,
-pragma_handlers: std.StringArrayHashMap(*Pragma),
+pragma_handlers: std.StringArrayHashMapUnmanaged(*Pragma) = .{},
 langopts: LangOpts = .{},
-generated_buf: std.ArrayList(u8),
+generated_buf: std.ArrayListUnmanaged(u8) = .{},
 builtins: Builtins = .{},
 types: struct {
     wchar: Type = undefined,
@@ -130,13 +132,22 @@ ms_cwd_source_id: ?Source.Id = null,
 pub fn init(gpa: Allocator) Compilation {
     return .{
         .gpa = gpa,
-        .sources = std.StringArrayHashMap(Source).init(gpa),
         .diag = Diagnostics.init(gpa),
-        .include_dirs = std.ArrayList([]const u8).init(gpa),
-        .system_include_dirs = std.ArrayList([]const u8).init(gpa),
-        .pragma_handlers = std.StringArrayHashMap(*Pragma).init(gpa),
-        .generated_buf = std.ArrayList(u8).init(gpa),
     };
+}
+
+/// Initialize Compilation with default environment,
+/// pragma handlers and emulation mode set to target.
+pub fn initDefault(gpa: Allocator) !Compilation {
+    var comp: Compilation = .{
+        .gpa = gpa,
+        .environment = try Environment.loadAll(gpa),
+        .diag = Diagnostics.init(gpa),
+    };
+    errdefer comp.deinit();
+    try comp.addDefaultPragmaHandlers();
+    comp.langopts.setEmulatedCompiler(target_util.systemCompiler(comp.target));
+    return comp;
 }
 
 pub fn deinit(comp: *Compilation) void {
@@ -148,16 +159,17 @@ pub fn deinit(comp: *Compilation) void {
         comp.gpa.free(source.buf);
         comp.gpa.free(source.splice_locs);
     }
-    comp.sources.deinit();
+    comp.sources.deinit(comp.gpa);
     comp.diag.deinit();
-    comp.include_dirs.deinit();
+    comp.include_dirs.deinit(comp.gpa);
     for (comp.system_include_dirs.items) |path| comp.gpa.free(path);
-    comp.system_include_dirs.deinit();
-    comp.pragma_handlers.deinit();
-    comp.generated_buf.deinit();
+    comp.system_include_dirs.deinit(comp.gpa);
+    comp.pragma_handlers.deinit(comp.gpa);
+    comp.generated_buf.deinit(comp.gpa);
     comp.builtins.deinit(comp.gpa);
     comp.string_interner.deinit(comp.gpa);
     comp.interner.deinit(comp.gpa);
+    comp.environment.deinit(comp.gpa);
 }
 
 pub fn getSourceEpoch(self: *const Compilation, max: i64) !?i64 {
@@ -957,7 +969,7 @@ pub fn defineSystemIncludes(comp: *Compilation, aro_dir: []const u8) !void {
         base_dir.access("include/stddef.h", .{}) catch continue;
         const path = try std.fs.path.join(comp.gpa, &.{ dirname, "include" });
         errdefer comp.gpa.free(path);
-        try comp.system_include_dirs.append(path);
+        try comp.system_include_dirs.append(comp.gpa, path);
         break;
     } else return error.AroIncludeNotFound;
 
@@ -971,12 +983,12 @@ pub fn defineSystemIncludes(comp: *Compilation, aro_dir: []const u8) !void {
         if (!std.meta.isError(std.fs.accessAbsolute(multiarch_path, .{}))) {
             const duped = try comp.gpa.dupe(u8, multiarch_path);
             errdefer comp.gpa.free(duped);
-            try comp.system_include_dirs.append(duped);
+            try comp.system_include_dirs.append(comp.gpa, duped);
         }
     }
     const usr_include = try comp.gpa.dupe(u8, "/usr/include");
     errdefer comp.gpa.free(usr_include);
-    try comp.system_include_dirs.append(usr_include);
+    try comp.system_include_dirs.append(comp.gpa, usr_include);
 }
 
 pub fn getSource(comp: *const Compilation, id: Source.Id) Source {
@@ -1005,7 +1017,7 @@ pub fn addSourceFromReader(comp: *Compilation, reader: anytype, path: []const u8
 /// To add the contents of an arbitrary reader as a Source, see addSourceFromReader
 /// To add a file's contents given its path, see addSourceFromPath
 pub fn addSourceFromOwnedBuffer(comp: *Compilation, buf: []u8, path: []const u8, kind: Source.Kind) !Source {
-    try comp.sources.ensureUnusedCapacity(1);
+    try comp.sources.ensureUnusedCapacity(comp.gpa, 1);
 
     var contents = buf;
     const duped_path = try comp.gpa.dupe(u8, path);
@@ -1397,7 +1409,7 @@ pub fn findInclude(
 }
 
 pub fn addPragmaHandler(comp: *Compilation, name: []const u8, handler: *Pragma) Allocator.Error!void {
-    try comp.pragma_handlers.putNoClobber(name, handler);
+    try comp.pragma_handlers.putNoClobber(comp.gpa, name, handler);
 }
 
 pub fn addDefaultPragmaHandlers(comp: *Compilation) Allocator.Error!void {

--- a/src/aro/Diagnostics.zig
+++ b/src/aro/Diagnostics.zig
@@ -12,8 +12,6 @@ const Tree = @import("Tree.zig");
 const is_windows = @import("builtin").os.tag == .windows;
 const LangOpts = @import("LangOpts.zig");
 
-const Diagnostics = @This();
-
 pub const Message = struct {
     tag: Tag,
     kind: Kind = undefined,
@@ -210,6 +208,8 @@ pub const Options = struct {
     @"unsupported-embed-param": Kind = .default,
     @"unused-result": Kind = .default,
 };
+
+const Diagnostics = @This();
 
 list: std.ArrayListUnmanaged(Message) = .{},
 arena: std.heap.ArenaAllocator,

--- a/src/aro/Driver/Filesystem.zig
+++ b/src/aro/Driver/Filesystem.zig
@@ -122,8 +122,6 @@ pub const Filesystem = union(enum) {
             base: []const u8,
             i: usize = 0,
 
-            const Self = @This();
-
             fn next(self: *@This()) !?std.fs.IterableDir.Entry {
                 while (self.i < self.entries.len) {
                     const entry = self.entries[self.i];

--- a/src/aro/Driver/GCCDetector.zig
+++ b/src/aro/Driver/GCCDetector.zig
@@ -5,6 +5,7 @@ const target_util = @import("../target.zig");
 const system_defaults = @import("system_defaults");
 const GCCVersion = @import("GCCVersion.zig");
 const Multilib = @import("Multilib.zig");
+
 const GCCDetector = @This();
 
 is_valid: bool = false,

--- a/src/aro/InitList.zig
+++ b/src/aro/InitList.zig
@@ -12,8 +12,6 @@ const Diagnostics = @import("Diagnostics.zig");
 const NodeList = std.ArrayList(NodeIndex);
 const Parser = @import("Parser.zig");
 
-const InitList = @This();
-
 const Item = struct {
     list: InitList = .{},
     index: u64,
@@ -22,6 +20,8 @@ const Item = struct {
         return std.math.order(a.index, b.index);
     }
 };
+
+const InitList = @This();
 
 list: std.ArrayListUnmanaged(Item) = .{},
 node: NodeIndex = .none,

--- a/src/aro/LangOpts.zig
+++ b/src/aro/LangOpts.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const DiagnosticTag = @import("Diagnostics.zig").Tag;
 const char_info = @import("char_info.zig");
 
-const LangOpts = @This();
-
 pub const Compiler = enum {
     clang,
     gcc,
@@ -106,6 +104,8 @@ pub const Standard = enum {
         }
     }
 };
+
+const LangOpts = @This();
 
 emulate: Compiler = .clang,
 standard: Standard = .default,

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -188,29 +188,29 @@ string_ids: struct {
 fn checkIdentifierCodepointWarnings(comp: *Compilation, codepoint: u21, loc: Source.Location) Compilation.Error!bool {
     assert(codepoint >= 0x80);
 
-    const err_start = comp.diag.list.items.len;
+    const err_start = comp.diagnostics.list.items.len;
 
     if (!char_info.isC99IdChar(codepoint)) {
-        try comp.diag.add(.{
+        try comp.addDiagnostic(.{
             .tag = .c99_compat,
             .loc = loc,
         }, &.{});
     }
     if (char_info.isInvisible(codepoint)) {
-        try comp.diag.add(.{
+        try comp.addDiagnostic(.{
             .tag = .unicode_zero_width,
             .loc = loc,
             .extra = .{ .actual_codepoint = codepoint },
         }, &.{});
     }
     if (char_info.homoglyph(codepoint)) |resembles| {
-        try comp.diag.add(.{
+        try comp.addDiagnostic(.{
             .tag = .unicode_homoglyph,
             .loc = loc,
             .extra = .{ .codepoints = .{ .actual = codepoint, .resembles = resembles } },
         }, &.{});
     }
-    return comp.diag.list.items.len != err_start;
+    return comp.diagnostics.list.items.len != err_start;
 }
 
 /// Issues diagnostics for the current extended identifier token
@@ -241,7 +241,7 @@ fn validateExtendedIdentifier(p: *Parser) !bool {
         }
         if (codepoint == '$') {
             warned = true;
-            if (p.comp.langopts.dollars_in_identifiers) try p.comp.diag.add(.{
+            if (p.comp.langopts.dollars_in_identifiers) try p.comp.addDiagnostic(.{
                 .tag = .dollar_in_identifier_extension,
                 .loc = loc,
             }, &.{});
@@ -382,7 +382,7 @@ pub fn errExtra(p: *Parser, tag: Diagnostics.Tag, tok_i: TokenIndex, extra: Diag
         loc = prev.loc;
         loc.byte_offset += @intCast(p.tokSlice(tok_i - 1).len);
     }
-    try p.comp.diag.add(.{
+    try p.comp.addDiagnostic(.{
         .tag = tag,
         .loc = loc,
         .extra = extra,
@@ -421,7 +421,7 @@ pub fn typeStr(p: *Parser, ty: Type) ![]const u8 {
 
     const mapper = p.comp.string_interner.getSlowTypeMapper();
     try ty.print(mapper, p.comp.langopts, p.strings.writer());
-    return try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
+    return try p.comp.diagnostics.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
 }
 
 pub fn typePairStr(p: *Parser, a: Type, b: Type) ![]const u8 {
@@ -440,7 +440,7 @@ pub fn typePairStrExtra(p: *Parser, a: Type, msg: []const u8, b: Type) ![]const 
     try p.strings.append('\'');
     try b.print(mapper, p.comp.langopts, p.strings.writer());
     try p.strings.append('\'');
-    return try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
+    return try p.comp.diagnostics.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
 }
 
 pub fn floatValueChangedStr(p: *Parser, res: *Result, old_value: Value, int_ty: Type) ![]const u8 {
@@ -458,7 +458,7 @@ pub fn floatValueChangedStr(p: *Parser, res: *Result, old_value: Value, int_ty: 
     try w.writeAll(" to ");
     try res.val.print(int_ty, p.comp, w);
 
-    return try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
+    return try p.comp.diagnostics.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
 }
 
 fn checkDeprecatedUnavailable(p: *Parser, ty: Type, usage_tok: TokenIndex, decl_tok: TokenIndex) !void {
@@ -471,7 +471,7 @@ fn checkDeprecatedUnavailable(p: *Parser, ty: Type, usage_tok: TokenIndex, decl_
         try w.print("call to '{s}' declared with attribute error: {}", .{
             p.tokSlice(@"error".__name_tok), std.zig.fmtEscapes(msg_str),
         });
-        const str = try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
+        const str = try p.comp.diagnostics.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
         try p.errStr(.error_attribute, usage_tok, str);
     }
     if (ty.getAttribute(.warning)) |warning| {
@@ -483,7 +483,7 @@ fn checkDeprecatedUnavailable(p: *Parser, ty: Type, usage_tok: TokenIndex, decl_
         try w.print("call to '{s}' declared with attribute warning: {}", .{
             p.tokSlice(warning.__name_tok), std.zig.fmtEscapes(msg_str),
         });
-        const str = try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
+        const str = try p.comp.diagnostics.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
         try p.errStr(.warning_attribute, usage_tok, str);
     }
     if (ty.getAttribute(.unavailable)) |unavailable| {
@@ -512,7 +512,7 @@ fn errDeprecated(p: *Parser, tag: Diagnostics.Tag, tok_i: TokenIndex, msg: ?Valu
         const str = p.comp.interner.get(m.ref()).bytes;
         try w.print(": {}", .{std.zig.fmtEscapes(str)});
     }
-    const str = try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
+    const str = try p.comp.diagnostics.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
     return p.errStr(tag, tok_i, str);
 }
 
@@ -618,7 +618,7 @@ fn diagnoseIncompleteDefinitions(p: *Parser) !void {
     const tys = node_slices.items(.ty);
     const data = node_slices.items(.data);
 
-    const err_start = p.comp.diag.list.items.len;
+    const err_start = p.comp.diagnostics.list.items.len;
     for (p.decl_buf.items) |decl_node| {
         const idx = @intFromEnum(decl_node);
         switch (tags[idx]) {
@@ -639,7 +639,7 @@ fn diagnoseIncompleteDefinitions(p: *Parser) !void {
         try p.errStr(.tentative_definition_incomplete, tentative_def_tok, type_str);
         try p.errStr(.forward_declaration_here, data[idx].decl_ref, type_str);
     }
-    const errors_added = p.comp.diag.list.items.len - err_start;
+    const errors_added = p.comp.diagnostics.list.items.len - err_start;
     assert(errors_added == 2 * p.tentative_defs.count()); // Each tentative def should add an error + note
 }
 
@@ -1185,7 +1185,7 @@ fn staticAssertMessage(p: *Parser, cond_node: NodeIndex, message: Result) !?[]co
         try buf.ensureUnusedCapacity(bytes.len);
         try Value.printString(bytes, message.ty, p.comp, buf.writer());
     }
-    return try p.comp.diag.arena.allocator().dupe(u8, buf.items);
+    return try p.comp.diagnostics.arena.allocator().dupe(u8, buf.items);
 }
 
 /// staticAssert
@@ -1222,9 +1222,9 @@ fn staticAssert(p: *Parser) Error!bool {
 
     // Array will never be zero; a value of zero for a pointer is a null pointer constant
     if ((res.ty.isArray() or res.ty.isPtr()) and !res.val.isZero(p.comp)) {
-        const err_start = p.comp.diag.list.items.len;
+        const err_start = p.comp.diagnostics.list.items.len;
         try p.errTok(.const_decl_folded, res_token);
-        if (res.ty.isPtr() and err_start != p.comp.diag.list.items.len) {
+        if (res.ty.isPtr() and err_start != p.comp.diagnostics.list.items.len) {
             // Don't show the note if the .const_decl_folded diagnostic was not added
             try p.errTok(.constant_expression_conversion_not_allowed, res_token);
         }
@@ -2697,7 +2697,7 @@ fn enumerator(p: *Parser, e: *Enumerator) Error!?EnumFieldAndNode {
     defer p.attr_buf.len = attr_buf_top;
     try p.attributeSpecifier();
 
-    const err_start = p.comp.diag.list.items.len;
+    const err_start = p.comp.diagnostics.list.items.len;
     if (p.eatToken(.equal)) |_| {
         const specified = try p.integerConstExpr(.gnu_folding_extension);
         if (specified.val.opt_ref == .none) {
@@ -2719,7 +2719,7 @@ fn enumerator(p: *Parser, e: *Enumerator) Error!?EnumFieldAndNode {
         e.num_negative_bits = @max(e.num_negative_bits, res.val.minSignedBits(p.comp));
     }
 
-    if (err_start == p.comp.diag.list.items.len) {
+    if (err_start == p.comp.diagnostics.list.items.len) {
         // only do these warnings if we didn't already warn about overflow or non-representable values
         if (e.res.val.compare(.lt, Value.zero, p.comp)) {
             const min_int = (Type{ .specifier = .int }).minInt(p.comp);
@@ -4170,7 +4170,7 @@ fn stmt(p: *Parser) Error!NodeIndex {
 
         // for (init
         const init_start = p.tok_i;
-        var err_start = p.comp.diag.list.items.len;
+        var err_start = p.comp.diagnostics.list.items.len;
         var init = if (!got_decl) try p.expr() else Result{};
         try init.saveValue(p);
         try init.maybeWarnUnused(p, init_start, err_start);
@@ -4190,7 +4190,7 @@ fn stmt(p: *Parser) Error!NodeIndex {
 
         // for (init; cond; incr
         const incr_start = p.tok_i;
-        err_start = p.comp.diag.list.items.len;
+        err_start = p.comp.diagnostics.list.items.len;
         var incr = try p.expr();
         try incr.maybeWarnUnused(p, incr_start, err_start);
         try incr.saveValue(p);
@@ -4276,7 +4276,7 @@ fn stmt(p: *Parser) Error!NodeIndex {
     if (try p.assembly(.stmt)) |some| return some;
 
     const expr_start = p.tok_i;
-    const err_start = p.comp.diag.list.items.len;
+    const err_start = p.comp.diagnostics.list.items.len;
 
     const e = try p.expr();
     if (e.node != .none) {
@@ -4818,7 +4818,7 @@ pub const Result = struct {
         defer p.strings.items.len = strings_top;
 
         try res.val.print(res.ty, p.comp, p.strings.writer());
-        return try p.comp.diag.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
+        return try p.comp.diagnostics.arena.allocator().dupe(u8, p.strings.items[strings_top..]);
     }
 
     fn expect(res: Result, p: *Parser) Error!void {
@@ -4843,7 +4843,7 @@ pub const Result = struct {
     fn maybeWarnUnused(res: Result, p: *Parser, expr_start: TokenIndex, err_start: usize) Error!void {
         if (res.ty.is(.void) or res.node == .none) return;
         // don't warn about unused result if the expression contained errors besides other unused results
-        for (p.comp.diag.list.items[err_start..]) |err_item| {
+        for (p.comp.diagnostics.list.items[err_start..]) |err_item| {
             if (err_item.tag != .unused_value) return;
         }
         var cur_node = res.node;
@@ -5868,13 +5868,13 @@ pub const Result = struct {
 /// expr : assignExpr (',' assignExpr)*
 fn expr(p: *Parser) Error!Result {
     var expr_start = p.tok_i;
-    var err_start = p.comp.diag.list.items.len;
+    var err_start = p.comp.diagnostics.list.items.len;
     var lhs = try p.assignExpr();
     if (p.tok_ids[p.tok_i] == .comma) try lhs.expect(p);
     while (p.eatToken(.comma)) |_| {
         try lhs.maybeWarnUnused(p, expr_start, err_start);
         expr_start = p.tok_i;
-        err_start = p.comp.diag.list.items.len;
+        err_start = p.comp.diagnostics.list.items.len;
 
         var rhs = try p.assignExpr();
         try rhs.expect(p);
@@ -6331,13 +6331,13 @@ fn mulExpr(p: *Parser) Error!Result {
 /// This will always be the last message, if present
 fn removeUnusedWarningForTok(p: *Parser, last_expr_tok: TokenIndex) void {
     if (last_expr_tok == 0) return;
-    if (p.comp.diag.list.items.len == 0) return;
+    if (p.comp.diagnostics.list.items.len == 0) return;
 
     const last_expr_loc = p.pp.tokens.items(.loc)[last_expr_tok];
-    const last_msg = p.comp.diag.list.items[p.comp.diag.list.items.len - 1];
+    const last_msg = p.comp.diagnostics.list.items[p.comp.diagnostics.list.items.len - 1];
 
     if (last_msg.tag == .unused_value and last_msg.loc.eql(last_expr_loc)) {
-        p.comp.diag.list.items.len = p.comp.diag.list.items.len - 1;
+        p.comp.diagnostics.list.items.len = p.comp.diagnostics.list.items.len - 1;
     }
 }
 
@@ -7162,7 +7162,7 @@ fn validateFieldAccess(p: *Parser, record_ty: Type, expr_ty: Type, field_name_to
     try expr_ty.print(mapper, p.comp.langopts, p.strings.writer());
     try p.strings.append('\'');
 
-    const duped = try p.comp.diag.arena.allocator().dupe(u8, p.strings.items);
+    const duped = try p.comp.diagnostics.arena.allocator().dupe(u8, p.strings.items);
     try p.errStr(.no_such_member, field_name_tok, duped);
     return error.ParsingFailed;
 }

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -31,8 +31,6 @@ const Builtins = @import("Builtins.zig");
 const Builtin = Builtins.Builtin;
 const target_util = @import("target.zig");
 
-const Parser = @This();
-
 const Switch = struct {
     default: ?TokenIndex = null,
     ranges: std.ArrayList(Range),
@@ -85,6 +83,8 @@ const ConstDeclFoldingMode = enum {
     /// folding const decls is prohibited; return an unavailable value
     no_const_decl_folding,
 };
+
+const Parser = @This();
 
 // values from preprocessor
 pp: *Preprocessor,

--- a/src/aro/Pragma.zig
+++ b/src/aro/Pragma.zig
@@ -4,9 +4,9 @@ const Preprocessor = @import("Preprocessor.zig");
 const Parser = @import("Parser.zig");
 const TokenIndex = @import("Tree.zig").TokenIndex;
 
-const Pragma = @This();
-
 pub const Error = Compilation.Error || error{ UnknownPragma, StopPreprocessing };
+
+const Pragma = @This();
 
 /// Called during Preprocessor.init
 beforePreprocess: ?*const fn (*Pragma, *Compilation) void = null,

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -364,9 +364,9 @@ fn preprocessExtra(pp: *Preprocessor, source: Source) MacroError!Token {
                         }
                         try pp.stringify(pp.top_expansion_buf.items);
                         const slice = pp.char_buf.items[char_top + 1 .. pp.char_buf.items.len - 2];
-                        const duped = try pp.comp.diag.arena.allocator().dupe(u8, slice);
+                        const duped = try pp.comp.diagnostics.arena.allocator().dupe(u8, slice);
 
-                        try pp.comp.diag.add(.{
+                        try pp.comp.addDiagnostic(.{
                             .tag = if (directive.id == .keyword_error) .error_directive else .warning_directive,
                             .loc = .{ .id = tok.source, .byte_offset = directive.start, .line = directive.line },
                             .extra = .{ .str = duped },
@@ -588,12 +588,12 @@ fn preprocessExtra(pp: *Preprocessor, source: Source) MacroError!Token {
                         continue;
                     },
                     .keyword_include_next => {
-                        try pp.comp.diag.add(.{
+                        try pp.comp.addDiagnostic(.{
                             .tag = .include_next,
                             .loc = .{ .id = tok.source, .byte_offset = directive.start, .line = directive.line },
                         }, &.{});
                         if (pp.include_depth == 0) {
-                            try pp.comp.diag.add(.{
+                            try pp.comp.addDiagnostic(.{
                                 .tag = .include_next_outside_header,
                                 .loc = .{ .id = tok.source, .byte_offset = directive.start, .line = directive.line },
                             }, &.{});
@@ -710,7 +710,7 @@ fn tokFromRaw(raw: RawToken) Token {
 }
 
 fn err(pp: *Preprocessor, raw: RawToken, tag: Diagnostics.Tag) !void {
-    try pp.comp.diag.add(.{
+    try pp.comp.addDiagnostic(.{
         .tag = tag,
         .loc = .{
             .id = raw.source,
@@ -721,7 +721,7 @@ fn err(pp: *Preprocessor, raw: RawToken, tag: Diagnostics.Tag) !void {
 }
 
 fn errStr(pp: *Preprocessor, tok: Token, tag: Diagnostics.Tag, str: []const u8) !void {
-    try pp.comp.diag.add(.{
+    try pp.comp.addDiagnostic(.{
         .tag = tag,
         .loc = tok.loc,
         .extra = .{ .str = str },
@@ -731,7 +731,7 @@ fn errStr(pp: *Preprocessor, tok: Token, tag: Diagnostics.Tag, str: []const u8) 
 fn fatal(pp: *Preprocessor, raw: RawToken, comptime fmt: []const u8, args: anytype) Compilation.Error {
     const source = pp.comp.getSource(raw.source);
     const line_col = source.lineCol(.{ .id = raw.source, .line = raw.line, .byte_offset = raw.start });
-    return pp.comp.diag.fatal(source.path, line_col.line, raw.line, line_col.col, fmt, args);
+    return pp.comp.diagnostics.fatal(source.path, line_col.line, raw.line, line_col.col, fmt, args);
 }
 
 fn verboseLog(pp: *Preprocessor, raw: RawToken, comptime fmt: []const u8, args: anytype) void {
@@ -799,7 +799,7 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
     for (pp.top_expansion_buf.items) |tok| {
         if (tok.id == .macro_ws) continue;
         if (!tok.id.validPreprocessorExprStart()) {
-            try pp.comp.diag.add(.{
+            try pp.comp.addDiagnostic(.{
                 .tag = .invalid_preproc_expr_start,
                 .loc = tok.loc,
             }, tok.expansionSlice());
@@ -824,7 +824,7 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
             .string_literal_utf_32,
             .string_literal_wide,
             => {
-                try pp.comp.diag.add(.{
+                try pp.comp.addDiagnostic(.{
                     .tag = .string_literal_in_pp_expr,
                     .loc = tok.loc,
                 }, tok.expansionSlice());
@@ -854,7 +854,7 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
             .arrow,
             .period,
             => {
-                try pp.comp.diag.add(.{
+                try pp.comp.addDiagnostic(.{
                     .tag = .invalid_preproc_operator,
                     .loc = tok.loc,
                 }, tok.expansionSlice());
@@ -939,7 +939,7 @@ fn handleKeywordDefined(pp: *Preprocessor, macro_tok: *Token, tokens: []const To
         return it.i;
     };
     if (!second.id.isMacroIdentifier()) {
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .macro_name_must_be_identifier,
             .loc = second.loc,
         }, second.expansionSlice());
@@ -950,11 +950,11 @@ fn handleKeywordDefined(pp: *Preprocessor, macro_tok: *Token, tokens: []const To
     const last = it.nextNoWS();
     if (last == null or last.?.id != .r_paren) {
         const tok = last orelse tokFromRaw(eof);
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .closing_paren,
             .loc = tok.loc,
         }, tok.expansionSlice());
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .to_match_paren,
             .loc = first.loc,
         }, first.expansionSlice());
@@ -1248,7 +1248,7 @@ fn stringify(pp: *Preprocessor, tokens: []const Token) !void {
     }
     if (pp.char_buf.items[pp.char_buf.items.len - 1] == '\\') {
         const tok = tokens[tokens.len - 1];
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .invalid_pp_stringify_escape,
             .loc = tok.loc,
         }, tok.expansionSlice());
@@ -1269,7 +1269,7 @@ fn reconstructIncludeString(pp: *Preprocessor, param_toks: []const Token) !?[]co
     const params = param_toks[begin..end];
 
     if (params.len == 0) {
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .expected_filename,
             .loc = param_toks[0].loc,
         }, param_toks[0].expansionSlice());
@@ -1277,7 +1277,7 @@ fn reconstructIncludeString(pp: *Preprocessor, param_toks: []const Token) !?[]co
     }
     // no string pasting
     if (params[0].id == .string_literal and params.len > 1) {
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .closing_paren,
             .loc = params[1].loc,
         }, params[1].expansionSlice());
@@ -1291,7 +1291,7 @@ fn reconstructIncludeString(pp: *Preprocessor, param_toks: []const Token) !?[]co
 
     const include_str = pp.char_buf.items[char_top..];
     if (include_str.len < 3) {
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .empty_filename,
             .loc = params[0].loc,
         }, params[0].expansionSlice());
@@ -1303,11 +1303,11 @@ fn reconstructIncludeString(pp: *Preprocessor, param_toks: []const Token) !?[]co
             if (include_str[include_str.len - 1] != '>') {
                 // Ugly hack to find out where the '>' should go, since we don't have the closing ')' location
                 const start = params[0].loc;
-                try pp.comp.diag.add(.{
+                try pp.comp.addDiagnostic(.{
                     .tag = .header_str_closing,
                     .loc = .{ .id = start.id, .byte_offset = start.byte_offset + @as(u32, @intCast(include_str.len)) + 1, .line = start.line },
                 }, params[0].expansionSlice());
-                try pp.comp.diag.add(.{
+                try pp.comp.addDiagnostic(.{
                     .tag = .header_str_match,
                     .loc = params[0].loc,
                 }, params[0].expansionSlice());
@@ -1317,7 +1317,7 @@ fn reconstructIncludeString(pp: *Preprocessor, param_toks: []const Token) !?[]co
         },
         '"' => return include_str,
         else => {
-            try pp.comp.diag.add(.{
+            try pp.comp.addDiagnostic(.{
                 .tag = .expected_filename,
                 .loc = params[0].loc,
             }, params[0].expansionSlice());
@@ -1347,7 +1347,7 @@ fn handleBuiltinMacro(pp: *Preprocessor, builtin: RawToken.Id, param_toks: []con
             }
             if (identifier == null and invalid == null) invalid = .{ .id = .eof, .loc = src_loc };
             if (invalid) |some| {
-                try pp.comp.diag.add(
+                try pp.comp.addDiagnostic(
                     .{ .tag = .feature_check_requires_identifier, .loc = some.loc },
                     some.expansionSlice(),
                 );
@@ -1396,7 +1396,7 @@ fn handleBuiltinMacro(pp: *Preprocessor, builtin: RawToken.Id, param_toks: []con
             };
             if (identifier == null and invalid == null) invalid = .{ .id = .eof, .loc = src_loc };
             if (invalid) |some| {
-                try pp.comp.diag.add(.{
+                try pp.comp.addDiagnostic(.{
                     .tag = .missing_tok_builtin,
                     .loc = some.loc,
                     .extra = .{ .tok_id_expected = .r_paren },
@@ -1417,7 +1417,7 @@ fn handleBuiltinMacro(pp: *Preprocessor, builtin: RawToken.Id, param_toks: []con
             const filename = include_str[1 .. include_str.len - 1];
             if (builtin == .macro_param_has_include or pp.include_depth == 0) {
                 if (builtin == .macro_param_has_include_next) {
-                    try pp.comp.diag.add(.{
+                    try pp.comp.addDiagnostic(.{
                         .tag = .include_next_outside_header,
                         .loc = src_loc,
                     }, &.{});
@@ -1541,7 +1541,7 @@ fn expandFuncMacro(
                 const arg = expanded_args.items[0];
                 const result = if (arg.len == 0) blk: {
                     const extra = Diagnostics.Message.Extra{ .arguments = .{ .expected = 1, .actual = 0 } };
-                    try pp.comp.diag.add(.{ .tag = .expected_arguments, .loc = loc, .extra = extra }, &.{});
+                    try pp.comp.addDiagnostic(.{ .tag = .expected_arguments, .loc = loc, .extra = extra }, &.{});
                     break :blk false;
                 } else try pp.handleBuiltinMacro(raw.id, arg, loc);
                 const start = pp.comp.generated_buf.items.len;
@@ -1554,7 +1554,7 @@ fn expandFuncMacro(
                 const not_found = "0\n";
                 const result = if (arg.len == 0) blk: {
                     const extra = Diagnostics.Message.Extra{ .arguments = .{ .expected = 1, .actual = 0 } };
-                    try pp.comp.diag.add(.{ .tag = .expected_arguments, .loc = loc, .extra = extra }, &.{});
+                    try pp.comp.addDiagnostic(.{ .tag = .expected_arguments, .loc = loc, .extra = extra }, &.{});
                     break :blk not_found;
                 } else res: {
                     var invalid: ?Token = null;
@@ -1570,7 +1570,7 @@ fn expandFuncMacro(
                     }
                     if (identifier == null and invalid == null) invalid = .{ .id = .eof, .loc = loc };
                     if (invalid) |some| {
-                        try pp.comp.diag.add(
+                        try pp.comp.addDiagnostic(
                             .{ .tag = .feature_check_requires_identifier, .loc = some.loc },
                             some.expansionSlice(),
                         );
@@ -1615,7 +1615,7 @@ fn expandFuncMacro(
                     },
                 };
                 if (string == null and invalid == null) invalid = .{ .loc = loc, .id = .eof };
-                if (invalid) |some| try pp.comp.diag.add(
+                if (invalid) |some| try pp.comp.addDiagnostic(
                     .{ .tag = .pragma_operator_string_literal, .loc = some.loc },
                     some.expansionSlice(),
                 ) else try pp.pragmaOperator(string.?, loc);
@@ -1825,7 +1825,7 @@ fn collectMacroFuncArguments(
                     try args.append(owned);
                 }
                 tokenizer.* = saved_tokenizer;
-                try pp.comp.diag.add(
+                try pp.comp.addDiagnostic(
                     .{ .tag = .unterminated_macro_arg_list, .loc = name_tok.loc },
                     name_tok.expansionSlice(),
                 );
@@ -1969,7 +1969,7 @@ fn expandMacroExhaustive(
                         .arguments = .{ .expected = @intCast(macro.params.len), .actual = args_count },
                     };
                     if (macro.var_args and args_count < macro.params.len) {
-                        try pp.comp.diag.add(
+                        try pp.comp.addDiagnostic(
                             .{ .tag = .expected_at_least_arguments, .loc = buf.items[idx].loc, .extra = extra },
                             buf.items[idx].expansionSlice(),
                         );
@@ -1978,7 +1978,7 @@ fn expandMacroExhaustive(
                         continue;
                     }
                     if (!macro.var_args and args_count != macro.params.len) {
-                        try pp.comp.diag.add(
+                        try pp.comp.addDiagnostic(
                             .{ .tag = .expected_arguments, .loc = buf.items[idx].loc, .extra = extra },
                             buf.items[idx].expansionSlice(),
                         );
@@ -2030,7 +2030,7 @@ fn expandMacroExhaustive(
                         try tok.addExpansionLocation(pp.gpa, &.{macro_tok.loc});
                         try tok.addExpansionLocation(pp.gpa, macro_expansion_locs);
                         if (tok.id == .keyword_defined and eval_ctx == .expr) {
-                            try pp.comp.diag.add(.{
+                            try pp.comp.addDiagnostic(.{
                                 .tag = .expansion_to_defined,
                                 .loc = tok.loc,
                             }, tok.expansionSlice());
@@ -2175,7 +2175,7 @@ fn pasteTokens(pp: *Preprocessor, lhs_toks: *ExpandBuf, rhs_toks: []const Token)
         try pp.errStr(
             lhs,
             .pasting_formed_invalid,
-            try pp.comp.diag.arena.allocator().dupe(u8, pp.comp.generated_buf.items[start..end]),
+            try pp.comp.diagnostics.arena.allocator().dupe(u8, pp.comp.generated_buf.items[start..end]),
         );
         try lhs_toks.append(tokFromRaw(next));
     }
@@ -2201,14 +2201,14 @@ fn defineMacro(pp: *Preprocessor, name_tok: RawToken, macro: Macro) Error!void {
     const gop = try pp.defines.getOrPut(pp.gpa, name_str);
     if (gop.found_existing and !gop.value_ptr.eql(macro, pp)) {
         const tag: Diagnostics.Tag = if (gop.value_ptr.is_builtin) .builtin_macro_redefined else .macro_redefined;
-        const start = pp.comp.diag.list.items.len;
-        try pp.comp.diag.add(.{
+        const start = pp.comp.diagnostics.list.items.len;
+        try pp.comp.addDiagnostic(.{
             .tag = tag,
             .loc = .{ .id = name_tok.source, .byte_offset = name_tok.start, .line = name_tok.line },
             .extra = .{ .str = name_str },
         }, &.{});
-        if (!gop.value_ptr.is_builtin and pp.comp.diag.list.items.len != start) {
-            try pp.comp.diag.add(.{
+        if (!gop.value_ptr.is_builtin and pp.comp.diagnostics.list.items.len != start) {
+            try pp.comp.addDiagnostic(.{
                 .tag = .previous_definition,
                 .loc = gop.value_ptr.loc,
             }, &.{});
@@ -2644,7 +2644,7 @@ fn embed(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!void {
             try pp.errStr(
                 tokFromRaw(param_first),
                 .unsupported_embed_param,
-                try pp.comp.diag.arena.allocator().dupe(u8, param),
+                try pp.comp.diagnostics.arena.allocator().dupe(u8, param),
             );
             pp.token_buf.items.len = start;
         }
@@ -2699,7 +2699,7 @@ fn include(pp: *Preprocessor, tokenizer: *Tokenizer, which: Compilation.WhichInc
     pp.include_depth += 1;
     defer pp.include_depth -= 1;
     if (pp.include_depth > max_include_depth) {
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .too_many_includes,
             .loc = .{ .id = first.source, .byte_offset = first.start, .line = first.line },
         }, &.{});
@@ -2787,7 +2787,7 @@ fn pragma(pp: *Preprocessor, tokenizer: *Tokenizer, pragma_tok: RawToken, operat
             else => |e| return e,
         };
     }
-    return pp.comp.diag.add(.{
+    return pp.comp.addDiagnostic(.{
         .tag = .unknown_pragma,
         .loc = pragma_name_tok.loc,
     }, pragma_name_tok.expansionSlice());
@@ -2817,7 +2817,7 @@ fn findIncludeFilenameToken(
                 else => {},
             }
         }
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .header_str_closing,
             .loc = .{ .id = first.source, .byte_offset = tokenizer.index, .line = first.line },
         }, &.{});

--- a/src/aro/Source.zig
+++ b/src/aro/Source.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const Source = @This();
 
 pub const Id = enum(u32) {
     unused = 0,
@@ -26,6 +25,8 @@ pub const Location = struct {
         return a.id == b.id and a.byte_offset == b.byte_offset and a.line == b.line;
     }
 };
+
+const Source = @This();
 
 path: []const u8,
 buf: []const u8,

--- a/src/aro/StringInterner.zig
+++ b/src/aro/StringInterner.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const mem = std.mem;
 const Compilation = @import("Compilation.zig");
 
-const StringInterner = @This();
-
 const StringToIdMap = std.StringHashMapUnmanaged(StringId);
 
 pub const StringId = enum(u32) {
@@ -43,6 +41,8 @@ pub const TypeMapper = struct {
         }
     }
 };
+
+const StringInterner = @This();
 
 string_table: StringToIdMap = .{},
 next_id: StringId = @enumFromInt(@intFromEnum(StringId.empty) + 1),

--- a/src/aro/SymbolStack.zig
+++ b/src/aro/SymbolStack.zig
@@ -11,8 +11,6 @@ const Parser = @import("Parser.zig");
 const Value = @import("Value.zig");
 const StringId = @import("StringInterner.zig").StringId;
 
-const SymbolStack = @This();
-
 pub const Symbol = struct {
     name: StringId,
     ty: Type,
@@ -32,6 +30,8 @@ pub const Kind = enum {
     enumeration,
     constexpr,
 };
+
+const SymbolStack = @This();
 
 syms: std.MultiArrayList(Symbol) = .{},
 scopes: std.ArrayListUnmanaged(u32) = .{},

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -4,8 +4,6 @@ const Compilation = @import("Compilation.zig");
 const Source = @import("Source.zig");
 const LangOpts = @import("LangOpts.zig");
 
-const Tokenizer = @This();
-
 pub const Token = struct {
     id: Id,
     source: Source.Id,
@@ -1016,6 +1014,8 @@ pub const Token = struct {
         .{ "__builtin_types_compatible_p", .builtin_types_compatible_p },
     });
 };
+
+const Tokenizer = @This();
 
 buf: []const u8,
 index: u32 = 0,

--- a/src/aro/Toolchain.zig
+++ b/src/aro/Toolchain.zig
@@ -9,8 +9,6 @@ const Linux = @import("toolchains/Linux.zig");
 const Multilib = @import("Driver/Multilib.zig");
 const Filesystem = @import("Driver/Filesystem.zig").Filesystem;
 
-const Toolchain = @This();
-
 pub const PathList = std.ArrayListUnmanaged([]const u8);
 
 pub const RuntimeLibKind = enum {
@@ -48,6 +46,8 @@ const Inner = union(enum) {
         }
     }
 };
+
+const Toolchain = @This();
 
 filesystem: Filesystem = .{ .real = {} },
 driver: *Driver,

--- a/src/aro/Toolchain.zig
+++ b/src/aro/Toolchain.zig
@@ -152,7 +152,7 @@ pub fn getLinkerPath(tc: *const Toolchain, buf: []u8) ![]const u8 {
     // to a relative path is surprising. This is more complex due to priorities
     // among -B, COMPILER_PATH and PATH. --ld-path= should be used instead.
     if (mem.indexOfScalar(u8, use_linker, '/') != null) {
-        try tc.driver.comp.diag.add(.{ .tag = .fuse_ld_path }, &.{});
+        try tc.driver.comp.addDiagnostic(.{ .tag = .fuse_ld_path }, &.{});
     }
 
     if (std.fs.path.isAbsolute(use_linker)) {
@@ -402,7 +402,7 @@ fn getUnwindLibKind(tc: *const Toolchain) !UnwindLibKind {
         return .libgcc;
     } else if (mem.eql(u8, libname, "libunwind")) {
         if (tc.getRuntimeLibKind() == .libgcc) {
-            try tc.driver.comp.diag.add(.{ .tag = .incompatible_unwindlib }, &.{});
+            try tc.driver.comp.addDiagnostic(.{ .tag = .incompatible_unwindlib }, &.{});
         }
         return .compiler_rt;
     } else {
@@ -479,7 +479,7 @@ pub fn addRuntimeLibs(tc: *const Toolchain, argv: *std.ArrayList([]const u8)) !v
             if (target_util.isKnownWindowsMSVCEnvironment(target)) {
                 const rtlib_str = tc.driver.rtlib orelse system_defaults.rtlib;
                 if (!mem.eql(u8, rtlib_str, "platform")) {
-                    try tc.driver.comp.diag.add(.{ .tag = .unsupported_rtlib_gcc, .extra = .{ .str = "MSVC" } }, &.{});
+                    try tc.driver.comp.addDiagnostic(.{ .tag = .unsupported_rtlib_gcc, .extra = .{ .str = "MSVC" } }, &.{});
                 }
             } else {
                 try tc.addLibGCC(argv);

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -79,7 +79,7 @@ pub const Token = struct {
     pub fn checkMsEof(tok: Token, source: Source, comp: *Compilation) !void {
         std.debug.assert(tok.id == .eof);
         if (source.buf.len > tok.loc.byte_offset and source.buf[tok.loc.byte_offset] == 0x1A) {
-            try comp.diag.add(.{
+            try comp.addDiagnostic(.{
                 .tag = .ctrl_z_eof,
                 .loc = .{
                     .id = source.id,

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -2,13 +2,12 @@ const std = @import("std");
 const Interner = @import("backend").Interner;
 const Type = @import("Type.zig");
 const Tokenizer = @import("Tokenizer.zig");
+const CodeGen = @import("CodeGen.zig");
 const Compilation = @import("Compilation.zig");
 const Source = @import("Source.zig");
 const Attribute = @import("Attribute.zig");
 const Value = @import("Value.zig");
 const StringInterner = @import("StringInterner.zig");
-
-const Tree = @This();
 
 pub const Token = struct {
     id: Id,
@@ -99,6 +98,8 @@ pub const TokenIndex = u32;
 pub const NodeIndex = enum(u32) { none, _ };
 pub const ValueMap = std.AutoHashMap(NodeIndex, Value);
 
+const Tree = @This();
+
 comp: *Compilation,
 arena: std.heap.ArenaAllocator,
 generated: []const u8,
@@ -107,6 +108,8 @@ nodes: Node.List.Slice,
 data: []const NodeIndex,
 root_decls: []const NodeIndex,
 value_map: ValueMap,
+
+pub const genIr = CodeGen.genIr;
 
 pub fn deinit(tree: *Tree) void {
     tree.comp.gpa.free(tree.root_decls);

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -10,8 +10,6 @@ const StringId = StringInterner.StringId;
 const target_util = @import("target.zig");
 const LangOpts = @import("LangOpts.zig");
 
-const Type = @This();
-
 pub const Qualifiers = packed struct {
     @"const": bool = false,
     atomic: bool = false,
@@ -408,6 +406,8 @@ pub const Specifier = enum {
     /// C23 nullptr_t
     nullptr_t,
 };
+
+const Type = @This();
 
 /// All fields of Type except data may be mutated
 data: union {

--- a/src/aro/pragmas/message.zig
+++ b/src/aro/pragmas/message.zig
@@ -32,7 +32,7 @@ fn preprocessorHandler(_: *Pragma, pp: *Preprocessor, start_idx: TokenIndex) Pra
 
     const str = Pragma.pasteTokens(pp, start_idx + 1) catch |err| switch (err) {
         error.ExpectedStringLiteral => {
-            return pp.comp.diag.add(.{
+            return pp.comp.addDiagnostic(.{
                 .tag = .pragma_requires_string_literal,
                 .loc = message_tok.loc,
                 .extra = .{ .str = "message" },
@@ -45,6 +45,6 @@ fn preprocessorHandler(_: *Pragma, pp: *Preprocessor, start_idx: TokenIndex) Pra
         message_expansion_locs[message_expansion_locs.len - 1]
     else
         message_tok.loc;
-    const extra = Diagnostics.Message.Extra{ .str = try pp.comp.diag.arena.allocator().dupe(u8, str) };
-    return pp.comp.diag.add(.{ .tag = .pragma_message, .loc = loc, .extra = extra }, &.{});
+    const extra = Diagnostics.Message.Extra{ .str = try pp.comp.diagnostics.arena.allocator().dupe(u8, str) };
+    return pp.comp.addDiagnostic(.{ .tag = .pragma_message, .loc = loc, .extra = extra }, &.{});
 }

--- a/src/aro/pragmas/once.zig
+++ b/src/aro/pragmas/once.zig
@@ -42,7 +42,7 @@ fn preprocessorHandler(pragma: *Pragma, pp: *Preprocessor, start_idx: TokenIndex
     const name_tok = pp.tokens.get(start_idx);
     const next = pp.tokens.get(start_idx + 1);
     if (next.id != .nl) {
-        try pp.comp.diag.add(.{
+        try pp.comp.addDiagnostic(.{
             .tag = .extra_tokens_directive_end,
             .loc = name_tok.loc,
         }, next.expansionSlice());

--- a/src/aro/pragmas/pack.zig
+++ b/src/aro/pragmas/pack.zig
@@ -34,7 +34,7 @@ fn parserHandler(pragma: *Pragma, p: *Parser, start_idx: TokenIndex) Compilation
     var idx = start_idx + 1;
     const l_paren = p.pp.tokens.get(idx);
     if (l_paren.id != .l_paren) {
-        return p.comp.diag.add(.{
+        return p.comp.addDiagnostic(.{
             .tag = .pragma_pack_lparen,
             .loc = l_paren.loc,
         }, l_paren.expansionSlice());

--- a/src/aro/toolchains/Linux.zig
+++ b/src/aro/toolchains/Linux.zig
@@ -385,6 +385,7 @@ test Linux {
     comp.environment = .{
         .path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     };
+    defer comp.environment = .{};
 
     const raw_triple = "x86_64-linux-gnu";
     const cross = std.zig.CrossTarget.parse(.{ .arch_os_abi = raw_triple }) catch unreachable;

--- a/src/backend/Interner.zig
+++ b/src/backend/Interner.zig
@@ -1,4 +1,3 @@
-const Interner = @This();
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
@@ -6,6 +5,8 @@ const BigIntConst = std.math.big.int.Const;
 const BigIntMutable = std.math.big.int.Mutable;
 const Hash = std.hash.Wyhash;
 const Limb = std.math.big.Limb;
+
+const Interner = @This();
 
 map: std.AutoArrayHashMapUnmanaged(void, void) = .{},
 items: std.MultiArrayList(struct {

--- a/src/backend/Object/Elf.zig
+++ b/src/backend/Object/Elf.zig
@@ -3,8 +3,6 @@ const Allocator = std.mem.Allocator;
 const Target = std.Target;
 const Object = @import("../Object.zig");
 
-const Elf = @This();
-
 const Section = struct {
     data: std.ArrayList(u8),
     relocations: std.ArrayListUnmanaged(Relocation) = .{},
@@ -34,6 +32,8 @@ const symtab_index = 2;
 const strtab_default = "\x00.strtab\x00.symtab\x00";
 const strtab_name = 1;
 const symtab_name = "\x00.strtab\x00".len;
+
+const Elf = @This();
 
 obj: Object,
 /// The keys are owned by the Codegen.tree

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,11 +1,10 @@
 const std = @import("std");
-const mem = std.mem;
 const Allocator = mem.Allocator;
+const mem = std.mem;
 const process = std.process;
 const aro = @import("aro");
 const Compilation = aro.Compilation;
 const Driver = aro.Driver;
-const target_util = aro.target_util;
 const Toolchain = aro.Toolchain;
 
 var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
@@ -27,37 +26,25 @@ pub fn main() u8 {
 
     const args = process.argsAlloc(arena) catch {
         std.debug.print("out of memory\n", .{});
-        if (fast_exit) std.process.exit(1);
+        if (fast_exit) process.exit(1);
         return 1;
     };
 
     const aro_name = std.fs.selfExePathAlloc(gpa) catch {
         std.debug.print("unable to find Aro executable path\n", .{});
-        if (fast_exit) std.process.exit(1);
+        if (fast_exit) process.exit(1);
         return 1;
     };
     defer gpa.free(aro_name);
 
-    var comp = Compilation.init(gpa);
+    var comp = Compilation.initDefault(gpa) catch |er| switch (er) {
+        error.OutOfMemory => {
+            std.debug.print("out of memory\n", .{});
+            if (fast_exit) process.exit(1);
+            return 1;
+        },
+    };
     defer comp.deinit();
-
-    comp.environment.loadAll(gpa) catch |er| switch (er) {
-        error.OutOfMemory => {
-            std.debug.print("out of memory\n", .{});
-            if (fast_exit) std.process.exit(1);
-            return 1;
-        },
-    };
-    defer comp.environment.deinit(gpa);
-
-    comp.addDefaultPragmaHandlers() catch |er| switch (er) {
-        error.OutOfMemory => {
-            std.debug.print("out of memory\n", .{});
-            if (fast_exit) std.process.exit(1);
-            return 1;
-        },
-    };
-    comp.langopts.setEmulatedCompiler(target_util.systemCompiler(comp.target));
 
     var driver: Driver = .{ .comp = &comp, .aro_name = aro_name };
     defer driver.deinit();
@@ -65,29 +52,29 @@ pub fn main() u8 {
     var toolchain: Toolchain = .{ .driver = &driver, .arena = arena };
     defer toolchain.deinit();
 
-    driver.main(&toolchain, args) catch |er| switch (er) {
+    driver.main(&toolchain, args, fast_exit) catch |er| switch (er) {
         error.OutOfMemory => {
             std.debug.print("out of memory\n", .{});
-            if (fast_exit) std.process.exit(1);
+            if (fast_exit) process.exit(1);
             return 1;
         },
         error.StreamTooLong => {
             std.debug.print("maximum file size exceeded\n", .{});
-            if (fast_exit) std.process.exit(1);
+            if (fast_exit) process.exit(1);
             return 1;
         },
         error.FatalError => {
             comp.renderErrors();
-            if (fast_exit) std.process.exit(1);
+            if (fast_exit) process.exit(1);
             return 1;
         },
         error.TooManyMultilibs => {
             std.debug.print("found more than one multilib with the same priority\n", .{});
-            if (fast_exit) std.process.exit(1);
+            if (fast_exit) process.exit(1);
             return 1;
         },
         else => |err| return err,
     };
-    if (fast_exit) std.process.exit(@intFromBool(comp.diag.errors != 0));
+    if (fast_exit) process.exit(@intFromBool(comp.diag.errors != 0));
     return @intFromBool(comp.diag.errors != 0);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -75,6 +75,6 @@ pub fn main() u8 {
         },
         else => |err| return err,
     };
-    if (fast_exit) process.exit(@intFromBool(comp.diag.errors != 0));
-    return @intFromBool(comp.diag.errors != 0);
+    if (fast_exit) process.exit(@intFromBool(comp.diagnostics.errors != 0));
+    return @intFromBool(comp.diagnostics.errors != 0);
 }

--- a/test/cases/adjust diagnostic levels.c
+++ b/test/cases/adjust diagnostic levels.c
@@ -23,5 +23,8 @@
 struct Foo {};
 
 #define EXPECTED_ERRORS "adjust diagnostic levels.c:2:9: warning: 'FOO' macro redefined [-Wmacro-redefined]" \
+	"adjust diagnostic levels.c:1:9: note: previous definition is here" \
 	"adjust diagnostic levels.c:6:9: error: 'BAR' macro redefined [-Werror,-Wmacro-redefined]" \
+	"adjust diagnostic levels.c:5:9: note: previous definition is here" \
 	"adjust diagnostic levels.c:18:9: warning: 'QUX' macro redefined [-Wmacro-redefined]" \
+	"adjust diagnostic levels.c:17:9: note: previous definition is here" \

--- a/test/cases/macro redefinition.c
+++ b/test/cases/macro redefinition.c
@@ -13,5 +13,8 @@
 #define QUX 1
 
 #define EXPECTED_ERRORS "macro redefinition.c:2:9: warning: 'FOO' macro redefined [-Wmacro-redefined]" \
+    "macro redefinition.c:1:9: note: previous definition is here" \
     "macro redefinition.c:3:9: warning: 'FOO' macro redefined [-Wmacro-redefined]" \
+    "macro redefinition.c:2:9: note: previous definition is here" \
     "macro redefinition.c:10:9: warning: 'BAZ' macro redefined [-Wmacro-redefined]" \
+    "macro redefinition.c:9:9: note: previous definition is here" \

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -303,13 +303,13 @@ fn singleRun(alloc: std.mem.Allocator, test_dir: []const u8, test_case: TestCase
 
     const expected = compErr.get(buf[0..buf_strm.pos]) orelse ExpectedFailure{};
 
-    if (comp.diag.list.items.len == 0 and expected.any()) {
+    if (comp.diagnostics.list.items.len == 0 and expected.any()) {
         stats.progress.log("\nTest Passed when failures expected:\n\texpected:{any}\n", .{expected});
     } else {
         var m = aro.Diagnostics.defaultMsgWriter(&comp);
         defer m.deinit();
         var actual = ExpectedFailure{};
-        for (comp.diag.list.items) |msg| {
+        for (comp.diagnostics.list.items) |msg| {
             switch (msg.kind) {
                 .@"fatal error", .@"error" => {},
                 else => continue,
@@ -332,7 +332,7 @@ fn singleRun(alloc: std.mem.Allocator, test_dir: []const u8, test_case: TestCase
         }
         if (!expected.eql(actual)) {
             m.print("\nexp:{any}\nact:{any}\n", .{ expected, actual });
-            for (comp.diag.list.items) |msg| {
+            for (comp.diagnostics.list.items) |msg| {
                 aro.Diagnostics.renderMessage(&comp, &m, msg);
             }
             stats.recordResult(.fail);

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -217,7 +217,7 @@ pub fn main() !void {
 
         const builtin_macros = try comp.generateBuiltinMacros(system_defines);
 
-        comp.diag.errors = 0;
+        comp.diagnostics.errors = 0;
         var pp = aro.Preprocessor.init(&comp);
         defer pp.deinit();
         if (only_preprocess) {
@@ -259,7 +259,7 @@ pub fn main() !void {
                 }
             } else {
                 comp.renderErrors();
-                if (comp.diag.errors != 0) {
+                if (comp.diagnostics.errors != 0) {
                     fail_count += 1;
                     continue;
                 }
@@ -373,7 +373,7 @@ pub fn main() !void {
         comp.renderErrors();
 
         if (pp.defines.get("EXPECTED_OUTPUT")) |macro| blk: {
-            if (comp.diag.errors != 0) break :blk;
+            if (comp.diagnostics.errors != 0) break :blk;
 
             if (macro.is_func) {
                 fail_count += 1;
@@ -442,7 +442,7 @@ pub fn main() !void {
             continue;
         }
 
-        if (comp.diag.errors != 0) fail_count += 1 else ok_count += 1;
+        if (comp.diagnostics.errors != 0) fail_count += 1 else ok_count += 1;
     }
 
     root_node.end();
@@ -460,7 +460,7 @@ pub fn main() !void {
 fn checkExpectedErrors(pp: *aro.Preprocessor, progress: *std.Progress, buf: *std.ArrayList(u8)) !?bool {
     const macro = pp.defines.get("EXPECTED_ERRORS") orelse return null;
 
-    const expected_count = pp.comp.diag.list.items.len;
+    const expected_count = pp.comp.diagnostics.list.items.len;
     var m = MsgWriter.init(pp.comp.gpa);
     defer m.deinit();
     aro.Diagnostics.renderMessages(pp.comp, &m);

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -164,12 +164,12 @@ pub fn main() !void {
     const cases_include_dir = try std.fs.path.join(gpa, &.{ args[1], "include" });
     defer gpa.free(cases_include_dir);
 
-    try initial_comp.include_dirs.append(cases_include_dir);
+    try initial_comp.include_dirs.append(gpa, cases_include_dir);
 
     const cases_next_include_dir = try std.fs.path.join(gpa, &.{ args[1], "include", "next" });
     defer gpa.free(cases_next_include_dir);
 
-    try initial_comp.include_dirs.append(cases_next_include_dir);
+    try initial_comp.include_dirs.append(gpa, cases_next_include_dir);
 
     try initial_comp.addDefaultPragmaHandlers();
     try initial_comp.defineSystemIncludes(test_dir);
@@ -189,9 +189,10 @@ pub fn main() !void {
         var comp = initial_comp;
         defer {
             // preserve some values
-            comp.include_dirs = @TypeOf(comp.include_dirs).init(gpa);
-            comp.system_include_dirs = @TypeOf(comp.system_include_dirs).init(gpa);
-            comp.pragma_handlers = @TypeOf(comp.pragma_handlers).init(gpa);
+            comp.include_dirs = .{};
+            comp.system_include_dirs = .{};
+            comp.pragma_handlers = .{};
+            comp.environment = .{};
             // reset everything else
             comp.deinit();
         }


### PR DESCRIPTION
* document functions that may call `exit`
* add `initDefault` helpers to Compilation and Preprocessor
* add `preprocessSources` helper to process sources into a parsable result
* adjust API for moving from one step of the pipeline to the next
* only exit from `invokeLinker` if `fast_exit` is set
* make `fast_exit` a parameter of `Driver.main`
* report fatal error when linker invocation fails
* move `@This()` to always be before first field
* add helper for rendering Ir to a unique Object

Closes #365