### PR TITLE
Fix usage of deprecated std lib APIs

### DIFF
--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -792,7 +792,7 @@ pub fn invokeLinker(d: *Driver, tc: *Toolchain, comptime fast_exit: bool) !void 
     var argv = std.ArrayList([]const u8).init(d.comp.gpa);
     defer argv.deinit();
 
-    var linker_path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var linker_path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const linker_path = try tc.getLinkerPath(&linker_path_buf);
     try argv.append(linker_path);
 
@@ -803,7 +803,7 @@ pub fn invokeLinker(d: *Driver, tc: *Toolchain, comptime fast_exit: bool) !void 
             return d.fatal("unable to dump linker args: {s}", .{errorDescription(er)});
         };
     }
-    var child = std.ChildProcess.init(argv.items, d.comp.gpa);
+    var child = std.process.Child.init(argv.items, d.comp.gpa);
     // TODO handle better
     child.stdin_behavior = .Inherit;
     child.stdout_behavior = .Inherit;

--- a/src/aro/Driver/Filesystem.zig
+++ b/src/aro/Driver/Filesystem.zig
@@ -46,7 +46,7 @@ fn canExecuteFake(entries: []const Filesystem.Entry, path: []const u8) bool {
 
 fn existsFake(entries: []const Filesystem.Entry, path: []const u8) bool {
     @setCold(true);
-    var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
     var fib = std.heap.FixedBufferAllocator.init(&buf);
     const resolved = std.fs.path.resolvePosix(fib.allocator(), &.{path}) catch return false;
     for (entries) |entry| {
@@ -181,7 +181,7 @@ pub const Filesystem = union(enum) {
     }
 
     pub fn joinedExists(fs: Filesystem, parts: []const []const u8) bool {
-        var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
         var fib = std.heap.FixedBufferAllocator.init(&buf);
         const joined = std.fs.path.join(fib.allocator(), parts) catch return false;
         return fs.exists(joined);

--- a/src/aro/Driver/GCCDetector.zig
+++ b/src/aro/Driver/GCCDetector.zig
@@ -397,7 +397,7 @@ fn collectLibDirsAndTriples(
 }
 
 pub fn discover(self: *GCCDetector, tc: *Toolchain) !void {
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     var fib = std.heap.FixedBufferAllocator.init(&path_buf);
 
     const target = tc.getTarget();
@@ -589,7 +589,7 @@ fn scanLibDirForGCCTriple(
     gcc_dir_exists: bool,
     gcc_cross_dir_exists: bool,
 ) !void {
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     var fib = std.heap.FixedBufferAllocator.init(&path_buf);
     for (0..2) |i| {
         if (i == 0 and !gcc_dir_exists) continue;

--- a/src/aro/Toolchain.zig
+++ b/src/aro/Toolchain.zig
@@ -221,7 +221,7 @@ pub fn addFilePathLibArgs(tc: *const Toolchain, argv: *std.ArrayList([]const u8)
 /// If not found there, just use `name`
 /// Writes the result to `buf` and returns a slice of it
 fn getProgramPath(tc: *const Toolchain, name: []const u8, buf: []u8) []const u8 {
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     var fib = std.heap.FixedBufferAllocator.init(&path_buf);
 
     var tool_specific_buf: [64]u8 = undefined;
@@ -251,7 +251,7 @@ pub fn getSysroot(tc: *const Toolchain) []const u8 {
 /// Search for `name` in a variety of places
 /// TODO: cache results based on `name` so we're not repeatedly allocating the same strings?
 pub fn getFilePath(tc: *const Toolchain, name: []const u8) ![]const u8 {
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     var fib = std.heap.FixedBufferAllocator.init(&path_buf);
     const allocator = fib.allocator();
 
@@ -304,7 +304,7 @@ const PathKind = enum {
 /// Join `components` into a path. If the path exists, dupe it into the toolchain arena and
 /// add it to the specified path list.
 pub fn addPathIfExists(tc: *Toolchain, components: []const []const u8, dest_kind: PathKind) !void {
-    var path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
     var fib = std.heap.FixedBufferAllocator.init(&path_buf);
 
     const candidate = try std.fs.path.join(fib.allocator(), components);

--- a/src/aro/toolchains/Linux.zig
+++ b/src/aro/toolchains/Linux.zig
@@ -478,7 +478,7 @@ test Linux {
     var argv = std.ArrayList([]const u8).init(driver.comp.gpa);
     defer argv.deinit();
 
-    var linker_path_buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+    var linker_path_buf: [std.fs.max_path_bytes]u8 = undefined;
     const linker_path = try toolchain.getLinkerPath(&linker_path_buf);
     try argv.append(linker_path);
 

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -344,7 +344,7 @@ fn singleRun(alloc: std.mem.Allocator, test_dir: []const u8, test_case: TestCase
 /// Get Zig std.Target from string in the arch-cpu-os-abi format.
 fn getTarget(zig_target_string: []const u8) !std.Target {
     var ret: std.Target = undefined;
-    var iter = std.mem.tokenize(u8, zig_target_string, "-");
+    var iter = std.mem.tokenizeScalar(u8, zig_target_string, '-');
 
     ret.cpu.arch = std.meta.stringToEnum(std.Target.Cpu.Arch, iter.next().?).?;
     ret.cpu.model = try std.Target.Cpu.Arch.parseCpuModel(ret.cpu.arch, iter.next().?);
@@ -384,12 +384,12 @@ fn setTarget(comp: *aro.Compilation, target: []const u8) !std.Target {
 }
 
 fn parseTargetsFromCode(cases: *TestCase.List, path: []const u8, source: []const u8) !void {
-    var lines = std.mem.tokenize(u8, source, "\n");
+    var lines = std.mem.tokenizeScalar(u8, source, '\n');
     while (lines.next()) |line| {
         if (std.mem.indexOf(u8, line, "// MAPPING|") == null) continue;
 
         std.debug.assert(std.mem.count(u8, line, "|") > 1);
-        var parts = std.mem.tokenize(u8, line, "|");
+        var parts = std.mem.tokenizeScalar(u8, line, '|');
         _ = parts.next(); // Skip the MAPPING bit
         const define = parts.next().?; // The define to set for this chunk.
 

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -20,7 +20,7 @@ fn addCommandLineArgs(comp: *aro.Compilation, file: aro.Source, macro_buf: anyty
         var test_args = std.ArrayList([]const u8).init(comp.gpa);
         defer test_args.deinit();
         const nl = std.mem.indexOfAny(u8, file.buf, "\n\r") orelse file.buf.len;
-        var it = std.mem.tokenize(u8, file.buf[0..nl], " ");
+        var it = std.mem.tokenizeScalar(u8, file.buf[0..nl], ' ');
         while (it.next()) |some| try test_args.append(some);
 
         var driver: aro.Driver = .{ .comp = comp };
@@ -37,7 +37,7 @@ fn addCommandLineArgs(comp: *aro.Compilation, file: aro.Source, macro_buf: anyty
     if (std.mem.indexOf(u8, file.buf, "//aro-env")) |idx| {
         const buf = file.buf[idx..];
         const nl = std.mem.indexOfAny(u8, buf, "\n\r") orelse buf.len;
-        var it = std.mem.tokenize(u8, buf[0..nl], " ");
+        var it = std.mem.tokenizeScalar(u8, buf[0..nl], ' ');
         while (it.next()) |some| {
             var parts = std.mem.splitScalar(u8, some, '=');
             const name = parts.next().?;
@@ -411,7 +411,7 @@ pub fn main() !void {
             //     try obj.finish(out_file);
             // }
 
-            var child = std.ChildProcess.init(&.{ args[2], "run", "-lc", obj_name }, gpa);
+            var child = std.process.Child.init(&.{ args[2], "run", "-lc", obj_name }, gpa);
             child.stdout_behavior = .Pipe;
 
             try child.spawn();


### PR DESCRIPTION
Updates Aro in preparation for https://github.com/ziglang/zig/pull/19847.

This is mergable now; it will just avoid compile errors once that PR is merged.

EDIT: CI failure is unrelated and would be fixed by https://github.com/Vexu/arocc/pull/707/commits/97697e702408bcbe7850f8b9d9db6fcb88bea8be:
```
src/aro/target.zig:744:22: error: switch must handle all possibilities
/opt/hostedtoolcache/zig/master/x64/lib/std/Target.zig:652:5: note: unhandled enumeration value: 'ohos'
```