### PR TITLE
Set size of typeof-incomplete arrays correctly

### DIFF
--- a/src/aro/LangOpts.zig
+++ b/src/aro/LangOpts.zig
@@ -47,7 +47,7 @@ pub const Standard = enum {
     /// Working Draft for ISO C23 with GNU extensions
     gnu23,
 
-    const NameMap = std.ComptimeStringMap(Standard, .{
+    const NameMap = std.StaticStringMap(Standard).initComptime(.{
         .{ "c89", .c89 },                .{ "c90", .c89 },          .{ "iso9899:1990", .c89 },
         .{ "iso9899:199409", .iso9899 }, .{ "gnu89", .gnu89 },      .{ "gnu90", .gnu89 },
         .{ "c99", .c99 },                .{ "iso9899:1999", .c99 }, .{ "c9x", .c99 },

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1818,10 +1818,8 @@ fn initDeclarator(p: *Parser, decl_spec: *DeclSpec, attr_buf_top: usize) Error!?
         var init_list_expr = try p.initializer(init_d.d.ty);
         init_d.initializer = init_list_expr;
         if (!init_list_expr.ty.isArray()) break :init;
-        if (init_d.d.ty.specifier == .incomplete_array) {
-            // Modifying .data is exceptionally allowed for .incomplete_array.
-            init_d.d.ty.data.array.len = init_list_expr.ty.arrayLen() orelse break :init;
-            init_d.d.ty.specifier = .array;
+        if (init_d.d.ty.is(.incomplete_array)) {
+            init_d.d.ty.setIncompleteArrayLen(init_list_expr.ty.arrayLen() orelse break :init);
         }
     }
 

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6648,7 +6648,7 @@ fn mulExpr(p: *Parser) Error!Result {
                     lhs.ty.signedness(p.comp) != .unsigned) try p.errOverflow(mul.?, lhs);
             } else if (div != null) {
                 if (try lhs.val.div(lhs.val, rhs.val, lhs.ty, p.comp) and
-                    lhs.ty.signedness(p.comp) != .unsigned) try p.errOverflow(mul.?, lhs);
+                    lhs.ty.signedness(p.comp) != .unsigned) try p.errOverflow(div.?, lhs);
             } else {
                 var res = try Value.rem(lhs.val, rhs.val, lhs.ty, p.comp);
                 if (res.opt_ref == .none) {

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -1731,7 +1731,7 @@ fn expandFuncMacro(
                     }
                     if (!pp.comp.langopts.standard.atLeast(.c23)) break :res not_found;
 
-                    const attrs = std.ComptimeStringMap([]const u8, .{
+                    const attrs = std.StaticStringMap([]const u8).initComptime(.{
                         .{ "deprecated", "201904L\n" },
                         .{ "fallthrough", "201904L\n" },
                         .{ "maybe_unused", "201904L\n" },

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -875,11 +875,8 @@ pub const Token = struct {
         };
     }
 
-    const all_kws = std.ComptimeStringMap(Id, .{
-        .{ "auto", auto: {
-            @setEvalBranchQuota(3000);
-            break :auto .keyword_auto;
-        } },
+    const all_kws = std.StaticStringMap(Id).initComptime(.{
+        .{ "auto", .keyword_auto },
         .{ "break", .keyword_break },
         .{ "case", .keyword_case },
         .{ "char", .keyword_char },

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -463,6 +463,23 @@ pub fn isArray(ty: Type) bool {
     };
 }
 
+/// Must only be used to set the length of an incomplete array as determined by its initializer
+pub fn setIncompleteArrayLen(ty: *Type, len: u64) void {
+    switch (ty.specifier) {
+        .incomplete_array => {
+            // Modifying .data is exceptionally allowed for .incomplete_array.
+            ty.data.array.len = len;
+            ty.specifier = .array;
+        },
+
+        .typeof_type => ty.data.sub_type.setIncompleteArrayLen(len),
+        .typeof_expr => ty.data.expr.ty.setIncompleteArrayLen(len),
+        .attributed => ty.data.attributed.base.setIncompleteArrayLen(len),
+
+        else => unreachable,
+    }
+}
+
 /// Whether the type is promoted if used as a variadic argument or as an argument to a function with no prototype
 fn undergoesDefaultArgPromotion(ty: Type, comp: *const Compilation) bool {
     return switch (ty.specifier) {

--- a/test/cases/arithmetic overflow.c
+++ b/test/cases/arithmetic overflow.c
@@ -5,3 +5,7 @@ _Static_assert(0x00000000 - 0x00000001 == 0xFFFFFFFF, "");
 _Static_assert(0x80000000 * 2 == 0, "");
 _Static_assert(2 * 0x80000000 == 0, "");
 _Static_assert(sizeof(int) != 4 || ((unsigned)(-1) << 1) == 0xFFFFFFFFU - 1, "");
+_Static_assert((-9223372036854775807LL - 1LL) / -1 != 0, "failed");
+
+#define EXPECTED_ERRORS "arithmetic overflow.c:8:47: warning: overflow in expression; result is '9223372036854775808' [-Winteger-overflow]" \
+

--- a/test/cases/typeof incomplete array.c
+++ b/test/cases/typeof incomplete array.c
@@ -1,0 +1,2 @@
+typeof(const int[]) arr1 = {1,2};
+_Static_assert(sizeof(arr1) == sizeof(int[2]), "");

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -4,11 +4,8 @@ const aro = @import("aro");
 
 /// These tests don't work for any platform due to Aro bugs.
 /// Skip entirely.
-const global_test_exclude = std.ComptimeStringMap(void, .{
-    // ComptimeStringMap can't be empty so the entry below is a placeholder
-    // To skip a test entirely just put the test name e.g. .{"0044"}
-    .{"NONE"},
-});
+/// To skip a test entirely just put the test name as a single-element tuple e.g. initComptime(.{.{"0044"}});
+const global_test_exclude = std.StaticStringMap(void).initComptime(.{});
 
 fn lessThan(_: void, lhs: []const u8, rhs: []const u8) bool {
     return std.mem.lessThan(u8, lhs, rhs);
@@ -412,7 +409,7 @@ fn parseTargetsFromCode(cases: *TestCase.List, path: []const u8, source: []const
 
 const compErr = blk: {
     @setEvalBranchQuota(100_000);
-    break :blk std.ComptimeStringMap(ExpectedFailure, .{
+    break :blk std.StaticStringMap(ExpectedFailure).initComptime(.{
         .{
             "aarch64-generic-windows-msvc:Msvc|0011",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },


### PR DESCRIPTION
Also includes an unrelated copy-paste fix for division overflow