### PR TITLE
Compilation: store cwd in Compilation

### DIFF
--- a/src/aro/Builtins.zig
+++ b/src/aro/Builtins.zig
@@ -350,7 +350,7 @@ test Iterator {
 }
 
 test "All builtins" {
-    var comp = Compilation.init(std.testing.allocator);
+    var comp = Compilation.init(std.testing.allocator, std.fs.cwd());
     defer comp.deinit();
     _ = try comp.generateBuiltinMacros(.include_system_defines);
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -373,7 +373,7 @@ test "All builtins" {
 test "Allocation failures" {
     const Test = struct {
         fn testOne(allocator: std.mem.Allocator) !void {
-            var comp = Compilation.init(allocator);
+            var comp = Compilation.init(allocator, std.fs.cwd());
             defer comp.deinit();
             _ = try comp.generateBuiltinMacros(.include_system_defines);
             var arena = std.heap.ArenaAllocator.init(comp.gpa);

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -3383,7 +3383,7 @@ test "Preserve pragma tokens sometimes" {
             var buf = std.ArrayList(u8).init(allocator);
             defer buf.deinit();
 
-            var comp = Compilation.init(allocator);
+            var comp = Compilation.init(allocator, std.fs.cwd());
             defer comp.deinit();
 
             try comp.addDefaultPragmaHandlers();
@@ -3443,7 +3443,7 @@ test "destringify" {
             try std.testing.expectEqualStrings(destringified, pp.char_buf.items);
         }
     };
-    var comp = Compilation.init(allocator);
+    var comp = Compilation.init(allocator, std.fs.cwd());
     defer comp.deinit();
     var pp = Preprocessor.init(&comp);
     defer pp.deinit();
@@ -3501,7 +3501,7 @@ test "Include guards" {
         }
 
         fn testIncludeGuard(allocator: std.mem.Allocator, comptime template: []const u8, tok_id: RawToken.Id, expected_guards: u32) !void {
-            var comp = Compilation.init(allocator);
+            var comp = Compilation.init(allocator, std.fs.cwd());
             defer comp.deinit();
             var pp = Preprocessor.init(&comp);
             defer pp.deinit();

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -2151,7 +2151,7 @@ test "C23 keywords" {
 }
 
 test "Tokenizer fuzz test" {
-    var comp = Compilation.init(std.testing.allocator);
+    var comp = Compilation.init(std.testing.allocator, std.fs.cwd());
     defer comp.deinit();
 
     const input_bytes = std.testing.fuzzInput(.{});
@@ -2173,7 +2173,7 @@ test "Tokenizer fuzz test" {
 }
 
 fn expectTokensExtra(contents: []const u8, expected_tokens: []const Token.Id, standard: ?LangOpts.Standard) !void {
-    var comp = Compilation.init(std.testing.allocator);
+    var comp = Compilation.init(std.testing.allocator, std.fs.cwd());
     defer comp.deinit();
     if (standard) |provided| {
         comp.langopts.standard = provided;

--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -67,7 +67,7 @@ test "minUnsignedBits" {
         }
     };
 
-    var comp = Compilation.init(std.testing.allocator);
+    var comp = Compilation.init(std.testing.allocator, std.fs.cwd());
     defer comp.deinit();
     const target_query = try std.Target.Query.parse(.{ .arch_os_abi = "x86_64-linux-gnu" });
     comp.target = try std.zig.system.resolveTargetQuery(target_query);
@@ -102,7 +102,7 @@ test "minSignedBits" {
         }
     };
 
-    var comp = Compilation.init(std.testing.allocator);
+    var comp = Compilation.init(std.testing.allocator, std.fs.cwd());
     defer comp.deinit();
     const target_query = try std.Target.Query.parse(.{ .arch_os_abi = "x86_64-linux-gnu" });
     comp.target = try std.zig.system.resolveTargetQuery(target_query);

--- a/src/aro/toolchains/Linux.zig
+++ b/src/aro/toolchains/Linux.zig
@@ -424,7 +424,7 @@ test Linux {
     defer arena_instance.deinit();
     const arena = arena_instance.allocator();
 
-    var comp = Compilation.init(std.testing.allocator);
+    var comp = Compilation.init(std.testing.allocator, std.fs.cwd());
     defer comp.deinit();
     comp.environment = .{
         .path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",

--- a/src/main.zig
+++ b/src/main.zig
@@ -37,7 +37,7 @@ pub fn main() u8 {
     };
     defer gpa.free(aro_name);
 
-    var comp = Compilation.initDefault(gpa) catch |er| switch (er) {
+    var comp = Compilation.initDefault(gpa, std.fs.cwd()) catch |er| switch (er) {
         error.OutOfMemory => {
             std.debug.print("out of memory\n", .{});
             if (fast_exit) process.exit(1);

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -212,7 +212,7 @@ fn runTestCases(allocator: std.mem.Allocator, test_dir: []const u8, wg: *std.Thr
 fn singleRun(alloc: std.mem.Allocator, test_dir: []const u8, test_case: TestCase, stats: *Stats) !void {
     const path = test_case.path;
 
-    var comp = aro.Compilation.init(alloc);
+    var comp = aro.Compilation.init(alloc, std.fs.cwd());
     defer comp.deinit();
 
     try comp.addDefaultPragmaHandlers();

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -54,7 +54,7 @@ fn addCommandLineArgs(comp: *aro.Compilation, file: aro.Source, macro_buf: anyty
 }
 
 fn testOne(allocator: std.mem.Allocator, path: []const u8, test_dir: []const u8) !void {
-    var comp = aro.Compilation.init(allocator);
+    var comp = aro.Compilation.init(allocator, std.fs.cwd());
     defer comp.deinit();
 
     try comp.addDefaultPragmaHandlers();
@@ -159,7 +159,7 @@ pub fn main() !void {
     });
 
     // prepare compiler
-    var initial_comp = aro.Compilation.init(gpa);
+    var initial_comp = aro.Compilation.init(gpa, std.fs.cwd());
     defer initial_comp.deinit();
 
     const cases_include_dir = try std.fs.path.join(gpa, &.{ args[1], "include" });


### PR DESCRIPTION
Removes a dependency on global system state. The primary usage would be a library that wants to use aro with an arbitrary working directory without actually having to change the working directory of the process.