### PR TITLE
Remove __float80 as a distinct type

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -720,6 +720,11 @@ fn generateBuiltinTypes(comp: *Compilation) !void {
     try comp.generateNsConstantStringType();
 }
 
+pub fn float80Type(comp: *const Compilation) ?Type {
+    if (comp.langopts.emulate != .gcc) return null;
+    return target_util.float80Type(comp.target);
+}
+
 /// Smallest integer type with at least N bits
 fn intLeastN(comp: *const Compilation, bits: usize, signedness: std.builtin.Signedness) Type {
     if (bits == 64 and (comp.target.isDarwin() or comp.target.isWasm())) {

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -28,7 +28,6 @@ const StrInt = @import("StringInterner.zig");
 const StringId = StrInt.StringId;
 const Builtins = @import("Builtins.zig");
 const Builtin = Builtins.Builtin;
-const target_util = @import("target.zig");
 
 const Switch = struct {
     default: ?TokenIndex = null,

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -258,7 +258,6 @@ pub const Token = struct {
         keyword_asm,
         keyword_asm1,
         keyword_asm2,
-        keyword_float80,
         /// _Float128
         keyword_float128_1,
         /// __float128
@@ -417,7 +416,6 @@ pub const Token = struct {
                 .keyword_asm,
                 .keyword_asm1,
                 .keyword_asm2,
-                .keyword_float80,
                 .keyword_float128_1,
                 .keyword_float128_2,
                 .keyword_int128,
@@ -702,7 +700,6 @@ pub const Token = struct {
                 .keyword_asm => "asm",
                 .keyword_asm1 => "__asm",
                 .keyword_asm2 => "__asm__",
-                .keyword_float80 => "__float80",
                 .keyword_float128_1 => "_Float128",
                 .keyword_float128_2 => "__float128",
                 .keyword_int128 => "__int128",
@@ -982,7 +979,6 @@ pub const Token = struct {
         .{ "asm", .keyword_asm },
         .{ "__asm", .keyword_asm1 },
         .{ "__asm__", .keyword_asm2 },
-        .{ "__float80", .keyword_float80 },
         .{ "_Float128", .keyword_float128_1 },
         .{ "__float128", .keyword_float128_2 },
         .{ "__int128", .keyword_int128 },

--- a/src/aro/Tree/number_affixes.zig
+++ b/src/aro/Tree/number_affixes.zig
@@ -184,4 +184,8 @@ pub const Suffix = enum {
             else => false,
         };
     }
+
+    pub fn isFloat80(suffix: Suffix) bool {
+        return suffix == .W or suffix == .IW;
+    }
 };

--- a/src/aro/target.zig
+++ b/src/aro/target.zig
@@ -133,6 +133,14 @@ pub fn int64Type(target: std.Target) Type {
     return .{ .specifier = .long_long };
 }
 
+pub fn float80Type(target: std.Target) ?Type {
+    switch (target.cpu.arch) {
+        .x86, .x86_64 => return .{ .specifier = .long_double },
+        else => {},
+    }
+    return null;
+}
+
 /// This function returns 1 if function alignment is not observable or settable.
 pub fn defaultFunctionAlignment(target: std.Target) u8 {
     return switch (target.cpu.arch) {

--- a/test/cases/__float80 clang.c
+++ b/test/cases/__float80 clang.c
@@ -1,0 +1,12 @@
+//aro-args --emulate=clang
+
+void foo(void) {
+    __float80 x;
+    double y = 1.0w;
+    _Complex double z = 2.0iw;
+}
+
+#define EXPECTED_ERRORS "__float80 clang.c:4:5: error: use of undeclared identifier '__float80'" \
+    "__float80 clang.c:5:16: error: invalid suffix 'w' on floating constant" \
+    "__float80 clang.c:6:25: error: invalid suffix 'iw' on floating constant" \
+

--- a/test/cases/__float80.c
+++ b/test/cases/__float80.c
@@ -1,7 +1,8 @@
+//aro-args --target=x86_64-linux
 void foo(void) {
     __float80 x = 1.0w;
     x = 1.0W;
-    _Complex __float80 z;
+    _Complex long double z;
     z = 1.0wI;
     z = 1.0iW;
 }

--- a/test/cases/ast/__float80.c
+++ b/test/cases/ast/__float80.c
@@ -2,36 +2,36 @@ fn_def: 'fn () void'
  name: foo
  body:
   compound_stmt: 'void'
-    var: '__float80'
+    var: 'long double'
      name: x
      init:
-      float_literal: '__float80' (value: 1)
+      float_literal: 'long double' (value: 1)
 
-    assign_expr: '__float80'
+    assign_expr: 'long double'
      lhs:
-      decl_ref_expr: '__float80' lvalue
+      decl_ref_expr: 'long double' lvalue
        name: x
      rhs:
-      float_literal: '__float80' (value: 1)
+      float_literal: 'long double' (value: 1)
 
-    var: '_Complex __float80'
+    var: '_Complex long double'
      name: z
 
-    assign_expr: '_Complex __float80'
+    assign_expr: '_Complex long double'
      lhs:
-      decl_ref_expr: '_Complex __float80' lvalue
+      decl_ref_expr: '_Complex long double' lvalue
        name: z
      rhs:
-      imaginary_literal: '_Complex __float80'
-        float_literal: '__float80'
+      imaginary_literal: '_Complex long double'
+        float_literal: 'long double'
 
-    assign_expr: '_Complex __float80'
+    assign_expr: '_Complex long double'
      lhs:
-      decl_ref_expr: '_Complex __float80' lvalue
+      decl_ref_expr: '_Complex long double' lvalue
        name: z
      rhs:
-      imaginary_literal: '_Complex __float80'
-        float_literal: '__float80'
+      imaginary_literal: '_Complex long double'
+        float_literal: 'long double'
 
     implicit_return: 'void'
 


### PR DESCRIPTION
Instead, it's a typedef for 80-bit extended double on platforms that support it, when emulating GCC.

Closes #641