### PR TITLE
Improve unused result diagnostics

### DIFF
--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -789,7 +789,7 @@ pub fn applyFieldAttributes(p: *Parser, field_ty: *Type, attr_buf_start: usize) 
     p.attr_application_buf.items.len = 0;
     for (attrs, toks) |attr, tok| switch (attr.tag) {
         // zig fmt: off
-        .@"packed", .may_alias, .deprecated, .unavailable, .unused, .warn_if_not_aligned, .mode,
+        .@"packed", .may_alias, .deprecated, .unavailable, .unused, .warn_if_not_aligned, .mode, .warn_unused_result, .nodiscard,
         => try p.attr_application_buf.append(p.gpa, attr),
         // zig fmt: on
         .vector_size => try attr.applyVectorSize(p, tok, field_ty),

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -5168,18 +5168,16 @@ pub const Result = struct {
             => return,
             .call_expr_one => {
                 const fn_ptr = p.nodes.items(.data)[@intFromEnum(cur_node)].bin.lhs;
-                const call_tok = p.tmpTree().callableTok(fn_ptr) orelse return;
-                const fn_ty = p.nodes.items(.ty)[@intFromEnum(fn_ptr)].elemType();
-                if (fn_ty.hasAttribute(.nodiscard)) try p.errStr(.nodiscard_unused, expr_start, p.tokSlice(call_tok));
-                if (fn_ty.hasAttribute(.warn_unused_result)) try p.errStr(.warn_unused_result, expr_start, p.tokSlice(call_tok));
+                const call_info = p.tmpTree().callableResultUsage(fn_ptr) orelse return;
+                if (call_info.nodiscard) try p.errStr(.nodiscard_unused, expr_start, p.tokSlice(call_info.tok));
+                if (call_info.warn_unused_result) try p.errStr(.warn_unused_result, expr_start, p.tokSlice(call_info.tok));
                 return;
             },
             .call_expr => {
                 const fn_ptr = p.data.items[p.nodes.items(.data)[@intFromEnum(cur_node)].range.start];
-                const call_tok = p.tmpTree().callableTok(fn_ptr) orelse return;
-                const fn_ty = p.nodes.items(.ty)[@intFromEnum(fn_ptr)].elemType();
-                if (fn_ty.hasAttribute(.nodiscard)) try p.errStr(.nodiscard_unused, expr_start, p.tokSlice(call_tok));
-                if (fn_ty.hasAttribute(.warn_unused_result)) try p.errStr(.warn_unused_result, expr_start, p.tokSlice(call_tok));
+                const call_info = p.tmpTree().callableResultUsage(fn_ptr) orelse return;
+                if (call_info.nodiscard) try p.errStr(.nodiscard_unused, expr_start, p.tokSlice(call_info.tok));
+                if (call_info.warn_unused_result) try p.errStr(.warn_unused_result, expr_start, p.tokSlice(call_info.tok));
                 return;
             },
             .stmt_expr => {

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -5168,20 +5168,18 @@ pub const Result = struct {
             => return,
             .call_expr_one => {
                 const fn_ptr = p.nodes.items(.data)[@intFromEnum(cur_node)].bin.lhs;
+                const call_tok = p.tmpTree().callableTok(fn_ptr) orelse return;
                 const fn_ty = p.nodes.items(.ty)[@intFromEnum(fn_ptr)].elemType();
-                const cast_info = p.nodes.items(.data)[@intFromEnum(fn_ptr)].cast.operand;
-                const decl_ref = p.nodes.items(.data)[@intFromEnum(cast_info)].decl_ref;
-                if (fn_ty.hasAttribute(.nodiscard)) try p.errStr(.nodiscard_unused, expr_start, p.tokSlice(decl_ref));
-                if (fn_ty.hasAttribute(.warn_unused_result)) try p.errStr(.warn_unused_result, expr_start, p.tokSlice(decl_ref));
+                if (fn_ty.hasAttribute(.nodiscard)) try p.errStr(.nodiscard_unused, expr_start, p.tokSlice(call_tok));
+                if (fn_ty.hasAttribute(.warn_unused_result)) try p.errStr(.warn_unused_result, expr_start, p.tokSlice(call_tok));
                 return;
             },
             .call_expr => {
                 const fn_ptr = p.data.items[p.nodes.items(.data)[@intFromEnum(cur_node)].range.start];
+                const call_tok = p.tmpTree().callableTok(fn_ptr) orelse return;
                 const fn_ty = p.nodes.items(.ty)[@intFromEnum(fn_ptr)].elemType();
-                const cast_info = p.nodes.items(.data)[@intFromEnum(fn_ptr)].cast.operand;
-                const decl_ref = p.nodes.items(.data)[@intFromEnum(cast_info)].decl_ref;
-                if (fn_ty.hasAttribute(.nodiscard)) try p.errStr(.nodiscard_unused, expr_start, p.tokSlice(decl_ref));
-                if (fn_ty.hasAttribute(.warn_unused_result)) try p.errStr(.warn_unused_result, expr_start, p.tokSlice(decl_ref));
+                if (fn_ty.hasAttribute(.nodiscard)) try p.errStr(.nodiscard_unused, expr_start, p.tokSlice(call_tok));
+                if (fn_ty.hasAttribute(.warn_unused_result)) try p.errStr(.warn_unused_result, expr_start, p.tokSlice(call_tok));
                 return;
             },
             .stmt_expr => {

--- a/test/cases/warn unused result.c
+++ b/test/cases/warn unused result.c
@@ -1,10 +1,34 @@
+typedef int (*fnptr)(int, int);
+
+
 int foo() __attribute__((warn_unused_result)) {
    return 0;
 }
 
-void bar() {
+fnptr make_fn(int a, int b) {
+   return 0;
+}
+
+void bar(fnptr ptr) {
    foo();
+   (foo)();
+   (foo - 16)();
+   (foo + 16)();
+   (*****foo)();
+   make_fn(1, 2)(2, 2);
+}
+
+struct S {
+  int __attribute__((warn_unused_result))(*close)(void);
+};
+
+void baz(struct S *s){
+    (bar(0), s->close)();
 }
 
 
-#define EXPECTED_ERRORS "warn unused result.c:6:4: warning: ignoring return value of 'foo', declared with 'warn_unused_result' attribute [-Wunused-result]"
+#define EXPECTED_ERRORS "warn unused result.c:13:4: warning: ignoring return value of 'foo', declared with 'warn_unused_result' attribute [-Wunused-result]" \
+   "warn unused result.c:14:4: warning: ignoring return value of 'foo', declared with 'warn_unused_result' attribute [-Wunused-result]" \
+   "warn unused result.c:17:4: warning: ignoring return value of 'foo', declared with 'warn_unused_result' attribute [-Wunused-result]" \
+   "warn unused result.c:26:5: warning: ignoring return value of 'close', declared with 'warn_unused_result' attribute [-Wunused-result]" \
+


### PR DESCRIPTION
Inspect the tree more closely to make sure we're accessing the correct data fields. Also adds result usage warnings/errors for calling function pointer fields of records.

Closes #653