### PR TITLE
Tokenizer: treat backslash-newline as an unterminated char/string literal

### DIFF
--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -1300,11 +1300,17 @@ pub fn next(self: *Tokenizer) Token {
                 else => {},
             },
             .char_escape_sequence => switch (c) {
-                '\r', '\n' => unreachable, // removed by line splicing
+                '\r', '\n' => {
+                    id = .unterminated_char_literal;
+                    break;
+                },
                 else => state = .char_literal,
             },
             .string_escape_sequence => switch (c) {
-                '\r', '\n' => unreachable, // removed by line splicing
+                '\r', '\n' => {
+                    id = .unterminated_string_literal;
+                    break;
+                },
                 else => state = .string_literal,
             },
             .identifier, .extended_identifier => switch (c) {

--- a/test/cases/spliced newline in string literal.c
+++ b/test/cases/spliced newline in string literal.c
@@ -1,0 +1,4 @@
+#define NO_ERROR_VALIDATION
+
+"\\
+

--- a/test/spliced newline in char literal.c
+++ b/test/spliced newline in char literal.c
@@ -1,0 +1,3 @@
+#define NO_ERROR_VALIDATION
+'\\
+


### PR DESCRIPTION
Two backslashes followed by two newlines in a literal will result in backslash-newline after linesplicing. Treat this as an unterminated literal

Closes #644