### PR TITLE
Compilation: set __GNUC__ and related macros

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -241,6 +241,12 @@ pub const SystemDefinesMode = enum {
 fn generateSystemDefines(comp: *Compilation, w: anytype) !void {
     const ptr_width = comp.target.ptrBitWidth();
 
+    if (comp.langopts.gnuc_version > 0) {
+        try w.print("#define __GNUC__ {d}\n", .{comp.langopts.gnuc_version / 10_000});
+        try w.print("#define __GNUC_MINOR__ {d}\n", .{comp.langopts.gnuc_version / 100 % 100});
+        try w.print("#define __GNUC_PATCHLEVEL__ {d}\n", .{comp.langopts.gnuc_version % 100});
+    }
+
     // os macros
     switch (comp.target.os.tag) {
         .linux => try w.writeAll(

--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -1057,9 +1057,8 @@ pub fn getCharSignedness(comp: *const Compilation) std.builtin.Signedness {
     return comp.langopts.char_signedness_override orelse comp.target.charSignedness();
 }
 
-pub fn defineSystemIncludes(comp: *Compilation, aro_dir: []const u8) !void {
-    var stack_fallback = std.heap.stackFallback(path_buf_stack_limit, comp.gpa);
-    const allocator = stack_fallback.get();
+/// Add built-in aro headers directory to system include paths
+pub fn addBuiltinIncludeDir(comp: *Compilation, aro_dir: []const u8) !void {
     var search_path = aro_dir;
     while (std.fs.path.dirname(search_path)) |dirname| : (search_path = dirname) {
         var base_dir = std.fs.cwd().openDir(dirname, .{}) catch continue;
@@ -1071,23 +1070,12 @@ pub fn defineSystemIncludes(comp: *Compilation, aro_dir: []const u8) !void {
         try comp.system_include_dirs.append(comp.gpa, path);
         break;
     } else return error.AroIncludeNotFound;
+}
 
-    if (comp.target.os.tag == .linux) {
-        const triple_str = try comp.target.linuxTriple(allocator);
-        defer allocator.free(triple_str);
-
-        const multiarch_path = try std.fs.path.join(allocator, &.{ "/usr/include", triple_str });
-        defer allocator.free(multiarch_path);
-
-        if (!std.meta.isError(std.fs.accessAbsolute(multiarch_path, .{}))) {
-            const duped = try comp.gpa.dupe(u8, multiarch_path);
-            errdefer comp.gpa.free(duped);
-            try comp.system_include_dirs.append(comp.gpa, duped);
-        }
-    }
-    const usr_include = try comp.gpa.dupe(u8, "/usr/include");
-    errdefer comp.gpa.free(usr_include);
-    try comp.system_include_dirs.append(comp.gpa, usr_include);
+pub fn addSystemIncludeDir(comp: *Compilation, path: []const u8) !void {
+    const duped = try comp.gpa.dupe(u8, path);
+    errdefer comp.gpa.free(duped);
+    try comp.system_include_dirs.append(comp.gpa, duped);
 }
 
 pub fn getSource(comp: *const Compilation, id: Source.Id) Source {

--- a/src/aro/Driver/GCCVersion.zig
+++ b/src/aro/Driver/GCCVersion.zig
@@ -98,6 +98,16 @@ pub fn order(a: GCCVersion, b: GCCVersion) Order {
     return .eq;
 }
 
+/// Used for determining __GNUC__ macro values
+/// This matches clang's logic for overflowing values
+pub fn toUnsigned(self: GCCVersion) u32 {
+    var result: u32 = 0;
+    if (self.major > 0) result = @as(u32, @intCast(self.major)) *% 10_000;
+    if (self.minor > 0) result +%= @as(u32, @intCast(self.minor)) *% 100;
+    if (self.patch > 0) result +%= @as(u32, @intCast(self.patch));
+    return result;
+}
+
 test parse {
     const versions = [10]GCCVersion{
         parse("5"),

--- a/src/aro/LangOpts.zig
+++ b/src/aro/LangOpts.zig
@@ -135,6 +135,11 @@ preserve_comments: bool = false,
 /// Preserve comments in macros when preprocessing
 preserve_comments_in_macros: bool = false,
 
+/// Used ONLY for generating __GNUC__ and related macros. Does not control the presence/absence of any features
+/// Encoded as major * 10,000 + minor * 100 + patch
+/// e.g. 4.2.1 == 40201
+gnuc_version: u32 = 0,
+
 pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!void {
     self.standard = Standard.NameMap.get(name) orelse return error.InvalidStandard;
 }

--- a/src/aro/Toolchain.zig
+++ b/src/aro/Toolchain.zig
@@ -487,3 +487,22 @@ pub fn addRuntimeLibs(tc: *const Toolchain, argv: *std.ArrayList([]const u8)) !v
         try argv.append("-ldl");
     }
 }
+
+pub fn defineSystemIncludes(tc: *Toolchain) !void {
+    return switch (tc.inner) {
+        .uninitialized => unreachable,
+        .linux => |*linux| linux.defineSystemIncludes(tc),
+        .unknown => {
+            if (tc.driver.nostdinc) return;
+
+            const comp = tc.driver.comp;
+            if (!tc.driver.nobuiltininc) {
+                try comp.addBuiltinIncludeDir(tc.driver.aro_name);
+            }
+
+            if (!tc.driver.nostdlibinc) {
+                try comp.addSystemIncludeDir("/usr/include");
+            }
+        },
+    };
+}

--- a/src/aro/toolchains/Linux.zig
+++ b/src/aro/toolchains/Linux.zig
@@ -373,6 +373,50 @@ fn getOSLibDir(target: std.Target) []const u8 {
     return "lib64";
 }
 
+pub fn defineSystemIncludes(self: *const Linux, tc: *const Toolchain) !void {
+    if (tc.driver.nostdinc) return;
+
+    const comp = tc.driver.comp;
+    const target = tc.getTarget();
+
+    // musl prefers /usr/include before builtin includes, so musl targets will add builtins
+    // at the end of this function (unless disabled with nostdlibinc)
+    if (!tc.driver.nobuiltininc and (!target.isMusl() or tc.driver.nostdlibinc)) {
+        try comp.addBuiltinIncludeDir(tc.driver.aro_name);
+    }
+
+    if (tc.driver.nostdlibinc) return;
+
+    const sysroot = tc.getSysroot();
+    const local_include = try std.fmt.allocPrint(comp.gpa, "{s}{s}", .{ sysroot, "/usr/local/include" });
+    defer comp.gpa.free(local_include);
+    try comp.addSystemIncludeDir(local_include);
+
+    if (self.gcc_detector.is_valid) {
+        const gcc_include_path = try std.fs.path.join(comp.gpa, &.{ self.gcc_detector.parent_lib_path, "..", self.gcc_detector.gcc_triple, "include" });
+        defer comp.gpa.free(gcc_include_path);
+        try comp.addSystemIncludeDir(gcc_include_path);
+    }
+
+    if (getMultiarchTriple(target)) |triple| {
+        const joined = try std.fs.path.join(comp.gpa, &.{ sysroot, "usr", "include", triple });
+        errdefer comp.gpa.free(joined);
+        if (tc.filesystem.exists(joined)) {
+            try comp.addSystemIncludeDir(joined);
+        }
+    }
+
+    if (target.os.tag == .rtems) return;
+
+    try comp.addSystemIncludeDir("/include");
+    try comp.addSystemIncludeDir("/usr/include");
+
+    std.debug.assert(!tc.driver.nostdlibinc);
+    if (!tc.driver.nobuiltininc and target.isMusl()) {
+        try comp.addBuiltinIncludeDir(tc.driver.aro_name);
+    }
+}
+
 test Linux {
     if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
 

--- a/src/aro/toolchains/Linux.zig
+++ b/src/aro/toolchains/Linux.zig
@@ -400,7 +400,7 @@ pub fn defineSystemIncludes(self: *const Linux, tc: *const Toolchain) !void {
 
     if (getMultiarchTriple(target)) |triple| {
         const joined = try std.fs.path.join(comp.gpa, &.{ sysroot, "usr", "include", triple });
-        errdefer comp.gpa.free(joined);
+        defer comp.gpa.free(joined);
         if (tc.filesystem.exists(joined)) {
             try comp.addSystemIncludeDir(joined);
         }

--- a/test/cases/gnuc version default.c
+++ b/test/cases/gnuc version default.c
@@ -1,0 +1,3 @@
+_Static_assert(__GNUC__ == 4, "");
+_Static_assert(__GNUC_MINOR__ == 2, "");
+_Static_assert(__GNUC_PATCHLEVEL__ == 1, "");

--- a/test/cases/gnuc version empty.c
+++ b/test/cases/gnuc version empty.c
@@ -1,0 +1,5 @@
+//aro-args -fgnuc-version=
+
+#if defined(__GNUC__) || defined(__GNUC_MINOR__) || defined(__GNUC_PATCHLEVEL__)
+#error "__GNUC__ macros should not be defined"
+#endif

--- a/test/cases/gnuc version override.c
+++ b/test/cases/gnuc version override.c
@@ -1,0 +1,5 @@
+//aro-args -fgnuc-version=5.3.42
+
+_Static_assert(__GNUC__ == 5, "");
+_Static_assert(__GNUC_MINOR__ == 3, "");
+_Static_assert(__GNUC_PATCHLEVEL__ == 42, "");

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -221,7 +221,7 @@ fn singleRun(alloc: std.mem.Allocator, test_dir: []const u8, test_case: TestCase
     defer comp.deinit();
 
     try comp.addDefaultPragmaHandlers();
-    try comp.defineSystemIncludes(test_dir);
+    try comp.addBuiltinIncludeDir(test_dir);
 
     const target = setTarget(&comp, test_case.target) catch |err| switch (err) {
         error.UnknownCpuModel => unreachable,

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -58,7 +58,7 @@ fn testOne(allocator: std.mem.Allocator, path: []const u8, test_dir: []const u8)
     defer comp.deinit();
 
     try comp.addDefaultPragmaHandlers();
-    try comp.defineSystemIncludes(test_dir);
+    try comp.addBuiltinIncludeDir(test_dir);
 
     const file = try comp.addSourceFromPath(path);
     var macro_buf = std.ArrayList(u8).init(comp.gpa);
@@ -173,7 +173,7 @@ pub fn main() !void {
     try initial_comp.include_dirs.append(gpa, cases_next_include_dir);
 
     try initial_comp.addDefaultPragmaHandlers();
-    try initial_comp.defineSystemIncludes(test_dir);
+    try initial_comp.addBuiltinIncludeDir(test_dir);
 
     // apparently we can't use setAstCwd without libc on windows yet
     const win = @import("builtin").os.tag == .windows;

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -15,6 +15,7 @@ fn addCommandLineArgs(comp: *aro.Compilation, file: aro.Source, macro_buf: anyty
     var only_preprocess = false;
     var line_markers: aro.Preprocessor.Linemarkers = .none;
     var system_defines: aro.Compilation.SystemDefinesMode = .include_system_defines;
+    comp.langopts.gnuc_version = 40201; // Set to clang default value since we do not call parseArgs if there are no args
     if (std.mem.startsWith(u8, file.buf, "//aro-args")) {
         var test_args = std.ArrayList([]const u8).init(comp.gpa);
         defer test_args.deinit();


### PR DESCRIPTION
This allows us to pretend to be GCC 4.2.1 by default, just like clang.