### PR TITLE
Add unary minus support for float values

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6934,7 +6934,7 @@ fn unExpr(p: *Parser) Error!Result {
                 try p.errStr(.invalid_argument_un, tok, try p.typeStr(operand.ty));
 
             try operand.usualUnaryConversion(p, tok);
-            if (operand.val.is(.int, p.comp)) {
+            if (operand.val.is(.int, p.comp) or operand.val.is(.float, p.comp)) {
                 _ = try operand.val.sub(Value.zero, operand.val, operand.ty, p.comp);
             } else {
                 operand.val = .{};

--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -226,7 +226,7 @@ pub fn intCast(v: *Value, dest_ty: Type, comp: *Compilation) !void {
     v.* = try intern(comp, .{ .int = .{ .big_int = result_bigint.toConst() } });
 }
 
-/// Converts the stored value from an integer to a float.
+/// Converts the stored value to a float of the specified type
 /// `.none` value remains unchanged.
 pub fn floatCast(v: *Value, dest_ty: Type, comp: *Compilation) !void {
     if (v.opt_ref == .none) return;

--- a/test/cases/float values.c
+++ b/test/cases/float values.c
@@ -1,0 +1,2 @@
+_Static_assert(-1.0 - 1.0 == -2.0, "");
+_Static_assert(-2.0f == -2.0, "");


### PR DESCRIPTION
Previously only worked for `-1.` (since 1 has its own tag).