### PR TITLE
Type: handle typeof and attributed types in integerRank

### DIFF
--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -1313,6 +1313,10 @@ pub fn integerRank(ty: Type, comp: *const Compilation) usize {
         .long_long, .ulong_long => 6 + (ty.bitSizeof(comp).? << 3),
         .int128, .uint128 => 7 + (ty.bitSizeof(comp).? << 3),
 
+        .typeof_type => ty.data.sub_type.integerRank(comp),
+        .typeof_expr => ty.data.expr.ty.integerRank(comp),
+        .attributed => ty.data.attributed.base.integerRank(comp),
+
         else => unreachable,
     });
 }

--- a/test/cases/typeof pointer wrong size.c
+++ b/test/cases/typeof pointer wrong size.c
@@ -1,0 +1,6 @@
+#define NO_ERROR_VALIDATION
+
+void foo(void) {
+    char arr[10];
+    typeof(const int) *p = arr;
+}


### PR DESCRIPTION
Fixes a crash in the included test.