### PR TITLE
Rework attributes a bit

### DIFF
--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -38,6 +38,57 @@ pub const Kind = enum {
     }
 };
 
+pub const Iterator = struct {
+    source: union(enum) {
+        ty: Type,
+        slice: []const Attribute,
+    },
+    index: usize,
+
+    pub fn initSlice(slice: ?[]const Attribute) Iterator {
+        return .{ .source = .{ .slice = slice orelse &.{} }, .index = 0 };
+    }
+
+    pub fn initType(ty: Type) Iterator {
+        return .{ .source = .{ .ty = ty }, .index = 0 };
+    }
+
+    /// returns the next attribute as well as its index within the slice or current type
+    /// The index can be used to determine when a nested type has been recursed into
+    pub fn next(self: *Iterator) ?struct { Attribute, usize } {
+        switch (self.source) {
+            .slice => |slice| {
+                if (self.index < slice.len) {
+                    defer self.index += 1;
+                    return .{ slice[self.index], self.index };
+                }
+            },
+            .ty => |ty| {
+                switch (ty.specifier) {
+                    .typeof_type => {
+                        self.* = .{ .source = .{ .ty = ty.data.sub_type.* }, .index = 0 };
+                        return self.next();
+                    },
+                    .typeof_expr => {
+                        self.* = .{ .source = .{ .ty = ty.data.expr.ty }, .index = 0 };
+                        return self.next();
+                    },
+                    .attributed => {
+                        if (self.index < ty.data.attributed.attributes.len) {
+                            defer self.index += 1;
+                            return .{ ty.data.attributed.attributes[self.index], self.index };
+                        }
+                        self.* = .{ .source = .{ .ty = ty.data.attributed.base }, .index = 0 };
+                        return self.next();
+                    },
+                    else => {},
+                }
+            },
+        }
+        return null;
+    }
+};
+
 pub const ArgumentType = enum {
     string,
     identifier,
@@ -740,7 +791,6 @@ pub fn applyVariableAttributes(p: *Parser, ty: Type, attr_buf_start: usize, tag:
     const toks = p.attr_buf.items(.tok)[attr_buf_start..];
     p.attr_application_buf.items.len = 0;
     var base_ty = ty;
-    if (base_ty.specifier == .attributed) base_ty = base_ty.data.attributed.base;
     var common = false;
     var nocommon = false;
     for (attrs, toks) |attr, tok| switch (attr.tag) {
@@ -785,12 +835,7 @@ pub fn applyVariableAttributes(p: *Parser, ty: Type, attr_buf_start: usize, tag:
         => |t| try p.errExtra(.attribute_todo, tok, .{ .attribute_todo = .{ .tag = t, .kind = .variables } }),
         else => try ignoredAttrErr(p, tok, attr.tag, "variables"),
     };
-    const existing = ty.getAttributes();
-    if (existing.len == 0 and p.attr_application_buf.items.len == 0) return base_ty;
-    if (existing.len == 0) return base_ty.withAttributes(p.arena, p.attr_application_buf.items);
-
-    const attributed_type = try Type.Attributed.create(p.arena, base_ty, existing, p.attr_application_buf.items);
-    return Type{ .specifier = .attributed, .data = .{ .attributed = attributed_type } };
+    return base_ty.withAttributes(p.arena, p.attr_application_buf.items);
 }
 
 pub fn applyFieldAttributes(p: *Parser, field_ty: *Type, attr_buf_start: usize) ![]const Attribute {
@@ -815,7 +860,6 @@ pub fn applyTypeAttributes(p: *Parser, ty: Type, attr_buf_start: usize, tag: ?Di
     const toks = p.attr_buf.items(.tok)[attr_buf_start..];
     p.attr_application_buf.items.len = 0;
     var base_ty = ty;
-    if (base_ty.specifier == .attributed) base_ty = base_ty.data.attributed.base;
     for (attrs, toks) |attr, tok| switch (attr.tag) {
         // zig fmt: off
         .@"packed", .may_alias, .deprecated, .unavailable, .unused, .warn_if_not_aligned, .mode,
@@ -836,19 +880,7 @@ pub fn applyTypeAttributes(p: *Parser, ty: Type, attr_buf_start: usize, tag: ?Di
         => |t| try p.errExtra(.attribute_todo, tok, .{ .attribute_todo = .{ .tag = t, .kind = .types } }),
         else => try ignoredAttrErr(p, tok, attr.tag, "types"),
     };
-
-    const existing = ty.getAttributes();
-    // TODO: the alignment annotation on a type should override
-    // the decl it refers to. This might not be true for others.  Maybe bug.
-
-    // if there are annotations on this type def use those.
-    if (p.attr_application_buf.items.len > 0) {
-        return try base_ty.withAttributes(p.arena, p.attr_application_buf.items);
-    } else if (existing.len > 0) {
-        // else use the ones on the typedef decl we were refering to.
-        return try base_ty.withAttributes(p.arena, existing);
-    }
-    return base_ty;
+    return base_ty.withAttributes(p.arena, p.attr_application_buf.items);
 }
 
 pub fn applyFunctionAttributes(p: *Parser, ty: Type, attr_buf_start: usize) !Type {
@@ -856,7 +888,6 @@ pub fn applyFunctionAttributes(p: *Parser, ty: Type, attr_buf_start: usize) !Typ
     const toks = p.attr_buf.items(.tok)[attr_buf_start..];
     p.attr_application_buf.items.len = 0;
     var base_ty = ty;
-    if (base_ty.specifier == .attributed) base_ty = base_ty.data.attributed.base;
     var hot = false;
     var cold = false;
     var @"noinline" = false;
@@ -1059,6 +1090,7 @@ fn applyTransparentUnion(attr: Attribute, p: *Parser, tok: TokenIndex, ty: Type)
 }
 
 fn applyVectorSize(attr: Attribute, p: *Parser, tok: TokenIndex, ty: *Type) !void {
+    const base = ty.base();
     const is_enum = ty.is(.@"enum");
     if (!(ty.isInt() or ty.isFloat()) or !ty.isReal() or (is_enum and p.comp.langopts.emulate == .gcc)) {
         try p.errStr(.invalid_vec_elem_ty, tok, try p.typeStr(ty.*));
@@ -1075,7 +1107,7 @@ fn applyVectorSize(attr: Attribute, p: *Parser, tok: TokenIndex, ty: *Type) !voi
 
     const arr_ty = try p.arena.create(Type.Array);
     arr_ty.* = .{ .elem = ty.*, .len = vec_size };
-    ty.* = Type{
+    base.* = .{
         .specifier = .vector,
         .data = .{ .array = arr_ty },
     };

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1037,10 +1037,8 @@ fn decl(p: *Parser) Error!bool {
 
         // Collect old style parameter declarations.
         if (init_d.d.old_style_func != null) {
-            const attrs = init_d.d.ty.getAttributes();
-            var base_ty = if (init_d.d.ty.specifier == .attributed) init_d.d.ty.data.attributed.base else init_d.d.ty;
+            var base_ty = init_d.d.ty.base();
             base_ty.specifier = .func;
-            init_d.d.ty = try base_ty.withAttributes(p.arena, attrs);
 
             const param_buf_top = p.param_buf.items.len;
             defer p.param_buf.items.len = param_buf_top;
@@ -3901,8 +3899,6 @@ fn convertInitList(p: *Parser, il: InitList, init_ty: Type) Error!NodeIndex {
                 .specifier = .array,
                 .data = .{ .array = arr_ty },
             };
-            const attrs = init_ty.getAttributes();
-            arr_init_node.ty = try arr_init_node.ty.withAttributes(p.arena, attrs);
         } else if (start < max_items) {
             const elem = try p.addNode(.{
                 .tag = .array_filler_expr,

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -909,7 +909,9 @@ fn dumpNode(
 
     if (ty.specifier == .attributed) {
         try config.setColor(w, ATTRIBUTE);
-        for (ty.data.attributed.attributes) |attr| {
+        var it = Attribute.Iterator.initType(ty);
+        while (it.next()) |item| {
+            const attr, _ = item;
             try w.writeByteNTimes(' ', level + half);
             try w.print("attr: {s}", .{@tagName(attr.tag)});
             try tree.dumpAttribute(attr, w);

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -2343,6 +2343,7 @@ pub fn base(ty: *Type) *Type {
 }
 
 pub fn getAttribute(ty: Type, comptime tag: Attribute.Tag) ?Attribute.ArgumentsForTag(tag) {
+    if (tag == .aligned) @compileError("use requestedAlignment");
     var it = Attribute.Iterator.initType(ty);
     while (it.next()) |item| {
         const attribute, _ = item;

--- a/src/aro/record_layout.zig
+++ b/src/aro/record_layout.zig
@@ -101,7 +101,7 @@ const SysVContext = struct {
         field_attrs: ?[]const Attribute,
         field_layout: TypeLayout,
     ) !FieldLayout {
-        const annotation_alignment_bits = BITS_PER_BYTE * @as(u32, (Type.annotationAlignment(self.comp, field_attrs) orelse 1));
+        const annotation_alignment_bits = BITS_PER_BYTE * @as(u32, (Type.annotationAlignment(self.comp, Attribute.Iterator.initSlice(field_attrs)) orelse 1));
         const is_attr_packed = self.attr_packed or isPacked(field_attrs);
         const ignore_type_alignment = ignoreTypeAlignment(is_attr_packed, field.bit_width, self.ongoing_bitfield, field_layout);
 
@@ -240,7 +240,7 @@ const SysVContext = struct {
 
         // The field alignment can be increased by __attribute__((aligned)) annotations on the
         // field. See test case 0085.
-        if (Type.annotationAlignment(self.comp, fld_attrs)) |anno| {
+        if (Type.annotationAlignment(self.comp, Attribute.Iterator.initSlice(fld_attrs))) |anno| {
             fld_align_bits = @max(fld_align_bits, @as(u32, anno) * BITS_PER_BYTE);
         }
 
@@ -302,7 +302,7 @@ const SysVContext = struct {
         const attr_packed = self.attr_packed or isPacked(fld_attrs);
         const has_packing_annotation = attr_packed or self.max_field_align_bits != null;
 
-        const annotation_alignment = if (Type.annotationAlignment(self.comp, fld_attrs)) |anno| @as(u32, anno) * BITS_PER_BYTE else 1;
+        const annotation_alignment = if (Type.annotationAlignment(self.comp, Attribute.Iterator.initSlice(fld_attrs))) |anno| @as(u32, anno) * BITS_PER_BYTE else 1;
 
         const first_unused_bit: u64 = if (self.is_union) 0 else self.size_bits;
         var field_align_bits: u64 = 1;
@@ -441,7 +441,7 @@ const MsvcContext = struct {
         // underlying type and the __declspec(align) annotation on the field itself.
         // See test case 0028.
         var req_align = type_layout.required_alignment_bits;
-        if (Type.annotationAlignment(self.comp, fld_attrs)) |anno| {
+        if (Type.annotationAlignment(self.comp, Attribute.Iterator.initSlice(fld_attrs))) |anno| {
             req_align = @max(@as(u32, anno) * BITS_PER_BYTE, req_align);
         }
 

--- a/test/cases/nested attributes.c
+++ b/test/cases/nested attributes.c
@@ -1,0 +1,15 @@
+typedef int __attribute__((aligned(1))) ALIGN_1;
+typedef ALIGN_1 __attribute__((unused)) UNUSED;
+_Static_assert(_Alignof(UNUSED) == 1, "");
+
+typedef int __attribute__((aligned(16))) __attribute__((aligned(1))) ALIGN_16;
+_Static_assert(_Alignof(ALIGN_16) == 16, "");
+
+typedef ALIGN_16 __attribute__((aligned(1))) LOWERED_ALIGNMENT;
+_Static_assert(_Alignof(LOWERED_ALIGNMENT) == 1, "");
+
+typedef ALIGN_1 __attribute__((aligned(16))) RAISED_ALIGNMENT;
+_Static_assert(_Alignof(RAISED_ALIGNMENT) == 16, "");
+
+__auto_type ARRAY = (__attribute__((aligned(16))) int[]) {1, 2, 3};
+_Static_assert(_Alignof(__typeof__(ARRAY)) == _Alignof(int *), "");

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -407,14 +407,6 @@ const compErr = blk: {
     @setEvalBranchQuota(100_000);
     break :blk std.StaticStringMap(ExpectedFailure).initComptime(.{
         .{
-            "aarch64-generic-windows-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0014",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "aarch64-generic-windows-msvc:Msvc|0018",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -467,10 +459,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
-            "aarch64-generic-windows-msvc:Msvc|0046",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "aarch64-generic-windows-msvc:Msvc|0053",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -492,14 +480,6 @@ const compErr = blk: {
         },
         .{
             "aarch64-generic-windows-msvc:Msvc|0080",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -535,10 +515,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0046",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i586-windows-msvc:Msvc|0053",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -552,14 +528,6 @@ const compErr = blk: {
         },
         .{
             "x86-i586-windows-msvc:Msvc|0066",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -595,10 +563,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-uefi-msvc:Msvc|0046",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i686-uefi-msvc:Msvc|0053",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -612,14 +576,6 @@ const compErr = blk: {
         },
         .{
             "x86-i686-uefi-msvc:Msvc|0066",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -655,10 +611,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-windows-msvc:Msvc|0046",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i686-windows-msvc:Msvc|0053",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -672,14 +624,6 @@ const compErr = blk: {
         },
         .{
             "x86-i686-windows-msvc:Msvc|0066",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -731,10 +675,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
-            "thumb-baseline-windows-msvc:Msvc|0046",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "thumb-baseline-windows-msvc:Msvc|0053",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -756,14 +696,6 @@ const compErr = blk: {
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0080",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -799,10 +731,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0046",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86_64-x86_64-uefi-msvc:Msvc|0053",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -816,14 +744,6 @@ const compErr = blk: {
         },
         .{
             "x86_64-x86_64-uefi-msvc:Msvc|0066",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0011",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0014",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -857,10 +777,6 @@ const compErr = blk: {
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0045",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0046",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0053",


### PR DESCRIPTION
The main change here is making `attributed` types nestable instead of trying to merge them into a single level. This fixed a few record tests as well - previously there were cases where attributes could get dropped via multiple layers of typedefs if each added its own attributes.