### PR TITLE
Type: add helpers for managing typeof and attributed types

### DIFF
--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -1014,14 +1014,13 @@ pub fn applyEnumeratorAttributes(p: *Parser, ty: Type, attr_buf_start: usize) !T
 }
 
 fn applyAligned(attr: Attribute, p: *Parser, ty: Type, tag: ?Diagnostics.Tag) !void {
-    const base = ty.canonicalize(.standard);
     if (attr.args.aligned.alignment) |alignment| alignas: {
         if (attr.syntax != .keyword) break :alignas;
 
         const align_tok = attr.args.aligned.__name_tok;
         if (tag) |t| try p.errTok(t, align_tok);
 
-        const default_align = base.alignof(p.comp);
+        const default_align = ty.alignof(p.comp);
         if (ty.isFunc()) {
             try p.errTok(.alignas_on_func, align_tok);
         } else if (alignment.requested < default_align) {

--- a/src/aro/CodeGen.zig
+++ b/src/aro/CodeGen.zig
@@ -185,12 +185,12 @@ fn genType(c: *CodeGen, base_ty: Type) !Interner.Ref {
 
 fn genFn(c: *CodeGen, decl: NodeIndex) Error!void {
     const name = c.tree.tokSlice(c.node_data[@intFromEnum(decl)].decl.name);
-    const func_ty = c.node_ty[@intFromEnum(decl)].canonicalize(.standard);
+    const func_ty = c.node_ty[@intFromEnum(decl)];
     c.ret_nodes.items.len = 0;
 
     try c.builder.startFn();
 
-    for (func_ty.data.func.params) |param| {
+    for (func_ty.params()) |param| {
         // TODO handle calling convention here
         const arg = try c.builder.addArg(try c.genType(param.ty));
 

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -981,7 +981,7 @@ fn decl(p: *Parser) Error!bool {
             (decl_spec.ty.isRecord() and !decl_spec.ty.isAnonymousRecord(p.comp) and
             !decl_spec.ty.isTypeof())) // we follow GCC and clang's behavior here
         {
-            const specifier = decl_spec.ty.canonicalize(.standard).specifier;
+            const specifier = decl_spec.ty.base();
             const attrs = p.attr_buf.items(.attr)[attr_buf_top..];
             const toks = p.attr_buf.items(.tok)[attr_buf_top..];
             for (attrs, toks) |attr, tok| {
@@ -1870,7 +1870,7 @@ fn initDeclarator(p: *Parser, decl_spec: *DeclSpec, attr_buf_top: usize) Error!?
         init_d.d.ty = try Attribute.applyVariableAttributes(p, init_d.d.ty, attr_buf_top, null);
     }
     if (decl_spec.storage_class != .typedef and init_d.d.ty.hasIncompleteSize()) incomplete: {
-        const specifier = init_d.d.ty.canonicalize(.standard).specifier;
+        const specifier = init_d.d.ty.base();
         if (decl_spec.storage_class == .@"extern") switch (specifier) {
             .@"struct", .@"union", .@"enum" => break :incomplete,
             .incomplete_array => {
@@ -3776,8 +3776,8 @@ fn coerceArrayInitExtra(p: *Parser, item: *Result, tok: TokenIndex, target: Type
         return true; // do not do further coercion
     }
 
-    const target_spec = target.elemType().canonicalize(.standard).specifier;
-    const item_spec = item.ty.elemType().canonicalize(.standard).specifier;
+    const target_spec = target.elemType().base();
+    const item_spec = item.ty.elemType().base();
 
     const compatible = target.elemType().eql(item.ty.elemType(), p.comp, false) or
         (is_str_lit and item_spec == .char and (target_spec == .uchar or target_spec == .schar)) or

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -167,7 +167,7 @@ record: struct {
     fn addFieldsFromAnonymous(r: @This(), p: *Parser, ty: Type) Error!void {
         for (ty.getRecord().?.fields) |f| {
             if (f.isAnonymousRecord()) {
-                try r.addFieldsFromAnonymous(p, f.ty.canonicalize(.standard));
+                try r.addFieldsFromAnonymous(p, f.ty);
             } else if (f.name_tok != 0) {
                 try r.addField(p, f.name, f.name_tok);
             }

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -5795,8 +5795,8 @@ pub const Result = struct {
                 .{ .invalid, .fp16 },
                 .{ .complex_float16, .float16 },
             };
-            const a_spec = a.ty.canonicalize(.standard).specifier;
-            const b_spec = b.ty.canonicalize(.standard).specifier;
+            const a_spec = a.ty.base();
+            const b_spec = b.ty.base();
             if (p.comp.target.cTypeBitSize(.longdouble) == 128) {
                 if (try a.floatConversion(b, a_spec, b_spec, p, float_types[0])) return;
             }

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -1363,12 +1363,11 @@ fn dumpNode(
 
             var lhs_ty = tree.nodes.items(.ty)[@intFromEnum(data.member.lhs)];
             if (lhs_ty.isPtr()) lhs_ty = lhs_ty.elemType();
-            lhs_ty = lhs_ty.canonicalize(.standard);
 
             try w.writeByteNTimes(' ', level + 1);
             try w.writeAll("name: ");
             try config.setColor(w, NAME);
-            try w.print("{s}\n", .{mapper.lookup(lhs_ty.data.record.fields[data.member.index].name)});
+            try w.print("{s}\n", .{mapper.lookup(lhs_ty.getRecord().?.fields[data.member.index].name)});
             try config.setColor(w, .reset);
         },
         .array_access_expr => {

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -146,7 +146,7 @@ pub const Attributed = struct {
     attributes: []Attribute,
     base: Type,
 
-    pub fn create(allocator: std.mem.Allocator, base: Type, existing_attributes: []const Attribute, attributes: []const Attribute) !*Attributed {
+    pub fn create(allocator: std.mem.Allocator, base_ty: Type, existing_attributes: []const Attribute, attributes: []const Attribute) !*Attributed {
         const attributed_type = try allocator.create(Attributed);
         errdefer allocator.destroy(attributed_type);
 
@@ -156,7 +156,7 @@ pub const Attributed = struct {
 
         attributed_type.* = .{
             .attributes = all_attrs,
-            .base = base,
+            .base = base_ty,
         };
         return attributed_type;
     }
@@ -825,8 +825,8 @@ fn realIntegerConversion(a: Type, b: Type, comp: *const Compilation) Type {
 
 pub fn makeIntegerUnsigned(ty: Type) Type {
     // TODO discards attributed/typeof
-    var base = ty.canonicalize(.standard);
-    switch (base.specifier) {
+    var base_ty = ty.canonicalize(.standard);
+    switch (base_ty.specifier) {
         // zig fmt: off
         .uchar, .ushort, .uint, .ulong, .ulong_long, .uint128,
         .complex_uchar, .complex_ushort, .complex_uint, .complex_ulong, .complex_ulong_long, .complex_uint128,
@@ -834,21 +834,21 @@ pub fn makeIntegerUnsigned(ty: Type) Type {
         // zig fmt: on
 
         .char, .complex_char => {
-            base.specifier = @enumFromInt(@intFromEnum(base.specifier) + 2);
-            return base;
+            base_ty.specifier = @enumFromInt(@intFromEnum(base_ty.specifier) + 2);
+            return base_ty;
         },
 
         // zig fmt: off
         .schar, .short, .int, .long, .long_long, .int128,
         .complex_schar, .complex_short, .complex_int, .complex_long, .complex_long_long, .complex_int128 => {
-            base.specifier = @enumFromInt(@intFromEnum(base.specifier) + 1);
-            return base;
+            base_ty.specifier = @enumFromInt(@intFromEnum(base_ty.specifier) + 1);
+            return base_ty;
         },
         // zig fmt: on
 
         .bit_int, .complex_bit_int => {
-            base.data.int.signedness = .unsigned;
-            return base;
+            base_ty.data.int.signedness = .unsigned;
+            return base_ty;
         },
         else => unreachable,
     }
@@ -1137,6 +1137,10 @@ pub const QualHandling = enum {
     preserve_quals,
 };
 
+pub fn base(ty: Type) Type.Specifier {
+    return ty.canonicalize(.standard).specifier;
+}
+
 /// Canonicalize a possibly-typeof() type. If the type is not a typeof() type, simply
 /// return it. Otherwise, determine the actual qualified type.
 /// The `qual_handling` parameter can be used to return the full set of qualifiers
@@ -1332,19 +1336,19 @@ pub fn sameRankDifferentSign(a: Type, b: Type, comp: *const Compilation) bool {
 
 pub fn makeReal(ty: Type) Type {
     // TODO discards attributed/typeof
-    var base = ty.canonicalize(.standard);
-    switch (base.specifier) {
+    var base_ty = ty.canonicalize(.standard);
+    switch (base_ty.specifier) {
         .complex_float16, .complex_float, .complex_double, .complex_long_double, .complex_float128 => {
-            base.specifier = @enumFromInt(@intFromEnum(base.specifier) - 5);
-            return base;
+            base_ty.specifier = @enumFromInt(@intFromEnum(base_ty.specifier) - 5);
+            return base_ty;
         },
         .complex_char, .complex_schar, .complex_uchar, .complex_short, .complex_ushort, .complex_int, .complex_uint, .complex_long, .complex_ulong, .complex_long_long, .complex_ulong_long, .complex_int128, .complex_uint128 => {
-            base.specifier = @enumFromInt(@intFromEnum(base.specifier) - 13);
-            return base;
+            base_ty.specifier = @enumFromInt(@intFromEnum(base_ty.specifier) - 13);
+            return base_ty;
         },
         .complex_bit_int => {
-            base.specifier = .bit_int;
-            return base;
+            base_ty.specifier = .bit_int;
+            return base_ty;
         },
         else => return ty,
     }
@@ -1352,19 +1356,19 @@ pub fn makeReal(ty: Type) Type {
 
 pub fn makeComplex(ty: Type) Type {
     // TODO discards attributed/typeof
-    var base = ty.canonicalize(.standard);
-    switch (base.specifier) {
+    var base_ty = ty.canonicalize(.standard);
+    switch (base_ty.specifier) {
         .float, .double, .long_double, .float128 => {
-            base.specifier = @enumFromInt(@intFromEnum(base.specifier) + 5);
-            return base;
+            base_ty.specifier = @enumFromInt(@intFromEnum(base_ty.specifier) + 5);
+            return base_ty;
         },
         .char, .schar, .uchar, .short, .ushort, .int, .uint, .long, .ulong, .long_long, .ulong_long, .int128, .uint128 => {
-            base.specifier = @enumFromInt(@intFromEnum(base.specifier) + 13);
-            return base;
+            base_ty.specifier = @enumFromInt(@intFromEnum(base_ty.specifier) + 13);
+            return base_ty;
         },
         .bit_int => {
-            base.specifier = .complex_bit_int;
-            return base;
+            base_ty.specifier = .complex_bit_int;
+            return base_ty;
         },
         else => return ty,
     }

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -433,7 +433,7 @@ pub const invalid = Type{ .specifier = .invalid };
 /// types if necessary.
 pub fn is(ty: Type, specifier: Specifier) bool {
     std.debug.assert(specifier != .typeof_type and specifier != .typeof_expr);
-    return ty.get(specifier) != null;
+    return ty.base() == specifier;
 }
 
 pub fn withAttributes(self: Type, allocator: std.mem.Allocator, attributes: []const Attribute) !Type {

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -1389,9 +1389,9 @@ pub fn integerRank(ty: Type, comp: *const Compilation) usize {
         .long_long, .ulong_long => 6 + (ty.bitSizeof(comp).? << 3),
         .int128, .uint128 => 7 + (ty.bitSizeof(comp).? << 3),
 
-        .typeof_type => ty.data.sub_type.integerRank(comp),
-        .typeof_expr => ty.data.expr.ty.integerRank(comp),
-        .attributed => ty.data.attributed.base.integerRank(comp),
+        .typeof_type => unreachable,
+        .typeof_expr => unreachable,
+        .attributed => unreachable,
 
         .@"enum" => real.data.@"enum".tag_ty.integerRank(comp),
 
@@ -1423,7 +1423,7 @@ pub fn makeReal(ty: Type) Type {
             base_ty.specifier = .bit_int;
             return base_ty;
         },
-        else => return ty,
+        else => return base_ty,
     }
 }
 

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -1244,13 +1244,14 @@ pub fn canonicalize(ty: Type, qual_handling: QualHandling) Type {
     return cur;
 }
 
-pub fn get(ty: *const Type, specifier: Specifier) ?*const Type {
+pub fn get(ty: Type, specifier: Specifier) ?Type {
     std.debug.assert(specifier != .typeof_type and specifier != .typeof_expr);
-    return switch (ty.specifier) {
-        .typeof_type => ty.data.sub_type.get(specifier),
-        .typeof_expr => ty.data.expr.ty.get(specifier),
-        .attributed => ty.data.attributed.base.get(specifier),
-        else => if (ty.specifier == specifier) ty else null,
+    const canon = ty.canonicalize(.standard);
+    return switch (canon.specifier) {
+        .typeof_type => unreachable,
+        .typeof_expr => unreachable,
+        .attributed => unreachable,
+        else => if (canon.specifier == specifier) canon else null,
     };
 }
 

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -471,11 +471,12 @@ pub fn isFunc(ty: Type) bool {
 }
 
 pub fn isArray(ty: Type) bool {
-    return switch (ty.specifier) {
-        .array, .static_array, .incomplete_array, .variable_len_array, .unspecified_variable_len_array => !ty.isDecayed(),
-        .typeof_type => !ty.isDecayed() and ty.data.sub_type.isArray(),
-        .typeof_expr => !ty.isDecayed() and ty.data.expr.ty.isArray(),
-        .attributed => !ty.isDecayed() and ty.data.attributed.base.isArray(),
+    const canon = ty.canonicalize(.standard);
+    return switch (canon.specifier) {
+        .array, .static_array, .incomplete_array, .variable_len_array, .unspecified_variable_len_array => !canon.isDecayed(),
+        .typeof_type => unreachable,
+        .typeof_expr => unreachable,
+        .attributed => unreachable,
         else => false,
     };
 }

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -499,16 +499,16 @@ pub fn setIncompleteArrayLen(ty: *Type, len: u64) void {
 
 /// Whether the type is promoted if used as a variadic argument or as an argument to a function with no prototype
 fn undergoesDefaultArgPromotion(ty: Type, comp: *const Compilation) bool {
-    return switch (ty.specifier) {
+    return switch (ty.base()) {
         .bool => true,
         .char, .uchar, .schar => true,
         .short, .ushort => true,
-        .@"enum" => if (comp.langopts.emulate == .clang) ty.data.@"enum".isIncomplete() else false,
+        .@"enum" => if (comp.langopts.emulate == .clang) ty.hasIncompleteSize() else false,
         .float => true,
 
-        .typeof_type => ty.data.sub_type.undergoesDefaultArgPromotion(comp),
-        .typeof_expr => ty.data.expr.ty.undergoesDefaultArgPromotion(comp),
-        .attributed => ty.data.attributed.base.undergoesDefaultArgPromotion(comp),
+        .typeof_type => unreachable,
+        .typeof_expr => unreachable,
+        .attributed => unreachable,
         else => false,
     };
 }

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -1138,7 +1138,76 @@ pub const QualHandling = enum {
 };
 
 pub fn base(ty: Type) Type.Specifier {
-    return ty.canonicalize(.standard).specifier;
+    var cur = ty;
+    while (true) {
+        switch (cur.specifier) {
+            .invalid,
+            .auto_type,
+            .c23_auto,
+            => unreachable,
+
+            .typeof_type => cur = cur.data.sub_type.*,
+            .typeof_expr => cur = cur.data.expr.ty,
+            .attributed => cur = cur.data.attributed.base,
+
+            .void,
+            .bool,
+            .char,
+            .schar,
+            .uchar,
+            .short,
+            .ushort,
+            .int,
+            .uint,
+            .long,
+            .ulong,
+            .long_long,
+            .ulong_long,
+            .int128,
+            .uint128,
+            .complex_char,
+            .complex_schar,
+            .complex_uchar,
+            .complex_short,
+            .complex_ushort,
+            .complex_int,
+            .complex_uint,
+            .complex_long,
+            .complex_ulong,
+            .complex_long_long,
+            .complex_ulong_long,
+            .complex_int128,
+            .complex_uint128,
+            .bit_int,
+            .complex_bit_int,
+            .fp16,
+            .float16,
+            .float,
+            .double,
+            .long_double,
+            .float128,
+            .complex_float16,
+            .complex_float,
+            .complex_double,
+            .complex_long_double,
+            .complex_float128,
+            .pointer,
+            .unspecified_variable_len_array,
+            .func,
+            .var_args_func,
+            .old_style_func,
+            .array,
+            .static_array,
+            .incomplete_array,
+            .vector,
+            .variable_len_array,
+            .@"struct",
+            .@"union",
+            .@"enum",
+            .nullptr_t,
+            => |s| return s,
+        }
+    }
 }
 
 /// Canonicalize a possibly-typeof() type. If the type is not a typeof() type, simply

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -2421,17 +2421,10 @@ pub const Builder = struct {
 };
 
 pub fn getAttribute(ty: Type, comptime tag: Attribute.Tag) ?Attribute.ArgumentsForTag(tag) {
-    switch (ty.specifier) {
-        .typeof_type => return ty.data.sub_type.getAttribute(tag),
-        .typeof_expr => return ty.data.expr.ty.getAttribute(tag),
-        .attributed => {
-            for (ty.data.attributed.attributes) |attribute| {
-                if (attribute.tag == tag) return @field(attribute.args, @tagName(tag));
-            }
-            return null;
-        },
-        else => return null,
+    for (ty.getAttributes()) |attribute| {
+        if (attribute.tag == tag) return @field(attribute.args, @tagName(tag));
     }
+    return null;
 }
 
 pub fn hasAttribute(ty: Type, tag: Attribute.Tag) bool {

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -443,22 +443,29 @@ pub fn withAttributes(self: Type, allocator: std.mem.Allocator, attributes: []co
 }
 
 pub fn isCallable(ty: Type) ?Type {
-    return switch (ty.specifier) {
-        .func, .var_args_func, .old_style_func => ty,
-        .pointer => if (ty.data.sub_type.isFunc()) ty.data.sub_type.* else null,
-        .typeof_type => ty.data.sub_type.isCallable(),
-        .typeof_expr => ty.data.expr.ty.isCallable(),
-        .attributed => ty.data.attributed.base.isCallable(),
+    const canon = ty.canonicalize(.standard);
+    return switch (ty.base()) {
+        .func, .var_args_func, .old_style_func => canon,
+        .pointer => {
+            const child_ty = ty.elemType();
+            if (child_ty.isFunc()) {
+                return child_ty;
+            }
+            return null;
+        },
+        .typeof_type => unreachable,
+        .typeof_expr => unreachable,
+        .attributed => unreachable,
         else => null,
     };
 }
 
 pub fn isFunc(ty: Type) bool {
-    return switch (ty.specifier) {
+    return switch (ty.base()) {
         .func, .var_args_func, .old_style_func => true,
-        .typeof_type => ty.data.sub_type.isFunc(),
-        .typeof_expr => ty.data.expr.ty.isFunc(),
-        .attributed => ty.data.attributed.base.isFunc(),
+        .typeof_type => unreachable,
+        .typeof_expr => unreachable,
+        .attributed => unreachable,
         else => false,
     };
 }


### PR DESCRIPTION
The idea behind this is to prepare for #733 by making typeof and attributed types slightly less annoying to deal with, by moving the recursive call logic to a single place (2 actually), which should make it easier to add a new `typedef` specifier which will generally just call into its subtype for most of the Type functions.