### PR TITLE
Reduce the size of the DAFSA nodes for names

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -174,7 +174,7 @@ pub fn build(b: *Build) !void {
                 .name = "backend",
                 .module = aro_backend,
             },
-            GenerateDef.create(b, .{ .name = "Builtins/Builtin.def" }),
+            GenerateDef.create(b, .{ .name = "Builtins/Builtin.def", .needs_large_dafsa_node = true }),
             GenerateDef.create(b, .{ .name = "Attribute/names.def" }),
             GenerateDef.create(b, .{ .name = "Diagnostics/messages.def", .kind = .named }),
         },


### PR DESCRIPTION
Just something random I noticed: names can use 32 bits per DAFSA node instead of the 64 bits needed for the builtins.

I haven't done any performance/size comparisons but it should make for a smaller and faster names DAFSA.