### PR TITLE
Tokenizer: prevent OOB read when processing #embed directive

### DIFF
--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -1802,7 +1802,7 @@ pub fn nextNoWSComments(self: *Tokenizer) Token {
 /// Try to tokenize a '::' even if not supported by the current language standard.
 pub fn colonColon(self: *Tokenizer) Token {
     var tok = self.nextNoWS();
-    if (tok.id == .colon and self.buf[self.index] == ':') {
+    if (tok.id == .colon and self.index < self.buf.len and self.buf[self.index] == ':') {
         self.index += 1;
         tok.id = .colon_colon;
     }

--- a/test/cases/colon after #embed.c
+++ b/test/cases/colon after #embed.c
@@ -1,0 +1,3 @@
+#define NO_ERROR_VALIDATION
+
+#embed "embed byte"n:


### PR DESCRIPTION
If a colon appeared at the end of an embed directive and was the last byte in a file, we would do an out of bounds read trying to tokenize a double colon.