### PR TITLE
Parser: don't concatenate improperly-encoded strings

### DIFF
--- a/test/cases/concat improperly encoded strings.c
+++ b/test/cases/concat improperly encoded strings.c
@@ -1,0 +1,5 @@
+/* Note: saved with iso-8859-1 encoding, do not change */
+int *p = L"" "ÿ";
+
+#define EXPECTED_ERRORS "concat improperly encoded strings.c:2:14: error: illegal character encoding in character literal" \
+


### PR DESCRIPTION
Fixes #674