### PR TITLE
Fix incorrect line numbers in linemarkers

### DIFF
--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -248,7 +248,7 @@ pub fn preprocessSources(pp: *Preprocessor, sources: []const Source) Error!void 
         try pp.addIncludeStart(header);
         _ = try pp.preprocess(header);
     }
-    try pp.addIncludeResume(first.id, 0, 0);
+    try pp.addIncludeResume(first.id, 0, 1);
     const eof = try pp.preprocess(first);
     try pp.tokens.append(pp.comp.gpa, eof);
 }
@@ -290,7 +290,7 @@ pub fn addIncludeStart(pp: *Preprocessor, source: Source) !void {
     try pp.tokens.append(pp.gpa, .{ .id = .include_start, .loc = .{
         .id = source.id,
         .byte_offset = std.math.maxInt(u32),
-        .line = 0,
+        .line = 1,
     } });
 }
 
@@ -3130,8 +3130,7 @@ fn printLinemarker(
 ) !void {
     try w.writeByte('#');
     if (pp.linemarkers == .line_directives) try w.writeAll("line");
-    // line_no is 0 indexed
-    try w.print(" {d} \"", .{line_no + 1});
+    try w.print(" {d} \"", .{line_no});
     for (source.path) |byte| switch (byte) {
         '\n' => try w.writeAll("\\n"),
         '\r' => try w.writeAll("\\r"),
@@ -3248,7 +3247,7 @@ pub fn prettyPrintTokens(pp: *Preprocessor, w: anytype) !void {
             .include_start => {
                 const source = pp.comp.getSource(cur.loc.id);
 
-                try pp.printLinemarker(w, 0, source, .start);
+                try pp.printLinemarker(w, 1, source, .start);
                 last_nl = true;
             },
             .include_resume => {


### PR DESCRIPTION
Line numbers are 1-indexed, not 0-indexed. Before this commit, include_start/include_resume tokens were being added with a mix of 1-indexed and 0-indexed line numbers. After this commit, all line numbers are 1-indexed.

Closes #604

I would have added test cases, but there's nothing in place for testing linemarkers (if I add a test case, the file paths in the line markers end up as absolute). For example, this test case:

```c
//aro-args -E -fuse-line-directives
this is line 2







this is line 10
```

Expects this output:

```c
#line 2 "/home/ryan/Programming/zig/arocc/test/cases/linemarkers.c"
this is line 2
#line 10 "/home/ryan/Programming/zig/arocc/test/cases/linemarkers.c"
this is line 10
```

Let me know if you have an idea of how to add test cases for this. 

---

Fixes all the reproductions of the problem I was able to find.

---

```c
#include "a.h"


foo
```

Now correctly outputs:
```c
#line 1 "test.c"
#line 1 "<builtin>"
#line 293 "<builtin>"
#line 1 "<command line>"
#line 1 "test.c"
#line 1 "./a.h"

#line 4 "test.c"
foo
```

---

```c
this is line 1








this is line 10
```

Now correctly outputs:

```c
#line 1 "test.c"
#line 1 "<builtin>"
#line 293 "<builtin>"
#line 1 "<command line>"
#line 1 "test.c"
this is line 1
#line 10 "test.c"
this is line 10
```