### PR TITLE
Function type comparison tweaks

### DIFF
--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -105,6 +105,7 @@ pub const Func = struct {
     fn eql(a: *const Func, b: *const Func, a_spec: Specifier, b_spec: Specifier, comp: *const Compilation) bool {
         // return type cannot have qualifiers
         if (!a.return_type.eql(b.return_type, comp, false)) return false;
+        if (a.params.len == 0 and b.params.len == 0) return true;
 
         if (a.params.len != b.params.len) {
             if (a_spec == .old_style_func or b_spec == .old_style_func) {

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -114,6 +114,7 @@ pub const Func = struct {
                 }
                 return true;
             }
+            return false;
         }
         if ((a_spec == .func) != (b_spec == .func)) return false;
         // TODO validate this

--- a/test/cases/functions.c
+++ b/test/cases/functions.c
@@ -75,6 +75,9 @@ int (*return_array_ptr(void))[2] {
     return &ARRAY;
 }
 
+void no_params(void);
+void no_params(int x){}
+
 #define EXPECTED_ERRORS "functions.c:10:12: error: parameter named 'quux' is missing" \
     "functions.c:20:14: error: illegal initializer (only variables can be initialized)" \
     "functions.c:18:2: warning: non-void function 'foooo' does not return a value [-Wreturn-type]" \
@@ -85,3 +88,6 @@ int (*return_array_ptr(void))[2] {
     "functions.c:50:3: error: parameter has incomplete type 'union Union'" \
     "functions.c:53:30: error: parameter has incomplete type 'enum E'" \
     "functions.c:55:9: error: parameter has incomplete type 'enum EE'" \
+    "functions.c:79:6: error: redefinition of 'no_params' with a different type" \
+    "functions.c:78:6: note: previous definition is here" \
+

--- a/test/cases/redefinitions.c
+++ b/test/cases/redefinitions.c
@@ -85,6 +85,12 @@ int f4(int);
 int f5(int (*)(), double (*)[3]);
 int f5(int (*)(char), double (*)[]); // not compatible since char undergoes default argument promotion
 
+void f6();
+void f6(void) {}
+
+void f7(void);
+void f7() {}
+
 #define EXPECTED_ERRORS "redefinitions.c:4:5: error: redefinition of 'foo' as different kind of symbol" \
     "redefinitions.c:1:5: note: previous definition is here" \
     "redefinitions.c:5:5: error: redefinition of 'foo' as different kind of symbol" \


### PR DESCRIPTION
1. Check that param counts match before looping over them
2. Allow 0-argument new-style/old-style redefinition