### PR TITLE
Parser: skip enumerators which are redefinitions

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -2567,6 +2567,7 @@ fn enumSpec(p: *Parser) Error!Type {
             if (field.ty.eql(Type.int, p.comp, false)) continue;
 
             const sym = p.syms.get(field.name, .vars) orelse continue;
+            if (sym.kind != .enumeration) continue; // already an error
 
             var res = Result{ .node = field.node, .ty = field.ty, .val = sym.val };
             const dest_ty = if (p.comp.fixedEnumTagSpecifier()) |some|

--- a/test/cases/redefinitions.c
+++ b/test/cases/redefinitions.c
@@ -91,6 +91,11 @@ void f6(void) {}
 void f7(void);
 void f7() {}
 
+int X;
+enum E {
+    X = 4294967295,
+};
+
 #define EXPECTED_ERRORS "redefinitions.c:4:5: error: redefinition of 'foo' as different kind of symbol" \
     "redefinitions.c:1:5: note: previous definition is here" \
     "redefinitions.c:5:5: error: redefinition of 'foo' as different kind of symbol" \
@@ -130,4 +135,6 @@ void f7() {}
     "redefinitions.c:82:5: note: previous definition is here" \
     "redefinitions.c:86:5: error: redefinition of 'f5' with a different type" \
     "redefinitions.c:85:5: note: previous definition is here" \
+    "redefinitions.c:96:5: error: redefinition of 'X' as different kind of symbol" \
+    "redefinitions.c:94:5: note: previous definition is here" \
 


### PR DESCRIPTION
Fixes #628