### PR TITLE
Parser: fix imag keyword incorrectly apply to float numbers

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -7359,7 +7359,7 @@ fn unExpr(p: *Parser) Error!Result {
                     .msvc => {}, // Doesn't support `_Complex` or `__imag` in the first place
                     .gcc => operand.val = Value.zero,
                     .clang => {
-                        if (operand.val.is(.int, p.comp)) {
+                        if (operand.val.is(.int, p.comp) or operand.val.is(.float, p.comp)) {
                             operand.val = Value.zero;
                         } else {
                             operand.val = .{};

--- a/test/cases/complex numbers clang.c
+++ b/test/cases/complex numbers clang.c
@@ -15,8 +15,7 @@ void foo(int x, float y) {
     z = ~z;
 }
 
-#define EXPECTED_ERRORS "complex numbers clang.c:5:20: error: static_assert expression is not an integral constant expression" \
-    "complex numbers clang.c:6:20: error: static_assert expression is not an integral constant expression" \
+#define EXPECTED_ERRORS "complex numbers clang.c:6:20: error: static_assert expression is not an integral constant expression" \
     "complex numbers clang.c:7:20: error: static_assert expression is not an integral constant expression" \
     "complex numbers clang.c:9:42: warning: complex initialization specifying real and imaginary components is an extension [-Wcomplex-component-init]" \
     "complex numbers clang.c:10:6: warning: ISO C does not support '++'/'--' on complex type '_Complex double' [-Wpedantic]" \

--- a/test/cases/return.c
+++ b/test/cases/return.c
@@ -121,5 +121,5 @@ void call_return_signed(void) {
     "return.c:35:12: error: void function 'baz' should not return a value [-Wreturn-type]" \
     "return.c:38:17: error: function cannot return a function" \
     "return.c:96:12: error: returning 'double' from a function with incompatible result type 'void *'" \
-    "warning: returning 'unsigned int *' from a function with incompatible result type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]" \
+    "return.c:100:12: warning: returning 'unsigned int *' from a function with incompatible result type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]" \
 


### PR DESCRIPTION
Maintain consistent behavior with Clang.