### PR TITLE
Parser: improve return detection for switch statments

### DIFF
--- a/test/cases/return.c
+++ b/test/cases/return.c
@@ -120,7 +120,6 @@ void call_return_signed(void) {
     "return.c:32:5: error: non-void function 'bar' should return a value [-Wreturn-type]" \
     "return.c:35:12: error: void function 'baz' should not return a value [-Wreturn-type]" \
     "return.c:38:17: error: function cannot return a function" \
-    "return.c:74:5: warning: unreachable code [-Wunreachable-code]" \
     "return.c:96:12: error: returning 'double' from a function with incompatible result type 'void *'" \
     "warning: returning 'unsigned int *' from a function with incompatible result type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]" \
 

--- a/test/cases/unreachable code.c
+++ b/test/cases/unreachable code.c
@@ -1,0 +1,38 @@
+int test(int a){
+	switch(a) {
+		default: break;
+	}
+	return 1;
+}
+int test1(int a){
+	switch(a) {
+		break;
+		a=1;
+	}
+	return 1;
+}
+int test2(int a){
+	switch(a) {
+		return 1;
+		a=1;
+	}
+	return 1;
+}
+int compound_stmt(int a){
+	{
+		a=1;
+		return 1;
+		a=2;
+	}
+}
+int if_then_else(int a){
+	if(a)
+		return 1;
+	else
+		return 2;
+	return 3;
+}
+#define EXPECTED_ERRORS "unreachable code.c:10:3: warning: unreachable code [-Wunreachable-code]" \
+	"unreachable code.c:17:3: warning: unreachable code [-Wunreachable-code]" \
+	"unreachable code.c:25:3: warning: unreachable code [-Wunreachable-code]" \
+	"unreachable code.c:33:2: warning: unreachable code [-Wunreachable-code]" 


### PR DESCRIPTION
resolve #619
The switch statement was not handled correctly by nodeIsNoreturn, since break and continue returned .yes like return_stmt that caused that it was treated like a return from the function instead of just exiting the switch statement.
Also added handling for the default statement for a simple switch+default, the case statement is not handled for now because it requires more complex reasoning when combined with multiple cases or with an default statement inside a compound statement, so it return the default .no value.
And changed the check of compound_stmt to try to find a statement with a return instead of just looking the last one.
Since switch_stmt no longer return .complex i have remove it for now, since if_then_else_stmt will no longer propagate it and no other statement use it.
Because the nodeIsNoreturn function is also used to detect the cases of unreachable code, changing break and continue cause the analysis to no longer detect this type of case:
```c
int test(int a){
	switch(a){
		break;
		a=1;
	}
	return 1;
}
```
This is still not a complete solution since loop statements are not handled correctly, generating a "does not return a value" warning:
```c
int test(int a){
	while(1)
		return 1;
}
```