### PR TITLE
Get rid of a trailing space in `Compilation.zig`.

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -534,8 +534,8 @@ pub fn generateBuiltinMacros(comp: *Compilation, system_defines_mode: SystemDefi
 
     if (system_defines_mode == .include_system_defines) {
         try buf.appendSlice(
-            \\#define __VERSION__ "Aro 
-        ++ @import("backend").version_str ++ "\"\n" ++
+            \\#define __VERSION__ "Aro
+        ++ " " ++ @import("backend").version_str ++ "\"\n" ++
             \\#define __Aro__
             \\
         );


### PR DESCRIPTION
This kept tripping me up because I have my editor configured to eliminate trailing white space on save.