### PR TITLE
Compilation: define char types and sig_atomic size

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -457,6 +457,7 @@ fn generateSystemDefines(comp: *Compilation, w: anytype) !void {
     try comp.generateIntMaxAndWidth(w, "PTRDIFF", comp.types.ptrdiff);
     try comp.generateIntMaxAndWidth(w, "INTPTR", comp.types.intptr);
     try comp.generateIntMaxAndWidth(w, "UINTPTR", comp.types.intptr.makeIntegerUnsigned());
+    try comp.generateIntMaxAndWidth(w, "SIG_ATOMIC", target_util.sigAtomicType(comp.target));
 
     // int widths
     try w.print("#define __BITINT_MAXWIDTH__ {d}\n", .{bit_int_max_bits});
@@ -493,6 +494,8 @@ fn generateSystemDefines(comp: *Compilation, w: anytype) !void {
     try generateTypeMacro(w, mapper, "__PTRDIFF_TYPE__", comp.types.ptrdiff, comp.langopts);
     try generateTypeMacro(w, mapper, "__SIZE_TYPE__", comp.types.size, comp.langopts);
     try generateTypeMacro(w, mapper, "__WCHAR_TYPE__", comp.types.wchar, comp.langopts);
+    try generateTypeMacro(w, mapper, "__CHAR16_TYPE__", comp.types.uint_least16_t, comp.langopts);
+    try generateTypeMacro(w, mapper, "__CHAR32_TYPE__", comp.types.uint_least32_t, comp.langopts);
 
     try comp.generateExactWidthTypes(w, mapper);
     try comp.generateFastAndLeastWidthTypes(w, mapper);

--- a/src/aro/target.zig
+++ b/src/aro/target.zig
@@ -102,6 +102,16 @@ pub fn int16Type(target: std.Target) Type {
     };
 }
 
+/// sig_atomic_t for this target
+pub fn sigAtomicType(target: std.Target) Type {
+    if (target.cpu.arch.isWasm()) return .{ .specifier = .long };
+    return switch (target.cpu.arch) {
+        .avr => .{ .specifier = .schar },
+        .msp430 => .{ .specifier = .long },
+        else => .{ .specifier = .int },
+    };
+}
+
 /// int64_t for this target
 pub fn int64Type(target: std.Target) Type {
     switch (target.cpu.arch) {

--- a/test/cases/wide character constants.c
+++ b/test/cases/wide character constants.c
@@ -51,6 +51,9 @@ int Y = 'abc\E';
 #pragma GCC diagnostic pop
 int Z = 'ABC\D';
 
+_Static_assert(sizeof(__CHAR16_TYPE__) == sizeof(u'A'), "");
+_Static_assert(sizeof(__CHAR32_TYPE__) == sizeof(U'A'), "");
+
 #define EXPECTED_ERRORS "wide character constants.c:9:27: error: character too large for enclosing character literal type" \
     "wide character constants.c:10:16: error: wide character literals may not contain multiple characters" \
     "wide character constants.c:11:16: error: Unicode character literals may not contain multiple characters" \


### PR DESCRIPTION
These are used by the host `stdatomic.h` on my system.