### PR TITLE
Handle token stream in Parser

### DIFF
--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -230,7 +230,7 @@ fn diagnoseField(
 ) !?Diagnostics.Message {
     if (res.val.opt_ref == .none) {
         if (Wanted == Identifier and node.tag == .decl_ref_expr) {
-            @field(@field(arguments, decl.name), field.name) = Identifier{ .tok = node.data.decl_ref };
+            @field(@field(arguments, decl.name), field.name) = Identifier{ .tok = p.tokens.items[node.data.decl_ref] };
             return null;
         }
         return invalidArgMsg(Wanted, .expression);

--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -1514,26 +1514,27 @@ pub fn addPragmaHandler(comp: *Compilation, name: []const u8, handler: *Pragma) 
 }
 
 pub fn addDefaultPragmaHandlers(comp: *Compilation) Allocator.Error!void {
-    const GCC = @import("pragmas/gcc.zig");
-    var gcc = try GCC.init(comp.gpa);
-    errdefer gcc.deinit(gcc, comp);
+    _ = comp;
+    // const GCC = @import("pragmas/gcc.zig");
+    // var gcc = try GCC.init(comp.gpa);
+    // errdefer gcc.deinit(gcc, comp);
 
-    const Once = @import("pragmas/once.zig");
-    var once = try Once.init(comp.gpa);
-    errdefer once.deinit(once, comp);
+    // const Once = @import("pragmas/once.zig");
+    // var once = try Once.init(comp.gpa);
+    // errdefer once.deinit(once, comp);
 
-    const Message = @import("pragmas/message.zig");
-    var message = try Message.init(comp.gpa);
-    errdefer message.deinit(message, comp);
+    // const Message = @import("pragmas/message.zig");
+    // var message = try Message.init(comp.gpa);
+    // errdefer message.deinit(message, comp);
 
-    const Pack = @import("pragmas/pack.zig");
-    var pack = try Pack.init(comp.gpa);
-    errdefer pack.deinit(pack, comp);
+    // const Pack = @import("pragmas/pack.zig");
+    // var pack = try Pack.init(comp.gpa);
+    // errdefer pack.deinit(pack, comp);
 
-    try comp.addPragmaHandler("GCC", gcc);
-    try comp.addPragmaHandler("once", once);
-    try comp.addPragmaHandler("message", message);
-    try comp.addPragmaHandler("pack", pack);
+    // try comp.addPragmaHandler("GCC", gcc);
+    // try comp.addPragmaHandler("once", once);
+    // try comp.addPragmaHandler("message", message);
+    // try comp.addPragmaHandler("pack", pack);
 }
 
 pub fn getPragma(comp: *Compilation, name: []const u8) ?*Pragma {

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -966,12 +966,11 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
         .pp = pp,
         .comp = pp.comp,
         .gpa = pp.gpa,
-        .tok_ids = pp.tokens.items(.id),
-        .tok_i = @intCast(start),
         .arena = pp.arena.allocator(),
         .in_macro = true,
         .strings = std.ArrayList(u8).init(pp.comp.gpa),
 
+        .tokens = undefined,
         .data = undefined,
         .value_map = undefined,
         .labels = undefined,

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -3226,6 +3226,12 @@ fn readMoreTokens(pp: *Preprocessor) !void {
     // try pp.top_expansion_buf.append(.{ .id = .eof, .loc = .{} });
 }
 
+/// Skip the next token. Asserts that the token has already been inspected
+pub fn discardToken(pp: *Preprocessor) void {
+    std.debug.assert(pp.tok_i < pp.tokens.len);
+    pp.tok_i += 1;
+}
+
 pub fn nextToken(pp: *Preprocessor) !Token {
     if (pp.tok_i >= pp.tokens.len) {
         if (pp.checkpoints.items.len == 0) {

--- a/src/aro/SymbolStack.zig
+++ b/src/aro/SymbolStack.zig
@@ -4,7 +4,6 @@ const Allocator = mem.Allocator;
 const assert = std.debug.assert;
 const Tree = @import("Tree.zig");
 const Token = Tree.Token;
-const TokenIndex = Tree.TokenIndex;
 const NodeIndex = Tree.NodeIndex;
 const Type = @import("Type.zig");
 const Parser = @import("Parser.zig");

--- a/src/aro/SymbolStack.zig
+++ b/src/aro/SymbolStack.zig
@@ -179,13 +179,13 @@ pub fn defineTypedef(
         switch (prev.kind) {
             .typedef => {
                 if (!ty.eql(prev.ty, p.comp, true)) {
-                    try p.errStr(.redefinition_of_typedef, tok, try p.typePairStrExtra(ty, " vs ", prev.ty));
-                    if (prev.tok != 0) try p.errTok(.previous_definition, prev.tok);
+                    try p.errStr(.redefinition_of_typedef, p.tokens.items[tok], try p.typePairStrExtra(ty, " vs ", prev.ty));
+                    if (prev.tok != 0) try p.errTok(.previous_definition, p.tokens.items[prev.tok]);
                 }
             },
             .enumeration, .decl, .def, .constexpr => {
-                try p.errStr(.redefinition_different_sym, tok, p.tokSlice(tok));
-                try p.errTok(.previous_definition, prev.tok);
+                try p.errStr(.redefinition_different_sym, p.tokens.items[tok], p.tokSlice(p.tokens.items[tok]));
+                try p.errTok(.previous_definition, p.tokens.items[prev.tok]);
             },
             else => unreachable,
         }

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -95,6 +95,7 @@ pub const Token = struct {
     pub const Id = Tokenizer.Token.Id;
     pub const NumberPrefix = number_affixes.Prefix;
     pub const NumberSuffix = number_affixes.Suffix;
+    pub const invalid: Token = .{ .id = .invalid, .loc = .{} };
 };
 
 pub const TokenIndex = u32;

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -1909,7 +1909,7 @@ pub const Builder = struct {
         defer b.error_on_invalid = false;
 
         const new_spec = fromType(typedef_ty);
-        b.combineExtra(p, new_spec, 0) catch |err| switch (err) {
+        b.combineExtra(p, new_spec, Token.invalid) catch |err| switch (err) {
             error.FatalError => unreachable, // we do not add any diagnostics
             error.OutOfMemory => unreachable, // we do not add any diagnostics
             error.ParsingFailed => unreachable, // we do not add any diagnostics


### PR DESCRIPTION
This is very far from being ready for review but @Vexu I wanted to get your feedback on the general approach before going any further, since it will be a fairly large change.

The basic idea is that a significant source of memory usage currently is that we completely preprocess the file before parsing it. With large files that means we have a lot of tokens laying around even though most don't need to be saved. For example `zig2.c` results in a `pp.tokens.capacity` of `23,031,552` after preprocessing (`552,757,248` bytes in `ReleaseFast`, not counting expansion locations).

But, in general the only tokens we need to save are those used in `decl` and `decl_ref` tree nodes. Things like keywords, semicolons & other punctuation, literals, etc aren't needed after they're parsed. So the general idea is to have the parser pull in tokens from the preprocessor as needed, instead of doing it all up front. This is handled by having a stack of tokenizers in the preprocessor (`#include` pushes a new tokenizer onto the stack; finishing the file pops the tokenizer). Macros are fully expanded into an arraylist, so we don't need to store additional state in the preprocessor. Parser backtracking is handled by having "checkpoints" that prevent the preprocessor's token array from being cleared if any checkpoints are active.

