### PR TITLE
Implement target.getPICMode

### DIFF
--- a/src/aro/Diagnostics/messages.def
+++ b/src/aro/Diagnostics/messages.def
@@ -1481,6 +1481,11 @@ cli_error
     .extra = .str
     .kind = .@"error"
 
+cli_warn
+    .msg = "{s}"
+    .extra = .str
+    .kind = .warning
+
 cli_unused_link_object
     .msg = "{s}: linker input file unused because linking not done"
     .extra = .str

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -48,8 +48,6 @@ color: ?bool = null,
 nobuiltininc: bool = false,
 nostdinc: bool = false,
 nostdlibinc: bool = false,
-desired_pic_level: ?backend.CodeGenOptions.PicLevel = null,
-desired_pie_level: ?backend.CodeGenOptions.PicLevel = null,
 debug_dump_letters: packed struct(u3) {
     d: bool = false,
     m: bool = false,
@@ -311,20 +309,15 @@ pub fn parseArgs(
             } else if (mem.eql(u8, arg, "-fnative-half-arguments-and-returns")) {
                 d.comp.langopts.allow_half_args_and_returns = true;
             } else if (mem.eql(u8, arg, "-fno-pic") or mem.eql(u8, arg, "-fno-PIC") or mem.eql(u8, arg, "-fno-pie") or mem.eql(u8, arg, "-fno-PIE")) {
-                d.desired_pic_level = .none;
-                d.desired_pie_level = .none;
+                //
             } else if (mem.eql(u8, arg, "-fpic")) {
-                d.desired_pic_level = .one;
-                d.desired_pie_level = .none;
+                //
             } else if (mem.eql(u8, arg, "-fPIC")) {
-                d.desired_pic_level = .two;
-                d.desired_pie_level = .none;
+                //
             } else if (mem.eql(u8, arg, "-fpie")) {
-                d.desired_pic_level = .one;
-                d.desired_pie_level = .one;
+                //
             } else if (mem.eql(u8, arg, "-fPIE")) {
-                d.desired_pic_level = .two;
-                d.desired_pie_level = .two;
+                //
             } else if (mem.eql(u8, arg, "-fshort-enums")) {
                 d.comp.langopts.short_enums = true;
             } else if (mem.eql(u8, arg, "-fno-short-enums")) {

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -602,7 +602,7 @@ pub fn warn(d: *Driver, msg: []const u8) !void {
 pub fn unsupportedOptionForTarget(d: *Driver, target: std.Target, opt: []const u8) !void {
     try d.err(try std.fmt.allocPrint(
         d.comp.diagnostics.arena.allocator(),
-        "unsupported option '{s}' for target '{s}'\n",
+        "unsupported option '{s}' for target '{s}'",
         .{ opt, try target.linuxTriple(d.comp.diagnostics.arena.allocator()) },
     ));
 }
@@ -1045,7 +1045,7 @@ pub fn getPICMode(d: *Driver, lastpic: []const u8) !struct { backend.CodeGenOpti
                     pic = true;
                     try d.warn(try std.fmt.allocPrint(
                         d.comp.diagnostics.arena.allocator(),
-                        "option '{s}' was ignored by the {s} toolchain, using '-fPIC'\n",
+                        "option '{s}' was ignored by the {s} toolchain, using '-fPIC'",
                         .{ lastpic, if (target.os.tag == .ps4) "PS4" else "PS5" },
                     ));
                 }
@@ -1096,7 +1096,7 @@ pub fn getPICMode(d: *Driver, lastpic: []const u8) !struct { backend.CodeGenOpti
 
     // ROPI and RWPI are not compatible with PIC or PIE.
     if ((ropi or rwpi) and (pic or pie)) {
-        //TODO: diag error
+        try d.err("embedded and GOT-based position independence are incompatible");
     }
 
     if (target_util.isMIPS(target)) {

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -62,6 +62,7 @@ nostdlibinc: bool = false,
 apple_kext: bool = false,
 mkernel: bool = false,
 mabicalls: ?bool = null,
+dynamic_nopic: ?bool = null,
 debug_dump_letters: packed struct(u3) {
     d: bool = false,
     m: bool = false,
@@ -295,6 +296,8 @@ pub fn parseArgs(
                 d.apple_kext = true;
             } else if (mem.eql(u8, arg, "-mkernel")) {
                 d.mkernel = true;
+            } else if (mem.eql(u8, arg, "-mdynamic-no-pic")) {
+                d.dynamic_nopic = true;
             } else if (mem.eql(u8, arg, "-mabicalls")) {
                 d.mabicalls = true;
             } else if (mem.eql(u8, arg, "-mno-abicalls")) {
@@ -1049,10 +1052,9 @@ pub fn getPICMode(d: *Driver, args: []const []const u8, lastpic: []const u8) !st
         pie, pic = .{ false, false };
     }
 
-    const arg_idx = getLastArg(args, StaticStringSet.initComptime(.{.{"-mdynamic-no-pic"}}));
-    if (arg_idx) |idx| {
+    if (d.dynamic_nopic) |_| {
         if (!target.isDarwin()) {
-            try d.unsupportedOptionForTarget(target, args[idx]);
+            try d.unsupportedOptionForTarget(target, "-mdynamic-no-pic");
         }
         pic = is_pic_default or forced;
         return .{ if (pic) .two else .none, false };

--- a/src/aro/target.zig
+++ b/src/aro/target.zig
@@ -753,7 +753,6 @@ pub fn isPIEDefault(target: std.Target) DefaultPIStatus {
 
         .hurd,
         .zos,
-        .shadermodel,
         => .no,
 
         .openbsd,
@@ -821,7 +820,6 @@ pub fn isPICdefault(target: std.Target) DefaultPIStatus {
         .fuchsia,
         .cuda,
         .zos,
-        .shadermodel,
         => .no,
 
         .dragonfly,
@@ -898,7 +896,6 @@ pub fn isPICDefaultForced(target: std.Target) DefaultPIStatus {
         .elfiamcu,
         .fuchsia,
         .zos,
-        .shadermodel,
         => .no,
 
         .windows => {

--- a/src/aro/target.zig
+++ b/src/aro/target.zig
@@ -371,6 +371,17 @@ pub fn isCygwinMinGW(target: std.Target) bool {
     return target.os.tag == .windows and (target.abi == .gnu or target.abi == .cygnus);
 }
 
+pub fn isPS(target: std.Target) bool {
+    return (target.os.tag == .ps4 or target.os.tag == .ps5) and target.cpu.arch == .x86_64;
+}
+
+pub fn isMIPS(target: std.Target) bool {
+    return switch (target.cpu.arch) {
+        .mips, .mipsel, .mips64, .mips64el => true,
+        else => false,
+    };
+}
+
 pub fn builtinEnabled(target: std.Target, enabled_for: TargetSet) bool {
     var it = enabled_for.iterator();
     while (it.next()) |val| {
@@ -916,7 +927,7 @@ pub fn isPICDefaultForced(target: std.Target) DefaultPIStatus {
         => if (target.cpu.arch == .x86_64 or target.cpu.arch == .aarch64) .yes else .no,
 
         else => {
-            switch (target.cpu.arch) {
+            return switch (target.cpu.arch) {
                 .hexagon,
                 .lanai,
                 .avr,
@@ -938,7 +949,7 @@ pub fn isPICDefaultForced(target: std.Target) DefaultPIStatus {
                         return if (target.cpu.arch == .aarch64 or target.cpu.arch == .x86_64) .yes else .no;
                     return .no;
                 },
-            }
+            };
         },
     };
 }

--- a/src/aro/target.zig
+++ b/src/aro/target.zig
@@ -375,13 +375,6 @@ pub fn isPS(target: std.Target) bool {
     return (target.os.tag == .ps4 or target.os.tag == .ps5) and target.cpu.arch == .x86_64;
 }
 
-pub fn isMIPS(target: std.Target) bool {
-    return switch (target.cpu.arch) {
-        .mips, .mipsel, .mips64, .mips64el => true,
-        else => false,
-    };
-}
-
 pub fn builtinEnabled(target: std.Target, enabled_for: TargetSet) bool {
     var it = enabled_for.iterator();
     while (it.next()) |val| {
@@ -718,7 +711,8 @@ pub fn toLLVMTriple(target: std.Target, buf: []u8) []const u8 {
         .cygnus => "cygnus",
         .simulator => "simulator",
         .macabi => "macabi",
-        .ohos => "openhos",
+        .ohos => "ohos",
+        .ohoseabi => "ohoseabi",
     };
     writer.writeAll(llvm_abi) catch unreachable;
     return stream.getWritten();


### PR DESCRIPTION
I tried to solve #770,  but full implementation of this function is too long.  So for now, i have only implemented these two target-related [default functions](https://github.com/llvm/llvm-project/blob/f12e10b513686a12f20f0c897dcc9ffc00cbce09/clang/lib/Driver/ToolChains/CommonArgs.cpp#L1808).

 I'm unable to verify all the correctness.  Could please review this part first?  Once It's reviewed and passed, I'll submit the remaining code for `target.getPICMode` function.