### PR TITLE
Update fuzz step and instructions and fix a bug it caught

### DIFF
--- a/build/ZigLibDir.zig
+++ b/build/ZigLibDir.zig
@@ -1,0 +1,65 @@
+//! Step for determining the zig lib dir and various subdirectories via `zig env`
+
+const std = @import("std");
+const Step = std.Build.Step;
+const ZigLibDir = @This();
+const LazyPath = std.Build.LazyPath;
+
+step: Step,
+/// path to zig's lib directory
+lib_dir: std.Build.GeneratedFile,
+/// path to compiler-rt directory
+compiler_rt: std.Build.GeneratedFile,
+/// path to directory which has zig.h
+include: std.Build.GeneratedFile,
+
+pub fn create(owner: *std.Build) !*ZigLibDir {
+    const self = try owner.allocator.create(ZigLibDir);
+    const name = "zig lib dir";
+    self.* = .{
+        .step = Step.init(.{
+            .id = .custom,
+            .name = name,
+            .owner = owner,
+            .makeFn = make,
+        }),
+        .lib_dir = .{ .step = &self.step },
+        .compiler_rt = .{ .step = &self.step },
+        .include = .{ .step = &self.step },
+    };
+    return self;
+}
+
+const ZigEnv = struct {
+    lib_dir: []const u8,
+};
+
+fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+    _ = prog_node;
+
+    const b = step.owner;
+    const self = @fieldParentPtr(ZigLibDir, "step", step);
+
+    const zig_env_args: [2][]const u8 = .{ b.zig_exe, "env" };
+    var out_code: u8 = undefined;
+    const zig_env = try b.runAllowFail(&zig_env_args, &out_code, .Ignore);
+
+    const parsed_str = try std.json.parseFromSlice(ZigEnv, b.allocator, zig_env, .{ .ignore_unknown_fields = true });
+    defer parsed_str.deinit();
+
+    self.lib_dir.path = parsed_str.value.lib_dir;
+    self.compiler_rt.path = try std.fs.path.join(b.allocator, &[_][]const u8{ parsed_str.value.lib_dir, "compiler_rt.zig" });
+    self.include.path = try std.fs.path.join(b.allocator, &[_][]const u8{ parsed_str.value.lib_dir, "include" });
+}
+
+pub fn getLibPath(self: *ZigLibDir) std.Build.LazyPath {
+    return .{ .generated = &self.lib_dir };
+}
+
+pub fn getCompilerRTPath(self: *ZigLibDir) std.Build.LazyPath {
+    return .{ .generated = &self.compiler_rt };
+}
+
+pub fn getIncludePath(self: *ZigLibDir) std.Build.LazyPath {
+    return .{ .generated = &self.include };
+}

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -323,7 +323,7 @@ fn expectIdentifier(p: *Parser) Error!TokenIndex {
         return p.errExpectedToken(.identifier, actual);
     }
 
-    return (try p.eatIdentifier()) orelse unreachable;
+    return (try p.eatIdentifier()) orelse error.ParsingFailed;
 }
 
 fn eatToken(p: *Parser, id: Token.Id) ?TokenIndex {
@@ -4376,7 +4376,7 @@ fn stmt(p: *Parser) Error!NodeIndex {
 /// | keyword_default ':' stmt
 fn labeledStmt(p: *Parser) Error!?NodeIndex {
     if ((p.tok_ids[p.tok_i] == .identifier or p.tok_ids[p.tok_i] == .extended_identifier) and p.tok_ids[p.tok_i + 1] == .colon) {
-        const name_tok = p.expectIdentifier() catch unreachable;
+        const name_tok = try p.expectIdentifier();
         const str = p.tokSlice(name_tok);
         if (p.findLabel(str)) |some| {
             try p.errStr(.duplicate_label, name_tok, str);
@@ -7458,7 +7458,7 @@ fn primaryExpr(p: *Parser) Error!Result {
     }
     switch (p.tok_ids[p.tok_i]) {
         .identifier, .extended_identifier => {
-            const name_tok = p.expectIdentifier() catch unreachable;
+            const name_tok = try p.expectIdentifier();
             const name = p.tokSlice(name_tok);
             const interned_name = try StrInt.intern(p.comp, name);
             if (p.syms.findSymbol(interned_name)) |sym| {

--- a/test/README.MD
+++ b/test/README.MD
@@ -75,19 +75,26 @@ If a test case is currently broken, it should be commented and a `TESTS_SKIPPED`
 ---
 ## Running fuzz tests
 Fuzz testing requires [AFLplusplus](https://github.com/AFLplusplus/AFLplusplus). Run `zig build fuzz` to build the fuzz target,
-then `afl-fuzz -i test/cases -o test/fuzz-output -- ./zig-out/bin/fuzz`
+then `afl-fuzz -i test/cases -o test/fuzz-output -- ./zig-out/bin/arofuzz`
 
 A Dockerfile is provided to make it easier to get started with fuzzing. It requires two build args,
-`ZIG_VERSION` and `ZIG_SIG`. `ZIG_VERSION` should be the release filename from https://ziglang.org/download/, *without*
-the `.tar.xz` extension. `ZIG_ZIG` should be the SHA256 signature for the file.
+`ZIG_VERSION` and `ZIG_PUBKEY`. `ZIG_VERSION` should be the release filename from https://ziglang.org/download/, *without*
+the `.tar.xz` extension. `ZIG_PUBKEY` should be the minisign public key on https://ziglang.org/download/. You can also
+provide `USER_ID` and `GROUP_ID` so that files created in the container have the same user id and group id as files on
+your host system.
+
+Please read https://github.com/AFLplusplus/AFLplusplus/blob/stable/docs/fuzzing_in_depth.md#0-common-sense-risks before
+running the fuzzer on your system.
 
 ```sh-session
-docker build -t aro-fuzz \
-    --build-arg ZIG_VERSION=zig-linux-x86_64-0.9.0-dev.1903+2af94e76a \
-    --build-arg ZIG_SIG=79f0c9dceb254b55c0765e50a96a8f8b8e51ab63b06c80248fe90f0f69597410 \
-    test/docker/fuzz
 
-docker run --rm -it -v $PWD:/arocc -w /arocc aro-fuzz
-zig build fuzz
-afl-fuzz -i test/cases -o test/fuzz-output -- ./zig-out/bin/fuzz
+docker build -t aro-fuzz \
+    --build-arg ZIG_VERSION=zig-linux-x86_64-0.12.0-dev.1595+70d8baaec \
+    --build-arg ZIG_PUBKEY=RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U \
+    --build-arg USER_ID=$(id -u ${USER}) \
+    --build-arg GROUP_ID=$(id -g ${USER}) \
+    test/docker/fuzz
+docker run --rm -it -v $PWD:/arocc -w /arocc --mount type=tmpfs,destination=/ramdisk -e AFL_TMPDIR=/ramdisk aro-fuzz
+zig build fuzz  # This might take a while
+afl-fuzz -i test/cases -o test/fuzz-output -- ./zig-out/bin/arofuzz
 ```

--- a/test/docker/fuzz/Dockerfile
+++ b/test/docker/fuzz/Dockerfile
@@ -1,67 +1,46 @@
-FROM ubuntu:20.04
+FROM alpine:latest as build
 
-ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /usr/src/minisign
 
-env NO_ARCH_OPT 1
+RUN apk add --no-cache build-base cmake curl pkgconfig
+RUN apk add --no-cache upx ||:
+RUN curl https://download.libsodium.org/libsodium/releases/LATEST.tar.gz | tar xzvf - && cd libsodium-stable && env CFLAGS="-Os" CPPFLAGS="-DED25519_NONDETERMINISTIC=1" ./configure --disable-dependency-tracking && make -j$(nproc) check && make install && cd .. && rm -fr libsodium-stable
 
-RUN apt-get update && \
-    apt-get -y install --no-install-suggests --no-install-recommends \
-    automake \
-    ninja-build \
-    bison flex \
-    build-essential \
-    git \
-    python3 python3-dev python3-setuptools python-is-python3 \
-    libtool libtool-bin \
-    libglib2.0-dev \
-    wget jupp nano bash-completion less \
-    apt-utils apt-transport-https ca-certificates gnupg dialog \
-    libpixman-1-dev \
-    gnuplot-nox \
-    && rm -rf /var/lib/apt/lists/*
+COPY ./ ./
+RUN wget https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11.tar.gz
+RUN tar -xf minisign-0.11.tar.gz
+RUN mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_STATIC_EXECUTABLES=1 .. && make -j$(nproc)
+RUN upx --lzma build/minisign ||:
 
-RUN echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" >> /etc/apt/sources.list && \
-    wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+FROM aflplusplus/aflplusplus
+COPY --from=build /usr/src/minisign/build/minisign /usr/local/bin/
 
-RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main" >> /etc/apt/sources.list && \
-    apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 1E9377A2BA9EF27F
-
-RUN apt-get update && apt-get full-upgrade -y && \
-    apt-get -y install --no-install-suggests --no-install-recommends \
-    gcc-10 g++-10 gcc-10-plugin-dev gcc-10-multilib gcc-multilib gdb lcov \
-    clang-13 clang-tools-13 libc++1-13 libc++-13-dev \
-    libc++abi1-13 libc++abi-13-dev libclang1-13 libclang-13-dev \
-    libclang-common-13-dev libclang-cpp13 libclang-cpp13-dev liblld-13 \
-    liblld-13-dev liblldb-13 liblldb-13-dev libllvm13 libomp-13-dev \
-    libomp5-13 lld-13 lldb-13 llvm-13 llvm-13-dev llvm-13-runtime llvm-13-tools \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 0
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 0
-
-ENV LLVM_CONFIG=llvm-config-13
-ENV AFL_SKIP_CPUFREQ=1
-ENV AFL_TRY_AFFINITY=1
-ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
-
-RUN git clone --depth=1 https://github.com/vanhauser-thc/afl-cov /afl-cov
-RUN cd /afl-cov && make install && cd ..
-
-RUN git clone https://github.com/AFLplusplus/AFLplusplus.git
-
-WORKDIR /AFLplusplus
-
-RUN export CC=gcc-10 && export CXX=g++-10 && make clean && \
-    make distrib && make install && make clean
-
-WORKDIR /
-
+ARG USER_ID
+ARG GROUP_ID
 ARG ZIG_VERSION
-ARG ZIG_SIG
+ARG ZIG_PUBKEY
 
-RUN wget https://ziglang.org/builds/$ZIG_VERSION.tar.xz && \
-    echo $ZIG_SIG $ZIG_VERSION.tar.xz | sha256sum --check --strict && \
+RUN if [ ${USER_ID:-0} -ne 0 ] && [ ${GROUP_ID:-0} -ne 0 ]; then \
+    userdel -f www-data &&\
+    if getent group www-data ; then groupdel www-data; fi &&\
+    groupadd -g ${GROUP_ID} www-data &&\
+    useradd -l -u ${USER_ID} -g www-data www-data && \
+    install -d -m 0755 -o www-data -g www-data /home/www-data &&\
+    chown --changes --silent --no-dereference --recursive \
+          --from=33:33 ${USER_ID}:${GROUP_ID} \
+        /home/www-data \
+;fi
+
+WORKDIR /usr/local/bin
+
+RUN wget --inet4-only https://ziglang.org/builds/$ZIG_VERSION.tar.xz && \
+    wget --inet4-only "https://ziglang.org/builds/$ZIG_VERSION.tar.xz.minisig" && \
+    minisign -Vm $ZIG_VERSION.tar.xz -P $ZIG_PUBKEY && \
     tar -xvf $ZIG_VERSION.tar.xz && \
-    rm $ZIG_VERSION.tar.xz
+    rm $ZIG_VERSION.tar.xz $ZIG_VERSION.tar.xz.minisig
 
-ENV PATH="/$ZIG_VERSION:$PATH"
+USER www-data
+WORKDIR /home/www-data
+
+
+ENV PATH="$PATH:/usr/local/bin/$ZIG_VERSION"


### PR DESCRIPTION
I was having trouble getting the old fuzzing instructions to work (having to do with opaque pointers in llvm; by default AFL uses clang 14 which defaults to typed pointers but I didn't investigate too deeply).

The new method just compiles aro to C and then runs that through `afl-clang-lto`. It seems to work pretty well - I'm just not sure if I'm handling `compiler-rt` and the `zig.h` location in the best way.