### PR TITLE
Compilation: check for embedded null bytes in path for has_include

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -1349,6 +1349,10 @@ pub fn hasInclude(
     /// __has_include vs __has_include_next
     which: WhichInclude,
 ) !bool {
+    if (mem.indexOfScalar(u8, filename, 0) != null) {
+        return false;
+    }
+
     const cwd = std.fs.cwd();
     if (std.fs.path.isAbsolute(filename)) {
         if (which == .next) return false;


### PR DESCRIPTION
Prevents a crash caused by embedded NUL bytes