### PR TITLE
Type: check the type of variable len arrays in hasIncompleteSize

### DIFF
--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -889,7 +889,8 @@ pub fn hasIncompleteSize(ty: Type) bool {
         .@"struct", .@"union" => ty.data.record.isIncomplete(),
         .array, .static_array => ty.data.array.elem.hasIncompleteSize(),
         .typeof_type => ty.data.sub_type.hasIncompleteSize(),
-        .typeof_expr => ty.data.expr.ty.hasIncompleteSize(),
+        .typeof_expr, .variable_len_array => ty.data.expr.ty.hasIncompleteSize(),
+        .unspecified_variable_len_array => ty.data.sub_type.hasIncompleteSize(),
         .attributed => ty.data.attributed.base.hasIncompleteSize(),
         else => false,
     };

--- a/test/cases/incomplete types.c
+++ b/test/cases/incomplete types.c
@@ -41,6 +41,8 @@ void incomplete_enum_float(void) {
     e = 1.0f;
 }
 
+void incomplete_unspecified_variable_len_array(struct S b[1][*]);
+
 #define EXPECTED_ERRORS "incomplete types.c:4:5: error: dereferencing pointer to incomplete type 'struct S'" \
     "incomplete types.c:5:11: error: dereferencing pointer to incomplete type 'struct S'" \
     "incomplete types.c:8:5: error: dereferencing pointer to incomplete type 'union U'" \
@@ -53,3 +55,4 @@ void incomplete_enum_float(void) {
     "incomplete types.c:33:17: error: variable has incomplete type 'struct node'" \
     "incomplete types.c:34:13: error: statement requires expression with integer type ('struct node' invalid)" \
     "incomplete types.c:40:12: error: variable has incomplete type 'enum E'" \
+    "incomplete types.c:44:58: error: array has incomplete element type 'struct S [*]'" \

--- a/test/cases/invalid types.c
+++ b/test/cases/invalid types.c
@@ -17,6 +17,7 @@ void foo(int arr[]) {
     struct bar a[] = {1};
     struct bar[1][1] = {{1}};
     struct bar b[1][] = {{1}};
+    struct bar b[1][B(1)] = {1};
 }
 
 int bar["foo"];
@@ -49,10 +50,12 @@ void foo(void) {
     "invalid types.c:17:17: error: array has incomplete element type 'struct bar'" \
     "invalid types.c:18:15: error: expected identifier or '('" \
     "invalid types.c:19:17: error: array has incomplete element type 'struct bar []'" \
-    "invalid types.c:22:9: error: size of array has non-integer type 'char [4]'" \
-    "invalid types.c:23:13: error: array initializer must be an initializer list or wide string literal" \
+    "invalid types.c:20:21: error: call to undeclared function 'B'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]" \
+    "invalid types.c:20:23: warning: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C23 [-Wdeprecated-non-prototype]" \
+    "invalid types.c:20:17: error: array has incomplete element type 'struct bar [<expr>]'" \
+    "invalid types.c:23:9: error: size of array has non-integer type 'char [4]'" \
     "invalid types.c:24:13: error: array initializer must be an initializer list or wide string literal" \
-    "invalid types.c:26:5: warning: tentative array definition assumed to have one element" \
-    "invalid types.c:28:6: error: redefinition of 'foo'" \
-    "invalid types.c:29:9: error: variable has incomplete type 'int []'" \
-
+    "invalid types.c:25:13: error: array initializer must be an initializer list or wide string literal" \
+    "invalid types.c:27:5: warning: tentative array definition assumed to have one element" \
+    "invalid types.c:29:6: error: redefinition of 'foo'" \
+    "invalid types.c:30:9: error: variable has incomplete type 'int []'" \


### PR DESCRIPTION
resolve #602
variable_len_array and unspecified_variable_len_array data was not checked in hasIncompleteSize silencing the array_incomplete_elem error when validating the combined type in validateCombinedType and that caused findScalarInitializer to try to iterate the members of an incomplete struct.