### PR TITLE
Remove all usages of `std.mem.copy`

### DIFF
--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -151,8 +151,8 @@ pub const Attributed = struct {
         errdefer allocator.destroy(attributed_type);
 
         const all_attrs = try allocator.alloc(Attribute, existing_attributes.len + attributes.len);
-        std.mem.copy(Attribute, all_attrs, existing_attributes);
-        std.mem.copy(Attribute, all_attrs[existing_attributes.len..], attributes);
+        @memcpy(all_attrs, existing_attributes);
+        @memcpy(all_attrs[existing_attributes.len..], attributes);
 
         attributed_type.* = .{
             .attributes = all_attrs,

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -151,7 +151,7 @@ pub const Attributed = struct {
         errdefer allocator.destroy(attributed_type);
 
         const all_attrs = try allocator.alloc(Attribute, existing_attributes.len + attributes.len);
-        @memcpy(all_attrs, existing_attributes);
+        @memcpy(all_attrs[0..existing_attributes.len], existing_attributes);
         @memcpy(all_attrs[existing_attributes.len..], attributes);
 
         attributed_type.* = .{

--- a/src/backend/Ir.zig
+++ b/src/backend/Ir.zig
@@ -158,7 +158,7 @@ pub const Builder = struct {
         const a = b.arena.allocator();
         const input_refs = try a.alloc(Ref, inputs.len * 2 + 1);
         input_refs[0] = @enumFromInt(inputs.len);
-        std.mem.copy(Ref, input_refs[1..], std.mem.bytesAsSlice(Ref, std.mem.sliceAsBytes(inputs)));
+        @memcpy(input_refs[1..], std.mem.bytesAsSlice(Ref, std.mem.sliceAsBytes(inputs)));
 
         return b.addInst(.phi, .{ .phi = .{ .ptr = input_refs.ptr } }, ty);
     }


### PR DESCRIPTION
This is the upstream patch of ziglang/zig#18143