### PR TITLE
Parser: boolcast lhs of logical `or` expression even if not evaluating it

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6415,6 +6415,8 @@ fn lorExpr(p: *Parser) Error!Result {
         if (try lhs.adjustTypes(tok, &rhs, p, .boolean_logic)) {
             const res = lhs.val.toBool(p.comp) or rhs.val.toBool(p.comp);
             lhs.val = Value.fromBool(res);
+        } else {
+            lhs.val.boolCast(p.comp);
         }
         try lhs.boolRes(p, .bool_or_expr, rhs);
     }

--- a/test/cases/float values.c
+++ b/test/cases/float values.c
@@ -1,2 +1,6 @@
 _Static_assert(-1.0 - 1.0 == -2.0, "");
 _Static_assert(-2.0f == -2.0, "");
+_Static_assert(1.0 == (2.0||0), "");
+void foo(void) {
+    float f = 2.0 || 0;
+}


### PR DESCRIPTION
Ensure that the value, if present, is zero or one.

Closes #668