### PR TITLE
Attribute: convert unimplemented attributes to errors instead of panics

### DIFF
--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -772,7 +772,7 @@ pub fn applyVariableAttributes(p: *Parser, ty: Type, attr_buf_start: usize, tag:
         .copy,
         .tls_model,
         .visibility,
-        => std.debug.panic("apply variable attribute {s}", .{@tagName(attr.tag)}),
+        => |t| try p.errExtra(.attribute_todo, tok, .{ .attribute_todo = .{ .tag = t, .kind = .variables } }),
         else => try ignoredAttrErr(p, tok, attr.tag, "variables"),
     };
     const existing = ty.getAttributes();
@@ -823,7 +823,7 @@ pub fn applyTypeAttributes(p: *Parser, ty: Type, attr_buf_start: usize, tag: ?Di
         .copy,
         .scalar_storage_order,
         .nonstring,
-        => std.debug.panic("apply type attribute {s}", .{@tagName(attr.tag)}),
+        => |t| try p.errExtra(.attribute_todo, tok, .{ .attribute_todo = .{ .tag = t, .kind = .types } }),
         else => try ignoredAttrErr(p, tok, attr.tag, "types"),
     };
 
@@ -943,7 +943,7 @@ pub fn applyFunctionAttributes(p: *Parser, ty: Type, attr_buf_start: usize) !Typ
         .visibility,
         .weakref,
         .zero_call_used_regs,
-        => std.debug.panic("apply type attribute {s}", .{@tagName(attr.tag)}),
+        => |t| try p.errExtra(.attribute_todo, tok, .{ .attribute_todo = .{ .tag = t, .kind = .functions } }),
         else => try ignoredAttrErr(p, tok, attr.tag, "functions"),
     };
     return ty.withAttributes(p.arena, p.attr_application_buf.items);

--- a/src/aro/Diagnostics.zig
+++ b/src/aro/Diagnostics.zig
@@ -47,6 +47,10 @@ pub const Message = struct {
             tag: Attribute.Tag,
             specifier: enum { @"struct", @"union", @"enum" },
         },
+        attribute_todo: struct {
+            tag: Attribute.Tag,
+            kind: enum { variables, fields, types, functions },
+        },
         builtin_with_header: struct {
             builtin: Builtin.Tag,
             header: Header,
@@ -421,6 +425,10 @@ pub fn renderMessage(comp: *Compilation, m: anytype, msg: Message) void {
         .ignored_record_attr => printRt(m, prop.msg, .{ "{s}", "{s}" }, .{
             @tagName(msg.extra.ignored_record_attr.tag),
             @tagName(msg.extra.ignored_record_attr.specifier),
+        }),
+        .attribute_todo => printRt(m, prop.msg, .{ "{s}", "{s}" }, .{
+            @tagName(msg.extra.attribute_todo.tag),
+            @tagName(msg.extra.attribute_todo.kind),
         }),
         .builtin_with_header => printRt(m, prop.msg, .{ "{s}", "{s}" }, .{
             @tagName(msg.extra.builtin_with_header.header),

--- a/src/aro/Diagnostics/messages.def
+++ b/src/aro/Diagnostics/messages.def
@@ -2472,3 +2472,8 @@ overflow_result_requires_ptr
     .msg = "result argument to overflow builtin must be a pointer to a non-const integer ('{s}' invalid)"
     .extra = .str
     .kind = .@"error"
+
+attribute_todo
+    .msg = "TODO: implement '{s}' attribute for {s}"
+    .extra = .attribute_todo
+    .kind = .@"error"


### PR DESCRIPTION
Tested manually since this is meant to be temporary but I can add test cases if you want.