### PR TITLE
fix: spurious unsigned add and mul overflows

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6443,9 +6443,12 @@ fn addExpr(p: *Parser) Error!Result {
         try rhs.expect(p);
 
         const lhs_ty = lhs.ty;
+        const rhs_ty = rhs.ty;
         if (try lhs.adjustTypes(minus.?, &rhs, p, if (plus != null) .add else .sub)) {
             if (plus != null) {
-                if (try lhs.val.add(lhs.val, rhs.val, lhs.ty, p.comp)) try p.errOverflow(plus.?, lhs);
+                if (try lhs.val.add(lhs.val, rhs.val, lhs.ty, p.comp) and
+                    rhs_ty.signedness(p.comp) != .unsigned and
+                    lhs_ty.signedness(p.comp) != .unsigned) try p.errOverflow(plus.?, lhs);
             } else {
                 if (try lhs.val.sub(lhs.val, rhs.val, lhs.ty, p.comp)) try p.errOverflow(minus.?, lhs);
             }
@@ -6484,7 +6487,9 @@ fn mulExpr(p: *Parser) Error!Result {
 
         if (try lhs.adjustTypes(percent.?, &rhs, p, if (tag == .mod_expr) .integer else .arithmetic)) {
             if (mul != null) {
-                if (try lhs.val.mul(lhs.val, rhs.val, lhs.ty, p.comp)) try p.errOverflow(mul.?, lhs);
+                if (try lhs.val.mul(lhs.val, rhs.val, lhs.ty, p.comp) and
+                    rhs.ty.signedness(p.comp) != .unsigned and
+                    lhs.ty.signedness(p.comp) != .unsigned) try p.errOverflow(mul.?, lhs);
             } else if (div != null) {
                 if (try lhs.val.div(lhs.val, rhs.val, lhs.ty, p.comp)) try p.errOverflow(mul.?, lhs);
             } else {

--- a/test/cases/arithmetic overflow.c
+++ b/test/cases/arithmetic overflow.c
@@ -1,0 +1,5 @@
+_Static_assert(0xFFFFFFFF + 1 == 0, "'");
+_Static_assert(1 + 0xFFFFFFFF == 0, "'");
+_Static_assert(0 - 0x00000001 == 0xFFFFFFFF, "'");
+_Static_assert(0x00000000 - 0x00000001 == 0xFFFFFFFF, "'");
+_Static_assert(0x80000000 * 2 == 0, "'");


### PR DESCRIPTION
Add signedness checks prior to doing an `errOverflow`.

