### PR TITLE
Tokenizer: don't mark unterminated comment lexeme as unreachable

### DIFF
--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -496,9 +496,9 @@ pub const Token = struct {
             return switch (id) {
                 .include_start,
                 .include_resume,
-                .unterminated_comment, // Fatal error; parsing should not be attempted
                 => unreachable,
 
+                .unterminated_comment,
                 .invalid,
                 .identifier,
                 .extended_identifier,

--- a/test/cases/unterminated comment in preprocessor expression.c
+++ b/test/cases/unterminated comment in preprocessor expression.c
@@ -1,0 +1,6 @@
+#define EXPECTED_ERRORS "unterminated comment in preprocessor expression.c:7:5: error: invalid token at start of a preprocessor expression" \
+    "unterminated comment in preprocessor expression.c:7:1: error: unterminated conditional directive" \
+    "unterminated comment in preprocessor expression.c:7:1: error: unterminated conditional directive"
+
+#if /*
+


### PR DESCRIPTION
Fixes #561