### PR TITLE
Builtins: handle _Float16 type specifier

### DIFF
--- a/src/aro/Builtins.zig
+++ b/src/aro/Builtins.zig
@@ -99,10 +99,7 @@ fn createType(desc: TypeDescription, it: *TypeDescription.TypeIterator, comp: *c
             }
         },
         .h => builder.combine(undefined, .fp16, 0) catch unreachable,
-        .x => {
-            // Todo: _Float16
-            return .{ .specifier = .invalid };
-        },
+        .x => builder.combine(undefined, .float16, 0) catch unreachable,
         .y => {
             // Todo: __bf16
             return .{ .specifier = .invalid };


### PR DESCRIPTION
With this + #591 + #592 I'm able to parse `zig2.c` on my linux system without using an external preprocessor 🤯

Current numbers for reference, looks like we need to cut back on memory usage a bit but speed is looking good :)

```
Benchmark 1 (6 runs): clang -std=c11 -Ilib -fsyntax-only build/zig2.c
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          10.9s  ± 24.4ms    10.9s  … 10.9s           0 ( 0%)        0%
  peak_rss           1.00GB ± 37.0KB    1.00GB … 1.00GB          0 ( 0%)        0%
  cpu_cycles         44.3G  ± 99.6M     44.1G  … 44.4G           0 ( 0%)        0%
  instructions       72.1G  ±  129M     72.0G  … 72.3G           0 ( 0%)        0%
  cache_references    204M  ± 3.58M      201M  …  210M           0 ( 0%)        0%
  cache_misses       26.1M  ±  142K     25.9M  … 26.4M           0 ( 0%)        0%
  branch_misses       102M  ±  324K      101M  …  102M           0 ( 0%)        0%
Benchmark 2 (8 runs): arocc -Wno-integer-overflow -Wno-unused-value -Wno-return-type -std=c11 -I/usr/lib/gcc/x86_64-linux-gnu/10/include -Ilib -fsyntax-only build/zig2.c
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          8.46s  ±  227ms    8.23s  … 8.92s           0 ( 0%)        ⚡- 22.3% ±  1.9%
  peak_rss           1.37GB ± 37.4KB    1.37GB … 1.37GB          0 ( 0%)        💩+ 36.5% ±  0.0%
  cpu_cycles         29.9G  ± 93.9M     29.8G  … 30.1G           0 ( 0%)        ⚡- 32.4% ±  0.3%
  instructions       63.4G  ±  827      63.4G  … 63.4G           0 ( 0%)        ⚡- 12.1% ±  0.1%
  cache_references   78.6M  ±  914K     77.1M  … 80.0M           0 ( 0%)        ⚡- 61.4% ±  1.4%
  cache_misses       35.5M  ±  482K     35.2M  … 36.7M           1 (13%)        💩+ 36.2% ±  1.7%
  branch_misses       289M  ±  333K      288M  …  289M           0 ( 0%)        💩+184.3% ±  0.4%
```

