### PR TITLE
Build: Add a build.zig.zon file

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,19 @@
+.{
+    .name = "aro",
+
+    .version = "0.0.0",
+
+    .dependencies = .{},
+
+    .paths = .{
+        "build",
+        "build.zig",
+        "build.zig.zon",
+        "deps",
+        "include",
+        "src",
+        "LICENSE",
+        "LICENSE-UNICODE",
+        "README.md",
+    },
+}


### PR DESCRIPTION
Not sure how to handle the `version` field - we also compute it in build.zig