### PR TITLE
Preprocessor: Add debug dump options

### DIFF
--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -47,6 +47,19 @@ color: ?bool = null,
 nobuiltininc: bool = false,
 nostdinc: bool = false,
 nostdlibinc: bool = false,
+debug_dump_letters: packed struct(u3) {
+    d: bool = false,
+    m: bool = false,
+    n: bool = false,
+
+    /// Specifying letters whose behavior conflicts is undefined.
+    pub fn getPreprocessorDumpMode(self: @This()) Preprocessor.DumpMode {
+        if (self.d) return .macros_and_result;
+        if (self.m) return .macros_only;
+        if (self.n) return .macro_names_and_result;
+        return .result_only;
+    }
+} = .{},
 
 /// Full path to the aro executable
 aro_name: []const u8 = "",
@@ -92,6 +105,9 @@ pub const usage =
     \\
     \\Compile options:
     \\  -c, --compile           Only run preprocess, compile, and assemble steps
+    \\  -dM                     Output #define directives for all the macros defined during the execution of the preprocessor
+    \\  -dD                     Like -dM except that it outputs both the #define directives and the result of preprocessing
+    \\  -dN                     Like -dD, but emit only the macro names, not their expansions.
     \\  -D <macro>=<value>      Define <macro> to <value> (defaults to 1)
     \\  -E                      Only run the preprocessor
     \\  -fchar8_t               Enable char8_t (enabled by default in C23 and later)
@@ -234,6 +250,12 @@ pub fn parseArgs(
                 d.system_defines = .no_system_defines;
             } else if (mem.eql(u8, arg, "-c") or mem.eql(u8, arg, "--compile")) {
                 d.only_compile = true;
+            } else if (mem.eql(u8, arg, "-dD")) {
+                d.debug_dump_letters.d = true;
+            } else if (mem.eql(u8, arg, "-dM")) {
+                d.debug_dump_letters.m = true;
+            } else if (mem.eql(u8, arg, "-dN")) {
+                d.debug_dump_letters.n = true;
             } else if (mem.eql(u8, arg, "-E")) {
                 d.only_preprocess = true;
             } else if (mem.eql(u8, arg, "-P") or mem.eql(u8, arg, "--no-line-commands")) {
@@ -636,12 +658,16 @@ fn processSource(
     if (d.comp.langopts.ms_extensions) {
         d.comp.ms_cwd_source_id = source.id;
     }
-
+    const dump_mode = d.debug_dump_letters.getPreprocessorDumpMode();
     if (d.verbose_pp) pp.verbose = true;
     if (d.only_preprocess) {
         pp.preserve_whitespace = true;
         if (d.line_commands) {
             pp.linemarkers = if (d.use_line_directives) .line_directives else .numeric_directives;
+        }
+        switch (dump_mode) {
+            .macros_and_result, .macro_names_and_result => pp.store_macro_tokens = true,
+            .result_only, .macros_only => {},
         }
     }
 
@@ -663,7 +689,8 @@ fn processSource(
         defer if (d.output_name != null) file.close();
 
         var buf_w = std.io.bufferedWriter(file.writer());
-        pp.prettyPrintTokens(buf_w.writer()) catch |er|
+
+        pp.prettyPrintTokens(buf_w.writer(), dump_mode) catch |er|
             return d.fatal("unable to write result: {s}", .{errorDescription(er)});
 
         buf_w.flush() catch |er|

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -52,10 +52,11 @@ debug_dump_letters: packed struct(u3) {
     m: bool = false,
     n: bool = false,
 
-    /// Specifying letters whose behavior conflicts is undefined.
+    /// According to GCC, specifying letters whose behavior conflicts is undefined.
+    /// We follow clang in that `-dM` always takes precedence over `-dD`
     pub fn getPreprocessorDumpMode(self: @This()) Preprocessor.DumpMode {
-        if (self.d) return .macros_and_result;
         if (self.m) return .macros_only;
+        if (self.d) return .macros_and_result;
         if (self.n) return .macro_names_and_result;
         return .result_only;
     }

--- a/test/cases/debug dump macro names.c
+++ b/test/cases/debug dump macro names.c
@@ -1,0 +1,9 @@
+//aro-args -E -dN
+
+#define CHECK_PARTIAL_MATCH
+
+#define FOO 42
+#define BAR FOO
+int x = BAR;
+#undef FOO
+#define FOO 43

--- a/test/cases/debug dump macros and results.c
+++ b/test/cases/debug dump macros and results.c
@@ -1,0 +1,9 @@
+//aro-args -E -dD
+
+#define CHECK_PARTIAL_MATCH
+
+#define FOO 42
+#define BAR FOO
+int x = BAR;
+#undef FOO
+#define FOO 43

--- a/test/cases/debug dump macros.c
+++ b/test/cases/debug dump macros.c
@@ -1,0 +1,9 @@
+//aro-args -E -dM
+
+#define CHECK_PARTIAL_MATCH
+
+#define FOO 42
+#define BAR FOO
+int x = FOO;
+#undef BAR
+#define BAR 43

--- a/test/cases/expanded/debug dump macro names.c
+++ b/test/cases/expanded/debug dump macro names.c
@@ -1,0 +1,5 @@
+#define FOO
+#define BAR
+int x = 42;
+#undef FOO
+#define FOO

--- a/test/cases/expanded/debug dump macros and results.c
+++ b/test/cases/expanded/debug dump macros and results.c
@@ -1,0 +1,5 @@
+#define FOO 42
+#define BAR FOO
+int x = 42;
+#undef FOO
+#define FOO 43

--- a/test/cases/expanded/debug dump macros.c
+++ b/test/cases/expanded/debug dump macros.c
@@ -1,0 +1,1 @@
+#define BAR 43


### PR DESCRIPTION
Adds support for GCC's -dD, -dM, -dN flags which enable dumping macro names and/or definitions along with or instead of preprocessor output.

Added a `CHECK_PARTIAL_MATCH` option for preprocessor testing, because the output contains things like `__TIME__` which is difficult to fit into our existing preprocessor test framework.

`-dM` is also difficult to test extensively with the existing framework because it dumps the output in arbitrary order (just iterates over `pp.defines`) which seems to match the observed behavior of clang