### PR TITLE
Don't create implicit function definitions during record parsing

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -7680,6 +7680,8 @@ fn primaryExpr(p: *Parser) Error!Result {
                 else
                     try p.errStr(.implicit_func_decl, name_tok, name);
 
+                if (p.record.kind != .invalid) return .{ .ty = Type.invalid };
+
                 const func_ty = try p.arena.create(Type.Func);
                 func_ty.* = .{ .return_type = .{ .specifier = .int }, .params = &.{} };
                 const ty: Type = .{ .specifier = .old_style_func, .data = .{ .func = func_ty } };

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -7680,6 +7680,12 @@ fn primaryExpr(p: *Parser) Error!Result {
                 else
                     try p.errStr(.implicit_func_decl, name_tok, name);
 
+                // If record.kind != .invalid, we are currently parsing a record. Getting to here means
+                // that the C code tried to call a function which has not been defined or declared yet.
+                // It's always an error to call an implicitly defined function like this during record parsing.
+                // We return early because we do not want to create an implicitly defined function. Doing so
+                // will inadvertently treat the implicitly-defined function as a field decl for the record being
+                // parsed.
                 if (p.record.kind != .invalid) return .{ .ty = Type.invalid };
 
                 const func_ty = try p.arena.create(Type.Func);

--- a/test/README.MD
+++ b/test/README.MD
@@ -47,6 +47,17 @@ long float a;
 enum Foo {};
 ```
 ---
+## Ignoring errors in tests
+A test can ignore errors by defining a `NO_ERROR_VALIDATION` macro. This means the test will only fail if the
+compilation panics / crashes. This is useful for testing bugs found by fuzzing, where there may be a large number of
+uninteresting diagnostics.
+
+**example:**
+```c
+#define NO_ERROR_VALIDATION
+/* code goes here */
+```
+---
 ## Testing type resolution
 Type resolution can be tested by defining a `EXPECTED_TYPES` macro, and a function.
 The nth token in the `EXPECTED_TYPES` macro is the expected type of the nth statement

--- a/test/cases/invalid attributes.c
+++ b/test/cases/invalid attributes.c
@@ -5,5 +5,10 @@ struct S {
   __attribute__((packed)) b;
 };
 
+struct S2 {
+  __attribute__((__aligned__(char:  1))) long a;
+  __attribute__((packed)) b;
+};
+
 void foo(void) {
 }

--- a/test/cases/invalid attributes.c
+++ b/test/cases/invalid attributes.c
@@ -1,0 +1,9 @@
+#define NO_ERROR_VALIDATION
+
+struct S {
+  __attribute__((__aligned__(x(long)))) long a;
+  __attribute__((packed)) b;
+};
+
+void foo(void) {
+}

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -371,6 +371,8 @@ pub fn main() !void {
             continue;
         }
 
+        if (pp.defines.contains("NO_ERROR_VALIDATION")) continue;
+
         aro.Diagnostics.render(&comp, std.io.tty.detectConfig(std.io.getStdErr()));
 
         if (pp.defines.get("EXPECTED_OUTPUT")) |macro| blk: {


### PR DESCRIPTION
This prevents the parser from getting confused about the number of fields if a parser error triggers `parseOrNextDecl` to skip to the next decl.

Fixes #639