### PR TITLE
Parser: ensure that asmStr finds at least one string literal

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -4083,7 +4083,13 @@ fn asmStr(p: *Parser) Error!Result {
             try p.errStr(.invalid_asm_str, p.tok_i, "wide");
             return error.ParsingFailed;
         },
-        else => break,
+        else => {
+            if (i == p.tok_i) {
+                try p.errStr(.expected_str_literal_in, p.tok_i, "asm");
+                return error.ParsingFailed;
+            }
+            break;
+        },
     };
     return try p.stringLiteral();
 }

--- a/test/cases/asm.c
+++ b/test/cases/asm.c
@@ -2,9 +2,12 @@ void foo(void) __asm__("foo");
 __asm__ volatile volatile("foo");
 __asm__(u8"nop");
 __asm__(L"nop");
+__asm__(5);
 
 #define EXPECTED_ERRORS "asm.c:2:9: error: meaningless 'volatile' on assembly outside function" \
     "asm.c:2:18: error: meaningless 'volatile' on assembly outside function" \
     "asm.c:2:18: error: duplicate asm qualifier 'volatile'" \
     "asm.c:3:9: error: cannot use unicode string literal in assembly" \
     "asm.c:4:9: error: cannot use wide string literal in assembly" \
+    "asm.c:5:9: error: expected string literal in 'asm'" \
+


### PR DESCRIPTION
Parser.stringLiteral assumes the first token it sees will be some sort of string literal