### PR TITLE
Update for latest Zig build system changes

### DIFF
--- a/build/GenerateDef.zig
+++ b/build/GenerateDef.zig
@@ -21,7 +21,7 @@ pub const Options = struct {
     pub const Kind = enum { dafsa, named };
 };
 
-pub fn create(owner: *std.Build, options: Options) std.Build.ModuleDependency {
+pub fn create(owner: *std.Build, options: Options) std.Build.Module.Import {
     const self = owner.allocator.create(GenerateDef) catch @panic("OOM");
     const path = owner.pathJoin(&.{ options.src_prefix, options.name });
 
@@ -39,7 +39,7 @@ pub fn create(owner: *std.Build, options: Options) std.Build.ModuleDependency {
         .generated_file = .{ .step = &self.step },
     };
     const module = self.step.owner.createModule(.{
-        .source_file = .{ .generated = &self.generated_file },
+        .root_source_file = .{ .generated = &self.generated_file },
     });
     return .{
         .module = module,

--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -60,7 +60,8 @@ test "minUnsignedBits" {
 
     var comp = Compilation.init(std.testing.allocator);
     defer comp.deinit();
-    comp.target = (try std.zig.CrossTarget.parse(.{ .arch_os_abi = "x86_64-linux-gnu" })).toTarget();
+    const target_query = try std.Target.Query.parse(.{ .arch_os_abi = "x86_64-linux-gnu" });
+    comp.target = try std.zig.system.resolveTargetQuery(target_query);
 
     try Test.checkIntBits(&comp, 0, 0);
     try Test.checkIntBits(&comp, 1, 1);
@@ -94,7 +95,8 @@ test "minSignedBits" {
 
     var comp = Compilation.init(std.testing.allocator);
     defer comp.deinit();
-    comp.target = (try std.zig.CrossTarget.parse(.{ .arch_os_abi = "x86_64-linux-gnu" })).toTarget();
+    const target_query = try std.Target.Query.parse(.{ .arch_os_abi = "x86_64-linux-gnu" });
+    comp.target = try std.zig.system.resolveTargetQuery(target_query);
 
     try Test.checkIntBits(&comp, -1, 1);
     try Test.checkIntBits(&comp, -2, 2);

--- a/src/aro/toolchains/Linux.zig
+++ b/src/aro/toolchains/Linux.zig
@@ -388,8 +388,8 @@ test Linux {
     defer comp.environment = .{};
 
     const raw_triple = "x86_64-linux-gnu";
-    const cross = std.zig.CrossTarget.parse(.{ .arch_os_abi = raw_triple }) catch unreachable;
-    comp.target = cross.toTarget(); // TODO deprecated
+    const target_query = try std.Target.Query.parse(.{ .arch_os_abi = raw_triple });
+    comp.target = try std.zig.system.resolveTargetQuery(target_query);
     comp.langopts.setEmulatedCompiler(.gcc);
 
     var driver: Driver = .{ .comp = &comp };


### PR DESCRIPTION
This gets aro compiling again after https://github.com/ziglang/zig/pull/18160. This is not thoroughly tested, so double check that all the changes make sense.

Some of the changes come from downstream changes made in https://github.com/ziglang/zig/pull/18160 (to `Driver.zig` and `GenerateDef.zig`).

EDIT: Note that the ziglang.org CI is broken right now so there's no `master` binaries with the https://github.com/ziglang/zig/pull/18160 changes yet.