### PR TITLE
Parser: allow calling function via statement expression

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6702,7 +6702,7 @@ fn removeUnusedWarningForTok(p: *Parser, last_expr_tok: TokenIndex) void {
 }
 
 /// castExpr
-///  :  '(' compoundStmt ')'
+///  :  '(' compoundStmt ')' suffixExpr*
 ///  |  '(' typeName ')' castExpr
 ///  | '(' typeName ')' '{' initializerItems '}'
 ///  | __builtin_choose_expr '(' integerConstExpr ',' assignExpr ',' assignExpr ')'
@@ -6729,6 +6729,11 @@ fn castExpr(p: *Parser) Error!Result {
             };
             try p.expectClosing(l_paren, .r_paren);
             try res.un(p, .stmt_expr);
+            while (true) {
+                const suffix = try p.suffixExpr(res);
+                if (suffix.empty(p)) break;
+                res = suffix;
+            }
             return res;
         }
         const ty = (try p.typeName()) orelse {

--- a/test/cases/statement expressions.c
+++ b/test/cases/statement expressions.c
@@ -16,6 +16,7 @@ void foo(void) {
         z;
     });
     z++;
+    ({foo;})();
 }
 
 void self_referential_initializer(void) {


### PR DESCRIPTION
resolve #654
Add suffixExpr parsing after compoundStmt before returning in castExpr like it is done in unExpr, without that the expr returned without parsing the callExpr and, expecting the semicolon, it generated an error.