### PR TITLE
Parser: do not define typedefs with invalid types

### DIFF
--- a/src/aro/SymbolStack.zig
+++ b/src/aro/SymbolStack.zig
@@ -178,9 +178,11 @@ pub fn defineTypedef(
     if (s.get(name, .vars)) |prev| {
         switch (prev.kind) {
             .typedef => {
-                if (!ty.eql(prev.ty, p.comp, true)) {
-                    try p.errStr(.redefinition_of_typedef, tok, try p.typePairStrExtra(ty, " vs ", prev.ty));
-                    if (prev.tok != 0) try p.errTok(.previous_definition, prev.tok);
+                if (!prev.ty.is(.invalid)) {
+                    if (!ty.eql(prev.ty, p.comp, true)) {
+                        try p.errStr(.redefinition_of_typedef, tok, try p.typePairStrExtra(ty, " vs ", prev.ty));
+                        if (prev.tok != 0) try p.errTok(.previous_definition, prev.tok);
+                    }
                 }
             },
             .enumeration, .decl, .def, .constexpr => {

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -1899,6 +1899,7 @@ pub const Builder = struct {
 
     /// Try to combine type from typedef, returns true if successful.
     pub fn combineTypedef(b: *Builder, p: *Parser, typedef_ty: Type, name_tok: TokenIndex) bool {
+        if (typedef_ty.is(.invalid)) return false;
         b.error_on_invalid = true;
         defer b.error_on_invalid = false;
 

--- a/test/cases/redefine invalid typedef.c
+++ b/test/cases/redefine invalid typedef.c
@@ -1,0 +1,5 @@
+typedef float *invalid1 __attribute__((vector_size(8)));
+typedef float invalid1;
+
+#define EXPECTED_ERRORS "redefine invalid typedef.c:1:40: error: invalid vector element type 'float *'" \
+


### PR DESCRIPTION
Putting invalid typedefs into the symbol table is problematic because if they get redefined, we try to render the original type (not possible for invalid types) for the error message.

Closes #645