### PR TITLE
Preprocessor: trailing backslash in stringize output is allowed if escaped

### DIFF
--- a/test/cases/stringify backslashes.c
+++ b/test/cases/stringify backslashes.c
@@ -1,0 +1,8 @@
+#define NO_ERROR_VALIDATION
+
+#define str(s) #s
+x[str()
+x[str(\)
+x[str(\\)
+x[str(\\\)
+x[str(\\\\)


### PR DESCRIPTION
If the stringify output ends with a backslash, retokenize it to determine if the final backslash is unpaired.