### PR TITLE
Parser: allow `~` operator for complex conjugation

### DIFF
--- a/src/aro/Diagnostics/messages.def
+++ b/src/aro/Diagnostics/messages.def
@@ -2456,3 +2456,9 @@ too_big_shift_count
     .opt = W("shift-count-overflow")
     .kind = .warning
     .all = true
+
+complex_conj
+    .msg = "ISO C does not support '~' for complex conjugation of '{s}'"
+    .opt = W("pedantic")
+    .extra = .str
+    .kind = .off

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6977,6 +6977,8 @@ fn unExpr(p: *Parser) Error!Result {
                 if (operand.val.is(.int, p.comp)) {
                     operand.val = try operand.val.bitNot(operand.ty, p.comp);
                 }
+            } else if (operand.ty.isComplex()) {
+                try p.errStr(.complex_conj, tok, try p.typeStr(operand.ty));
             } else {
                 try p.errStr(.invalid_argument_un, tok, try p.typeStr(operand.ty));
                 operand.val = .{};

--- a/test/cases/complex numbers clang.c
+++ b/test/cases/complex numbers clang.c
@@ -12,6 +12,7 @@ void foo(int x, float y) {
     z = __builtin_complex(2.0, 3);
     z = __builtin_complex(2.0, 3.0f);
     z = __builtin_complex(2.0, 3.0);
+    z = ~z;
 }
 
 #define EXPECTED_ERRORS "complex numbers clang.c:5:20: error: static_assert expression is not an integral constant expression" \
@@ -21,4 +22,5 @@ void foo(int x, float y) {
     "complex numbers clang.c:10:6: warning: ISO C does not support '++'/'--' on complex type '_Complex double' [-Wpedantic]" \
     "complex numbers clang.c:12:32: error: argument type 'int' is not a real floating point type" \
     "complex numbers clang.c:13:32: error: arguments are of different types ('double' vs 'float')" \
+    "complex numbers clang.c:15:9: warning: ISO C does not support '~' for complex conjugation of '_Complex double' [-Wpedantic]" \
 


### PR DESCRIPTION
Question: should this be its own Tree.Tag or should it reuse `.bit_not_expr`? 