### PR TITLE
Type: add a name field to track typedef names

### DIFF
--- a/src/aro/SymbolStack.zig
+++ b/src/aro/SymbolStack.zig
@@ -196,7 +196,12 @@ pub fn defineTypedef(
         .kind = .typedef,
         .name = name,
         .tok = tok,
-        .ty = ty,
+        .ty = .{
+            .name = name,
+            .specifier = ty.specifier,
+            .qual = ty.qual,
+            .data = ty.data,
+        },
         .node = node,
         .val = .{},
     });

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -881,6 +881,10 @@ fn dumpNode(
     }
     try config.setColor(w, TYPE);
     try w.writeByte('\'');
+    const name = ty.getName();
+    if (name != .empty) {
+        try w.print("{s}': '", .{mapper.lookup(name)});
+    }
     try ty.dump(mapper, tree.comp.langopts, w);
     try w.writeByte('\'');
 

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -422,6 +422,8 @@ data: union {
 specifier: Specifier,
 qual: Qualifiers = .{},
 decayed: bool = false,
+/// typedef name, if any
+name: StringId = .empty,
 
 pub const int = Type{ .specifier = .int };
 pub const invalid = Type{ .specifier = .invalid };
@@ -1173,6 +1175,15 @@ pub fn requestedAlignment(ty: Type, comp: *const Compilation) ?u29 {
 pub fn enumIsPacked(ty: Type, comp: *const Compilation) bool {
     std.debug.assert(ty.is(.@"enum"));
     return comp.langopts.short_enums or target_util.packAllEnums(comp.target) or ty.hasAttribute(.@"packed");
+}
+
+pub fn getName(ty: Type) StringId {
+    return switch (ty.specifier) {
+        .typeof_type => if (ty.name == .empty) ty.data.sub_type.getName() else ty.name,
+        .typeof_expr => if (ty.name == .empty) ty.data.expr.ty.getName() else ty.name,
+        .attributed => if (ty.name == .empty) ty.data.attributed.base.getName() else ty.name,
+        else => ty.name,
+    };
 }
 
 pub fn annotationAlignment(comp: *const Compilation, attrs: Attribute.Iterator) ?u29 {

--- a/test/cases/ast/_Float16.c
+++ b/test/cases/ast/_Float16.c
@@ -1,7 +1,7 @@
-typedef: '[1]struct __va_list_tag'
+typedef: '__builtin_va_list': '[1]struct __va_list_tag'
  name: va_list
 
-typedef: '[1]struct __va_list_tag'
+typedef: '__builtin_va_list': '[1]struct __va_list_tag'
  name: __gnuc_va_list
 
 fn_def: 'fn (x: _Float16, y: _Float16) _Float16'
@@ -24,14 +24,14 @@ fn_def: 'fn (x: int, ...) void'
  name: bar
  body:
   compound_stmt: 'void'
-    var: '[1]struct __va_list_tag'
+    var: 'va_list': '[1]struct __va_list_tag'
      name: va
 
     builtin_call_expr: 'void'
      name: __builtin_va_start
      args:
-      implicit_cast: (array_to_pointer) '*d[1]struct __va_list_tag'
-        decl_ref_expr: '[1]struct __va_list_tag' lvalue
+      implicit_cast: (array_to_pointer) 'va_list': '*d[1]struct __va_list_tag'
+        decl_ref_expr: 'va_list': '[1]struct __va_list_tag' lvalue
          name: va
       decl_ref_expr: 'int' lvalue
        name: x
@@ -39,8 +39,8 @@ fn_def: 'fn (x: int, ...) void'
     builtin_call_expr_one: 'void'
      name: __builtin_va_end
      arg:
-      implicit_cast: (array_to_pointer) '*d[1]struct __va_list_tag'
-        decl_ref_expr: '[1]struct __va_list_tag' lvalue
+      implicit_cast: (array_to_pointer) 'va_list': '*d[1]struct __va_list_tag'
+        decl_ref_expr: 'va_list': '[1]struct __va_list_tag' lvalue
          name: va
 
     implicit_return: 'void'

--- a/test/cases/ast/__float80.c
+++ b/test/cases/ast/__float80.c
@@ -2,14 +2,14 @@ fn_def: 'fn () void'
  name: foo
  body:
   compound_stmt: 'void'
-    var: 'long double'
+    var: '__float80': 'long double'
      name: x
      init:
       float_literal: 'long double' (value: 1)
 
-    assign_expr: 'long double'
+    assign_expr: '__float80': 'long double'
      lhs:
-      decl_ref_expr: 'long double' lvalue
+      decl_ref_expr: '__float80': 'long double' lvalue
        name: x
      rhs:
       float_literal: 'long double' (value: 1)

--- a/test/cases/ast/types.c
+++ b/test/cases/ast/types.c
@@ -29,13 +29,13 @@ fn_proto: 'attributed(fn () void)'
 typedef: 'int'
  name: A
 
-typedef: 'int'
+typedef: 'A': 'int'
  name: B
 
-typedef: 'int'
+typedef: 'A': 'int'
  name: C
 
-typedef: 'int'
+typedef: 'C': 'int'
  name: B
 
 typedef: '[2]int'
@@ -45,20 +45,20 @@ fn_def: 'fn (a: *d[2]const int, b: *d[2]const int) void'
  name: qux
  body:
   compound_stmt: 'void'
-    add_assign_expr: '*d[2]const int'
+    add_assign_expr: 'I': '*d[2]const int'
      lhs:
-      decl_ref_expr: '*d[2]const int' lvalue
+      decl_ref_expr: 'I': '*d[2]const int' lvalue
        name: b
      rhs:
-      implicit_cast: (int_to_pointer) '*d[2]const int'
+      implicit_cast: (int_to_pointer) 'I': '*d[2]const int'
         int_literal: 'int' (value: 1)
 
-    add_assign_expr: '*d[2]const int'
+    add_assign_expr: 'I': '*d[2]const int'
      lhs:
-      decl_ref_expr: '*d[2]const int' lvalue
+      decl_ref_expr: 'I': '*d[2]const int' lvalue
        name: a
      rhs:
-      implicit_cast: (int_to_pointer) '*d[2]const int'
+      implicit_cast: (int_to_pointer) 'I': '*d[2]const int'
         int_literal: 'int' (value: 1)
 
     implicit_return: 'void'

--- a/test/cases/ast/vectors.c
+++ b/test/cases/ast/vectors.c
@@ -8,24 +8,24 @@ fn_def: 'fn () void'
  name: foo
  body:
   compound_stmt: 'void'
-    var: 'vector(2, float)'
+    var: 'f2v': 'vector(2, float)'
      name: a
 
-    var: 'vector(2, float)'
+    var: 'f2v': 'vector(2, float)'
      name: b
 
-    assign_expr: 'vector(2, float)'
+    assign_expr: 'f2v': 'vector(2, float)'
      lhs:
-      decl_ref_expr: 'vector(2, float)' lvalue
+      decl_ref_expr: 'f2v': 'vector(2, float)' lvalue
        name: a
      rhs:
-      implicit_cast: (lval_to_rval) 'vector(2, float)'
-        decl_ref_expr: 'vector(2, float)' lvalue
+      implicit_cast: (lval_to_rval) 'f2v': 'vector(2, float)'
+        decl_ref_expr: 'f2v': 'vector(2, float)' lvalue
          name: b
 
-    mul_assign_expr: 'vector(2, float)'
+    mul_assign_expr: 'f2v': 'vector(2, float)'
      lhs:
-      decl_ref_expr: 'vector(2, float)' lvalue
+      decl_ref_expr: 'f2v': 'vector(2, float)' lvalue
        name: a
      rhs:
       implicit_cast: (vector_splat) 'float'


### PR DESCRIPTION
Just an idea - as a stop-gap before #733 is implemented. This would allow more progress on aro translate-c since one blocker right now is the lack of typedef names. It was about 5 minutes of work so I'm not very strongly advocating for it if you think it's too much of a hack.

We had at least 4 bytes of padding available in `Type` because it doesn't change the size of `Type` in either Safe or Fast modes.
