### PR TITLE
Store some tree nodes as [2]NodeIndex instead of bin with lhs,rhs.

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -8745,6 +8745,7 @@ fn genericSelection(p: *Parser) Error!Result {
             try p.list_buf.insert(list_buf_top + 1, try p.addNode(.{
                 .tag = .generic_default_expr,
                 .data = .{ .un = default.node },
+                .ty = default.ty,
             }));
             chosen = default;
         } else {
@@ -8755,11 +8756,13 @@ fn genericSelection(p: *Parser) Error!Result {
         try p.list_buf.insert(list_buf_top + 1, try p.addNode(.{
             .tag = .generic_association_expr,
             .data = .{ .un = chosen.node },
+            .ty = chosen.ty,
         }));
         if (default_tok != null) {
             try p.list_buf.append(try p.addNode(.{
                 .tag = .generic_default_expr,
-                .data = .{ .un = chosen.node },
+                .data = .{ .un = default.node },
+                .ty = default.ty,
             }));
         }
     }

--- a/test/cases/ast/attributed record fields.c
+++ b/test/cases/ast/attributed record fields.c
@@ -19,6 +19,7 @@ struct_decl_two: 'struct S5'
   record_field_decl: 'int'
    name: x
    field attr: packed
+
   record_field_decl: 'int'
    name: y
    field attr: packed
@@ -27,6 +28,7 @@ struct_decl_two: 'struct S6'
   record_field_decl: 'int'
    name: x
    field attr: packed
+
   record_field_decl: 'int'
    name: y
    field attr: packed
@@ -35,12 +37,14 @@ struct_decl_two: 'struct S7'
   record_field_decl: 'int'
    name: x
    field attr: packed
+
   record_field_decl: 'int'
    name: y
 
 struct_decl_two: 'struct S8'
   record_field_decl: 'int'
    name: x
+
   record_field_decl: 'int'
    name: y
    field attr: packed

--- a/test/cases/ast/cast kinds.c
+++ b/test/cases/ast/cast kinds.c
@@ -1,6 +1,7 @@
 union_decl_two: 'union U'
   record_field_decl: 'int'
    name: x
+
   record_field_decl: 'float'
    name: y
 

--- a/test/cases/ast/complex init.c
+++ b/test/cases/ast/complex init.c
@@ -7,6 +7,7 @@ fn_def: 'fn () void'
      init:
       array_init_expr_two: '_Complex double'
         float_literal: 'double' (value: 1)
+
         float_literal: 'double' (value: 2)
 
     var: '_Complex float'
@@ -14,6 +15,7 @@ fn_def: 'fn () void'
      init:
       array_init_expr_two: '_Complex float'
         float_literal: 'float' (value: 1)
+
         float_literal: 'float' (value: 2)
 
     assign_expr: '_Complex double'
@@ -48,6 +50,7 @@ fn_def: 'fn () void'
          array_init_expr_two: '_Complex double'
            implicit_cast: (float_cast) 'double'
              float_literal: 'float' (value: 1)
+
            implicit_cast: (float_cast) 'double'
              float_literal: 'float' (value: 2)
 
@@ -61,6 +64,7 @@ fn_def: 'fn () void'
          array_init_expr_two: '_Complex float'
            implicit_cast: (float_cast) 'float'
              float_literal: 'double' (value: 1)
+
            implicit_cast: (float_cast) 'float'
              float_literal: 'double' (value: 2)
 

--- a/test/cases/ast/generic ast.c
+++ b/test/cases/ast/generic ast.c
@@ -1,0 +1,38 @@
+var: 'int'
+ name: x
+ init:
+  generic_expr: 'int'
+   controlling:
+    int_literal: 'int' (value: 5)
+   chosen:
+    generic_association_expr: 'int'
+      int_literal: 'int' (value: 42)
+   rest:
+    generic_association_expr: 'double'
+      float_literal: 'double' (value: 32.5)
+
+var: 'int'
+ name: y
+ init:
+  generic_expr: 'int'
+   controlling:
+    int_literal: 'int' (value: 5)
+   chosen:
+    generic_association_expr: 'int'
+      int_literal: 'int' (value: 42)
+   rest:
+    generic_association_expr: 'double'
+      float_literal: 'double' (value: 32.5)
+    generic_default_expr: '[7]char'
+      string_literal_expr: '[7]char' lvalue (value: "string")
+
+var: 'double'
+ name: z
+ init:
+  implicit_cast: (int_to_float) 'double'
+    generic_expr_one: 'int'
+     controlling:
+      int_literal: 'int' (value: 5)
+     chosen:
+      int_literal: 'int' (value: 32)
+

--- a/test/cases/ast/promotion edge cases.c
+++ b/test/cases/ast/promotion edge cases.c
@@ -3,6 +3,7 @@ struct_decl_two: 'struct S'
    name: x
    bits:
     int_literal: 'int' (value: 3)
+
   record_field_decl: 'long'
    name: y
    bits:
@@ -45,6 +46,7 @@ fn_def: 'fn () void'
      init:
       struct_init_expr_two: 'struct S'
         int_literal: 'unsigned int' (value: 1)
+
         int_literal: 'long' (value: 1)
 
     var: 'int'

--- a/test/cases/ast/types.c
+++ b/test/cases/ast/types.c
@@ -70,6 +70,7 @@ enum_decl_two: 'enum E: unsigned int'
     implicit_cast: (int_cast) 'int'
       explicit_cast: (int_cast) 'char' (value: 2)
         int_literal: 'int' (value: 2)
+
   enum_field_decl: 'int' (value: 3)
    name: E
    value:

--- a/test/cases/generic ast.c
+++ b/test/cases/generic ast.c
@@ -1,0 +1,14 @@
+int x = _Generic(5,
+	int: 42,
+	double: 32.5
+);
+
+int y = _Generic(5,
+	int: 42,
+	double: 32.5,
+	default: "string"
+);
+
+double z = _Generic(5,
+	default: 32
+);


### PR DESCRIPTION
This is meant to be a quality-of-life improvement for aro consumers that addresses this comment: https://github.com/ziglang/zig/blob/a854ce3021773a3f5cd1dce8ac6bc9eb5f4f937c/lib/compiler/aro_translate_c.zig#L1034C32-L1034C38

While updating generic selections I noticed that some types were not correct so I updated those.