### PR TITLE
Value: allocate enough limbs for bitwise xor result

### DIFF
--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -739,9 +739,10 @@ pub fn bitXor(lhs: Value, rhs: Value, comp: *Compilation) !Value {
     const lhs_bigint = lhs.toBigInt(&lhs_space, comp);
     const rhs_bigint = rhs.toBigInt(&rhs_space, comp);
 
+    const extra = @intFromBool(lhs_bigint.positive != rhs_bigint.positive);
     const limbs = try comp.gpa.alloc(
         std.math.big.Limb,
-        @max(lhs_bigint.limbs.len, rhs_bigint.limbs.len),
+        @max(lhs_bigint.limbs.len, rhs_bigint.limbs.len) + extra,
     );
     defer comp.gpa.free(limbs);
     var result_bigint = std.math.big.int.Mutable{ .limbs = limbs, .positive = undefined, .len = undefined };

--- a/test/cases/binary expressions.c
+++ b/test/cases/binary expressions.c
@@ -72,6 +72,13 @@ int invalid_ptr_arithmetic(struct Foo *num) {
     return num - num;
 }
 
+_Static_assert((1 ^ -1) == -2, "");
+_Static_assert((0 ^ 0) == 0, "");
+_Static_assert((-1 ^ 0) == -1, "");
+_Static_assert((-1 ^ -1) == 0, "");
+_Static_assert((-2 ^ 2) == -4, "");
+
+
 #define EXPECTED_ERRORS "binary expressions.c:3:7: error: invalid operands to binary expression ('long' and 'float')" \
     "binary expressions.c:6:13: error: invalid operands to binary expression ('char' and 'int *')" \
     "binary expressions.c:8:9: error: invalid operands to binary expression ('void (*)(void)' and 'void')" \


### PR DESCRIPTION
bigint bitXor docs say that if exactly one argument is negative, we need an extra limb.

Closes #667
