### PR TITLE
update README with zig run

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ int main(void) {
     printf("Hello, world!\n");
     return 0;
 }
-$ zig build run -- hello.c -o hello
-$ ./hello
+$ zig run hello.c
 Hello, world!
-$
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ int main(void) {
     printf("Hello, world!\n");
     return 0;
 }
-$ zig run hello.c
+$ zig build && ./zig-out/bin/arocc hello.c -o hello
+$ ./hello
 Hello, world!
 ```


### PR DESCRIPTION
run step is no longer in `build.zig`, so the README example no longer works. We just use `zig run` instead.