### PR TITLE
Value: compare for zero against float instead of Value

### DIFF
--- a/build/GenerateDef.zig
+++ b/build/GenerateDef.zig
@@ -198,7 +198,7 @@ fn generate(self: *GenerateDef, input: []const u8) ![]const u8 {
         if (self.kind == .named) {
             try writer.writeAll("pub const Tag = enum {\n");
             for (values.keys()) |property| {
-                try writer.print("    {s},\n", .{std.zig.fmtId(property)});
+                try writer.print("    {p},\n", .{std.zig.fmtId(property)});
             }
             try writer.writeAll(
                 \\

--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -870,6 +870,12 @@ pub fn compare(lhs: Value, op: std.math.CompareOperator, rhs: Value, comp: *cons
         const rhs_f128 = rhs.toFloat(f128, comp);
         return std.math.compare(lhs_f128, op, rhs_f128);
     }
+    if (lhs_key == .complex or rhs_key == .complex) {
+        assert(op == .neq);
+        const real_equal = std.math.compare(lhs.toFloat(f128, comp), .eq, rhs.toFloat(f128, comp));
+        const imag_equal = std.math.compare(lhs.imag(f128, comp), .eq, rhs.imag(f128, comp));
+        return !real_equal or !imag_equal;
+    }
 
     var lhs_bigint_space: BigIntSpace = undefined;
     var rhs_bigint_space: BigIntSpace = undefined;

--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -143,7 +143,7 @@ pub fn floatToInt(v: *Value, dest_ty: Type, comp: *Compilation) !FloatToIntChang
         v.* = fromBool(!was_zero);
         if (was_zero or was_one) return .none;
         return .value_changed;
-    } else if (dest_ty.isUnsignedInt(comp) and v.compare(.lt, zero, comp)) {
+    } else if (dest_ty.isUnsignedInt(comp) and float_val < 0) {
         v.* = zero;
         return .out_of_range;
     }

--- a/test/cases/complex values.c
+++ b/test/cases/complex values.c
@@ -34,6 +34,7 @@ _Complex double c = (_Complex double) {1.0, 2.0,3.0};
 _Static_assert(3 + 4.0il == 3 + 4.0il, "");
 _Static_assert(5ll + 4.0il == 5ll + 4.0il, "");
 unsigned long complex_integer = 2.0i;
+bool b = 3 != 2.0i;
 
 #define EXPECTED_ERRORS "complex values.c:31:49: error: expected expression" \
 	"complex values.c:32:49: warning: excess elements in scalar initializer [-Wexcess-initializers]" \

--- a/test/cases/complex values.c
+++ b/test/cases/complex values.c
@@ -33,6 +33,7 @@ _Complex double c = (_Complex double) {1.0, 2.0,3.0};
 
 _Static_assert(3 + 4.0il == 3 + 4.0il, "");
 _Static_assert(5ll + 4.0il == 5ll + 4.0il, "");
+unsigned long complex_integer = 2.0i;
 
 #define EXPECTED_ERRORS "complex values.c:31:49: error: expected expression" \
 	"complex values.c:32:49: warning: excess elements in scalar initializer [-Wexcess-initializers]" \


### PR DESCRIPTION
We can't compare complex values; toFloat grabs just the real part. This logic will need to be updated when complex int values are supported.

Fixes #675