### PR TITLE
Parser: don't create pointer-to-invalid via ampersand operator

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6979,17 +6979,19 @@ fn unExpr(p: *Parser) Error!Result {
             {
                 if (tree.isBitfield(member_node)) try p.errTok(.addr_of_bitfield, tok);
             }
-            if (!tree.isLval(operand.node)) {
+            if (!tree.isLval(operand.node) and !operand.ty.is(.invalid)) {
                 try p.errTok(.addr_of_rvalue, tok);
             }
             if (operand.ty.qual.register) try p.errTok(.addr_of_register, tok);
 
-            const elem_ty = try p.arena.create(Type);
-            elem_ty.* = operand.ty;
-            operand.ty = Type{
-                .specifier = .pointer,
-                .data = .{ .sub_type = elem_ty },
-            };
+            if (!operand.ty.is(.invalid)) {
+                const elem_ty = try p.arena.create(Type);
+                elem_ty.* = operand.ty;
+                operand.ty = Type{
+                    .specifier = .pointer,
+                    .data = .{ .sub_type = elem_ty },
+                };
+            }
             try operand.saveValue(p);
             try operand.un(p, .addr_of_expr);
             return operand;

--- a/test/cases/binary expressions.c
+++ b/test/cases/binary expressions.c
@@ -72,6 +72,11 @@ int invalid_ptr_arithmetic(struct Foo *num) {
     return num - num;
 }
 
+void address_of_invalid_type(void) {
+    char x[64];
+    char *y = &(x&x);    
+}
+
 _Static_assert((1 ^ -1) == -2, "");
 _Static_assert((0 ^ 0) == 0, "");
 _Static_assert((-1 ^ 0) == -1, "");
@@ -104,3 +109,5 @@ _Static_assert((-2 ^ 2) == -4, "");
     "binary expressions.c:62:7: error: invalid operands to binary expression ('int' and 'float')" \
     "binary expressions.c:67:5: error: used type 'void' where arithmetic or pointer type is required" \
     "binary expressions.c:72:16: error: arithmetic on a pointer to an incomplete type 'struct Foo'" \
+    "binary expressions.c:77:18: error: invalid operands to binary expression ('char *' and 'char *')" \
+


### PR DESCRIPTION
Fixes #669