### PR TITLE
Parser: handle error during parsing of generic selection

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -8614,11 +8614,16 @@ fn genericSelection(p: *Parser) Error!Result {
                 try p.errStr(.generic_duplicate, start, try p.typeStr(ty));
                 try p.errStr(.generic_duplicate_here, chosen_tok, try p.typeStr(ty));
             }
-            for (p.list_buf.items[list_buf_top + 1 ..], p.decl_buf.items[decl_buf_top..]) |item, prev_tok| {
-                const prev_ty = p.nodes.items(.ty)[@intFromEnum(item)];
-                if (prev_ty.eql(ty, p.comp, true)) {
-                    try p.errStr(.generic_duplicate, start, try p.typeStr(ty));
-                    try p.errStr(.generic_duplicate_here, @intFromEnum(prev_tok), try p.typeStr(ty));
+            const list_buf = p.list_buf.items[list_buf_top + 1 ..];
+            const decl_buf = p.decl_buf.items[decl_buf_top..];
+            if (list_buf.len == decl_buf.len) {
+                // If these do not have the same length, there is already an error
+                for (list_buf, decl_buf) |item, prev_tok| {
+                    const prev_ty = p.nodes.items(.ty)[@intFromEnum(item)];
+                    if (prev_ty.eql(ty, p.comp, true)) {
+                        try p.errStr(.generic_duplicate, start, try p.typeStr(ty));
+                        try p.errStr(.generic_duplicate_here, @intFromEnum(prev_tok), try p.typeStr(ty));
+                    }
                 }
             }
             try p.list_buf.append(try p.addNode(.{

--- a/test/cases/generic.c
+++ b/test/cases/generic.c
@@ -8,6 +8,7 @@ void foo(void) {
     _Static_assert(_Generic(7, int[2]: 8, int(int): 9, default: 1) == 1, "test failure");
     _Static_assert(_Generic(7, default: 1) == 1, "test failure");
     _Static_assert(_Generic("hello", char *: 1, default: 2) == 1, "test failure");
+    _Generic(0, int: 8, long: bar());
 }
 
 #define EXPECTED_ERRORS "generic.c:2:15: error: expected ',', found ')'" \
@@ -22,3 +23,5 @@ void foo(void) {
     "generic.c:7:23: note: compatible type 'int' specified here" \
     "generic.c:8:32: warning: generic association array type cannot be matched with [-Wgeneric-qual-type]" \
     "generic.c:8:43: warning: generic association function type cannot be matched with [-Wgeneric-qual-type]" \
+    "generic.c:11:31: error: call to undeclared function 'bar'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]" \
+


### PR DESCRIPTION
ensure list_buf and decl_buf have the same length before iterating over them to check for duplicate controlling expressions

Fixes #659