### PR TITLE
Compilation: Add driver/frontend support for pic/pie options

### DIFF
--- a/src/aro/target.zig
+++ b/src/aro/target.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const LangOpts = @import("LangOpts.zig");
 const Type = @import("Type.zig");
 const TargetSet = @import("Builtins/Properties.zig").TargetSet;
+const backend = @import("backend");
 
 /// intmax_t for this target
 pub fn intMaxType(target: std.Target) Type {
@@ -720,6 +721,12 @@ pub fn toLLVMTriple(target: std.Target, buf: []u8) []const u8 {
     };
     writer.writeAll(llvm_abi) catch unreachable;
     return stream.getWritten();
+}
+
+/// This currently just returns the desired settings without considering target defaults / requirements
+pub fn getPICMode(target: std.Target, desired_pic_level: ?backend.CodeGenOptions.PicLevel, wants_pie: ?bool) struct { backend.CodeGenOptions.PicLevel, bool } {
+    _ = target;
+    return .{ desired_pic_level orelse .none, wants_pie orelse false };
 }
 
 test "alignment functions - smoke test" {

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -1,6 +1,7 @@
 pub const Interner = @import("backend/Interner.zig");
 pub const Ir = @import("backend/Ir.zig");
 pub const Object = @import("backend/Object.zig");
+pub const CodeGenOptions = @import("backend/CodeGenOptions.zig");
 
 pub const CallingConvention = enum {
     C,

--- a/src/backend/CodeGenOptions.zig
+++ b/src/backend/CodeGenOptions.zig
@@ -1,0 +1,27 @@
+/// place uninitialized global variables in a common block
+common: bool,
+/// Place each function into its own section in the output file if the target supports arbitrary sections
+func_sections: bool,
+/// Place each data item into its own section in the output file if the target supports arbitrary sections
+data_sections: bool,
+pic_level: PicLevel,
+/// Generate position-independent code that can only be linked into executables
+is_pie: bool,
+
+pub const PicLevel = enum(u8) {
+    /// Do not generate position-independent code
+    none = 0,
+    /// Generate position-independent code (PIC) suitable for use in a shared library, if supported for the target machine.
+    one = 1,
+    /// If supported for the target machine, emit position-independent code, suitable for dynamic linking and avoiding
+    /// any limit on the size of the global offset table.
+    two = 2,
+};
+
+pub const default: @This() = .{
+    .common = false,
+    .func_sections = false,
+    .data_sections = false,
+    .pic_level = .none,
+    .is_pie = false,
+};

--- a/test/cases/pic1.c
+++ b/test/cases/pic1.c
@@ -1,0 +1,7 @@
+//aro-args --target=x86_64-linux-gnu -fpic
+
+_Static_assert(__pic__ == 1, "");
+_Static_assert(__PIC__ == 1, "");
+#if defined __pie__ || defined __PIE__
+#error __pie__ and __PIE__ should not be defined
+#endif

--- a/test/cases/pic2.c
+++ b/test/cases/pic2.c
@@ -1,0 +1,7 @@
+//aro-args --target=x86_64-linux-gnu -fPIC
+
+_Static_assert(__pic__ == 2, "");
+_Static_assert(__PIC__ == 2, "");
+#if defined __pie__ || defined __PIE__
+#error __pie__ and __PIE__ should not be defined
+#endif

--- a/test/cases/pie1.c
+++ b/test/cases/pie1.c
@@ -1,0 +1,6 @@
+//aro-args --target=x86_64-linux-gnu -fpie
+
+_Static_assert(__pic__ == 1, "");
+_Static_assert(__PIC__ == 1, "");
+_Static_assert(__pie__ == 1, "");
+_Static_assert(__PIE__ == 1, "");

--- a/test/cases/pie2.c
+++ b/test/cases/pie2.c
@@ -1,0 +1,6 @@
+//aro-args --target=x86_64-linux-gnu -fPIE
+
+_Static_assert(__pic__ == 2, "");
+_Static_assert(__PIC__ == 2, "");
+_Static_assert(__pie__ == 2, "");
+_Static_assert(__PIE__ == 2, "");


### PR DESCRIPTION
Some time (real soon now™) I'd like to start writing a simple AST -> x86_64 assembly backend. No IR or optimizations or anything, just something that generates readable/debuggable assembly. 

Is that something that you think should be part of aro? Or a separate project that uses aro as a dependency? If it's part of aro I'd want to put it behind a `-fsimple-asm` or similar type of flag.