### PR TITLE
Tree: add location for most nodes

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -1604,6 +1604,17 @@ pub fn hasBuiltinFunction(comp: *const Compilation, builtin: Builtin) bool {
     }
 }
 
+pub fn locSlice(comp: *const Compilation, loc: Source.Location) []const u8 {
+    var tmp_tokenizer = Tokenizer{
+        .buf = comp.getSource(loc.id).buf,
+        .langopts = comp.langopts,
+        .index = loc.byte_offset,
+        .source = .generated,
+    };
+    const tok = tmp_tokenizer.next();
+    return tmp_tokenizer.buf[tok.start..tok.end];
+}
+
 pub const CharUnitSize = enum(u32) {
     @"1" = 1,
     @"2" = 2,

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -7866,6 +7866,7 @@ fn primaryExpr(p: *Parser) Error!Result {
                             .tag = .decl_ref_expr,
                             .ty = sym.ty,
                             .data = .{ .decl_ref = name_tok },
+                            .loc = @enumFromInt(name_tok),
                         }),
                     };
                 }
@@ -7883,6 +7884,7 @@ fn primaryExpr(p: *Parser) Error!Result {
                         .tag = if (sym.kind == .enumeration) .enumeration_ref else .decl_ref_expr,
                         .ty = sym.ty,
                         .data = .{ .decl_ref = name_tok },
+                        .loc = @enumFromInt(name_tok),
                     }),
                 };
             }
@@ -7909,6 +7911,7 @@ fn primaryExpr(p: *Parser) Error!Result {
                         .tag = .builtin_call_expr_one,
                         .ty = some.ty,
                         .data = .{ .decl = .{ .name = name_tok, .node = .none } },
+                        .loc = @enumFromInt(name_tok),
                     }),
                 };
             }
@@ -7926,6 +7929,7 @@ fn primaryExpr(p: *Parser) Error!Result {
                     .ty = ty,
                     .tag = .fn_proto,
                     .data = .{ .decl = .{ .name = name_tok } },
+                    .loc = @enumFromInt(name_tok),
                 });
 
                 try p.decl_buf.append(node);
@@ -7937,6 +7941,7 @@ fn primaryExpr(p: *Parser) Error!Result {
                         .tag = .decl_ref_expr,
                         .ty = ty,
                         .data = .{ .decl_ref = name_tok },
+                        .loc = @enumFromInt(name_tok),
                     }),
                 };
             }
@@ -7944,11 +7949,12 @@ fn primaryExpr(p: *Parser) Error!Result {
             return error.ParsingFailed;
         },
         .keyword_true, .keyword_false => |id| {
+            const tok_i = p.tok_i;
             p.tok_i += 1;
             const res = Result{
                 .val = Value.fromBool(id == .keyword_true),
                 .ty = .{ .specifier = .bool },
-                .node = try p.addNode(.{ .tag = .bool_literal, .ty = .{ .specifier = .bool }, .data = undefined }),
+                .node = try p.addNode(.{ .tag = .bool_literal, .ty = .{ .specifier = .bool }, .data = undefined, .loc = @enumFromInt(tok_i) }),
             };
             std.debug.assert(!p.in_macro); // Should have been replaced with .one / .zero
             try p.value_map.put(res.node, res.val);
@@ -7964,6 +7970,7 @@ fn primaryExpr(p: *Parser) Error!Result {
                     .tag = .nullptr_literal,
                     .ty = .{ .specifier = .nullptr_t },
                     .data = undefined,
+                    .loc = @enumFromInt(p.tok_i),
                 }),
             };
         },
@@ -8000,6 +8007,7 @@ fn primaryExpr(p: *Parser) Error!Result {
                     .tag = .decl_ref_expr,
                     .ty = ty,
                     .data = .{ .decl_ref = tok },
+                    .loc = @enumFromInt(tok),
                 }),
             };
         },
@@ -8035,6 +8043,7 @@ fn primaryExpr(p: *Parser) Error!Result {
                     .tag = .decl_ref_expr,
                     .ty = ty,
                     .data = .{ .decl_ref = p.tok_i },
+                    .loc = @enumFromInt(p.tok_i),
                 }),
             };
         },

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1161,9 +1161,18 @@ fn decl(p: *Parser) Error!bool {
         if (init_d.d.old_style_func) |tok_i| try p.errTok(.invalid_old_style_params, tok_i);
         const tag = try decl_spec.validate(p, &init_d.d.ty, init_d.initializer.node != .none);
 
-        const node = try p.addNode(.{ .ty = init_d.d.ty, .tag = tag, .data = .{
-            .decl = .{ .name = init_d.d.name, .node = init_d.initializer.node },
-        } });
+        const tok = switch (decl_spec.storage_class) {
+            .auto, .@"extern", .register, .static, .typedef => |tok| tok,
+            .none => init_d.d.name,
+        };
+        const node = try p.addNode(.{
+            .ty = init_d.d.ty,
+            .tag = tag,
+            .data = .{
+                .decl = .{ .name = init_d.d.name, .node = init_d.initializer.node },
+            },
+            .loc = @enumFromInt(tok),
+        });
         try p.decl_buf.append(node);
 
         const interned_name = try StrInt.intern(p.comp, p.tokSlice(init_d.d.name));

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1135,6 +1135,7 @@ fn decl(p: *Parser) Error!bool {
             .ty = init_d.d.ty,
             .tag = try decl_spec.validateFnDef(p),
             .data = .{ .decl = .{ .name = init_d.d.name, .node = body } },
+            .loc = @enumFromInt(init_d.d.name),
         });
         try p.decl_buf.append(node);
 

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -8884,8 +8884,8 @@ test "Node locations" {
 
     try std.testing.expectEqual(0, comp.diagnostics.list.items.len);
     for (tree.root_decls, 0..) |node, i| {
-        const loc = tree.nodeLoc(node).?;
-        const slice = tree.comp.locSlice(loc);
+        const tok_i = tree.nodeTok(node).?;
+        const slice = tree.tokSlice(tok_i);
         const expected = switch (i) {
             0 => "foo",
             1 => "bar",

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6450,6 +6450,7 @@ fn condExpr(p: *Parser) Error!Result {
             .tag = .binary_cond_expr,
             .ty = cond.ty,
             .data = .{ .if3 = .{ .cond = cond.node, .body = (try p.addList(&.{ cond_then.node, then_expr.node })).start } },
+            .loc = @enumFromInt(cond_tok),
         });
         return cond;
     }
@@ -6475,6 +6476,7 @@ fn condExpr(p: *Parser) Error!Result {
         .tag = .cond_expr,
         .ty = cond.ty,
         .data = .{ .if3 = .{ .cond = cond.node, .body = (try p.addList(&.{ then_expr.node, else_expr.node })).start } },
+        .loc = @enumFromInt(cond_tok),
     });
     return cond;
 }

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6087,6 +6087,7 @@ pub const Result = struct {
             .tag = .explicit_cast,
             .ty = res.ty,
             .data = .{ .cast = .{ .operand = res.node, .kind = cast_kind } },
+            .loc = @enumFromInt(l_paren),
         });
     }
 

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -4899,17 +4899,17 @@ fn returnStmt(p: *Parser) Error!?NodeIndex {
 
     if (e.node == .none) {
         if (!ret_ty.is(.void)) try p.errStr(.func_should_return, ret_tok, p.tokSlice(p.func.name));
-        return try p.addNode(.{ .tag = .return_stmt, .data = .{ .un = e.node } });
+        return try p.addNode(.{ .tag = .return_stmt, .data = .{ .un = e.node }, .loc = @enumFromInt(ret_tok) });
     } else if (ret_ty.is(.void)) {
         try p.errStr(.void_func_returns_value, e_tok, p.tokSlice(p.func.name));
-        return try p.addNode(.{ .tag = .return_stmt, .data = .{ .un = e.node } });
+        return try p.addNode(.{ .tag = .return_stmt, .data = .{ .un = e.node }, .loc = @enumFromInt(ret_tok) });
     }
 
     try e.lvalConversion(p);
     try e.coerce(p, ret_ty, e_tok, .ret);
 
     try e.saveValue(p);
-    return try p.addNode(.{ .tag = .return_stmt, .data = .{ .un = e.node } });
+    return try p.addNode(.{ .tag = .return_stmt, .data = .{ .un = e.node }, .loc = @enumFromInt(ret_tok) });
 }
 
 // ====== expressions ======

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -7063,6 +7063,7 @@ fn unExpr(p: *Parser) Error!Result {
                     .tag = .addr_of_label,
                     .data = .{ .decl_ref = name_tok },
                     .ty = result_ty,
+                    .loc = @enumFromInt(address_tok),
                 }),
                 .ty = result_ty,
             };

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -783,14 +783,16 @@ pub fn childNodes(tree: *const Tree, node: NodeIndex) []const NodeIndex {
 pub fn tokSlice(tree: *const Tree, tok_i: TokenIndex) []const u8 {
     if (tree.tokens.items(.id)[tok_i].lexeme()) |some| return some;
     const loc = tree.tokens.items(.loc)[tok_i];
-    var tmp_tokenizer = Tokenizer{
-        .buf = tree.comp.getSource(loc.id).buf,
-        .langopts = tree.comp.langopts,
-        .index = loc.byte_offset,
-        .source = .generated,
+    return tree.comp.locSlice(loc);
+}
+
+pub fn nodeLoc(tree: *const Tree, node: NodeIndex) ?Source.Location {
+    std.debug.assert(node != .none);
+    const loc = tree.nodes.items(.loc)[@intFromEnum(node)];
+    return switch (loc) {
+        .none => null,
+        else => |tok_i| tree.tokens.items(.loc)[@intFromEnum(tok_i)],
     };
-    const tok = tmp_tokenizer.next();
-    return tmp_tokenizer.buf[tok.start..tok.end];
 }
 
 pub fn dump(tree: *const Tree, config: std.io.tty.Config, writer: anytype) !void {

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -786,13 +786,18 @@ pub fn tokSlice(tree: *const Tree, tok_i: TokenIndex) []const u8 {
     return tree.comp.locSlice(loc);
 }
 
-pub fn nodeLoc(tree: *const Tree, node: NodeIndex) ?Source.Location {
+pub fn nodeTok(tree: *const Tree, node: NodeIndex) ?TokenIndex {
     std.debug.assert(node != .none);
     const loc = tree.nodes.items(.loc)[@intFromEnum(node)];
     return switch (loc) {
         .none => null,
-        else => |tok_i| tree.tokens.items(.loc)[@intFromEnum(tok_i)],
+        else => |tok_i| @intFromEnum(tok_i),
     };
+}
+
+pub fn nodeLoc(tree: *const Tree, node: NodeIndex) ?Source.Location {
+    const tok_i = tree.nodeTok(node) orelse return null;
+    return tree.tokens.items(.loc)[@intFromEnum(tok_i)];
 }
 
 pub fn dump(tree: *const Tree, config: std.io.tty.Config, writer: anytype) !void {

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -553,13 +553,18 @@ pub const Tag = enum(u8) {
     struct_init_expr,
     /// { union_init }
     union_init_expr,
+
     /// (ty){ un }
+    /// loc is token index of l_paren
     compound_literal_expr,
     /// (static ty){ un }
+    /// loc is token index of l_paren
     static_compound_literal_expr,
     /// (thread_local ty){ un }
+    /// loc is token index of l_paren
     thread_local_compound_literal_expr,
     /// (static thread_local ty){ un }
+    /// loc is token index of l_paren
     static_thread_local_compound_literal_expr,
 
     /// Inserted at the end of a function body if no return stmt is found.

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -137,8 +137,14 @@ pub const Node = struct {
     tag: Tag,
     ty: Type = .{ .specifier = .void },
     data: Data,
+    loc: Loc = .none,
 
     pub const Range = struct { start: u32, end: u32 };
+
+    pub const Loc = enum(u32) {
+        none = std.math.maxInt(u32),
+        _,
+    };
 
     pub const Data = union {
         decl: struct {
@@ -278,7 +284,8 @@ pub const Tag = enum(u8) {
 
     // ====== Decl ======
 
-    // _Static_assert
+    /// _Static_assert
+    /// loc is token index of _Static_assert
     static_assert,
 
     // function prototype
@@ -304,6 +311,7 @@ pub const Tag = enum(u8) {
     threadlocal_static_var,
 
     /// __asm__("...") at file scope
+    /// loc is token index of __asm__ keyword
     file_scope_asm,
 
     // typedef declaration
@@ -557,6 +565,7 @@ pub const Tag = enum(u8) {
     /// Inserted at the end of a function body if no return stmt is found.
     /// ty is the functions return type
     /// data is return_zero which is true if the function is called "main" and ty is compatible with int
+    /// loc is token index of closing r_brace of function
     implicit_return,
 
     /// Inserted in array_init_expr to represent unspecified elements.


### PR DESCRIPTION
This closes #732 (although some node types do not have locations yet e.g. array and struct initializers)

As expected this increases memory usage but there's not much of a performance hit (numbers are for parsing `zig2.c` which is `161,279,661` bytes)

```
Before
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          9.54s  ± 9.92ms    9.53s  … 9.55s           0 ( 0%)        0%
  peak_rss           1.61GB ± 28.8KB    1.61GB … 1.61GB          0 ( 0%)        0%
  cpu_cycles         36.9G  ± 40.2M     36.8G  … 36.9G           0 ( 0%)        0%
  instructions       78.6G  ± 70.2      78.6G  … 78.6G           0 ( 0%)        0%
  cache_references   93.3M  ±  399K     92.9M  … 93.7M           0 ( 0%)        0%
  cache_misses       43.9M  ±  187K     43.6M  … 44.0M           0 ( 0%)        0%
  branch_misses       327M  ±  345K      327M  …  327M           0 ( 0%)        0%

After
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          9.63s  ± 40.2ms    9.60s  … 9.67s           0 ( 0%)          +  1.0% ±  0.7%
  peak_rss           1.74GB ± 59.1KB    1.74GB … 1.74GB          0 ( 0%)        💩+  7.8% ±  0.0%
  cpu_cycles         37.0G  ±  167M     36.9G  … 37.2G           0 ( 0%)          +  0.5% ±  0.7%
  instructions       78.7G  ±  101      78.7G  … 78.7G           0 ( 0%)          +  0.2% ±  0.0%
  cache_references   97.1M  ±  808K     96.4M  … 98.0M           0 ( 0%)        💩+  4.1% ±  1.5%
  cache_misses       46.7M  ±  328K     46.4M  … 47.1M           0 ( 0%)        💩+  6.4% ±  1.4%
  branch_misses       327M  ±  599K      326M  …  327M           0 ( 0%)          -  0.1% ±  0.3%
```
