### PR TITLE
Issue a warning on gnu void pointer arithmetic

### DIFF
--- a/src/aro/Diagnostics.zig
+++ b/src/aro/Diagnostics.zig
@@ -196,6 +196,7 @@ pub const Options = struct {
     @"pointer-bool-conversion": Kind = .default,
     @"string-conversion": Kind = .default,
     @"gnu-auto-type": Kind = .default,
+    @"gnu-pointer-arith": Kind = .default,
     @"gnu-union-cast": Kind = .default,
     @"pointer-sign": Kind = .default,
     @"fuse-ld-path": Kind = .default,

--- a/src/aro/Diagnostics/messages.def
+++ b/src/aro/Diagnostics/messages.def
@@ -2165,6 +2165,12 @@ auto_type_extension
     .kind = .off
     .pedantic = true
 
+gnu_pointer_arith
+    .msg = "arithmetic on pointers to void is a GNU extension"
+    .opt = W("gnu-pointer-arith")
+    .kind = .off
+    .pedantic = true
+
 auto_type_not_allowed
     .msg = "'__auto_type' not allowed in {s}"
     .kind = .@"error"

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -5504,6 +5504,10 @@ pub const Result = struct {
                 // if both aren't arithmetic then either both should be pointers or just a
                 if (!a_ptr or !(b_ptr or b_int)) return a.invalidBinTy(tok, b, p);
 
+                if ((a.ty.isPtrTo(.void) or b.ty.isPtrTo(.void)) and
+                    (p.comp.diagnostics.options.@"gnu-pointer-arith" == .warning or p.comp.diagnostics.options.pedantic == .warning))
+                    try p.errTok(.gnu_pointer_arith, tok);
+
                 if (a_ptr and b_ptr) {
                     if (!a.ty.eql(b.ty, p.comp, false)) try p.errStr(.incompatible_pointers, tok, try p.typePairStr(a.ty, b.ty));
                     a.ty = p.comp.types.ptrdiff;

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -5492,6 +5492,9 @@ pub const Result = struct {
                 // if both aren't arithmetic one should be pointer and the other an integer
                 if (a_ptr == b_ptr or a_int == b_int) return a.invalidBinTy(tok, b, p);
 
+                if (a.ty.isVoidStar() or b.ty.isVoidStar())
+                    try p.errTok(.gnu_pointer_arith, tok);
+
                 // Do integer promotions but nothing else
                 if (a_int) try a.intCast(p, a.ty.integerPromotion(p.comp), tok);
                 if (b_int) try b.intCast(p, b.ty.integerPromotion(p.comp), tok);
@@ -5504,7 +5507,7 @@ pub const Result = struct {
                 // if both aren't arithmetic then either both should be pointers or just a
                 if (!a_ptr or !(b_ptr or b_int)) return a.invalidBinTy(tok, b, p);
 
-                if (a.ty.isVoidStar() or b.ty.isVoidStar())
+                if (a.ty.isVoidStar())
                     try p.errTok(.gnu_pointer_arith, tok);
 
                 if (a_ptr and b_ptr) {
@@ -7153,6 +7156,8 @@ fn unExpr(p: *Parser) Error!Result {
 
             var operand = try p.castExpr();
             try operand.expect(p);
+            if (operand.ty.isVoidStar())
+                try p.errTok(.gnu_pointer_arith, tok);
             if (!operand.ty.isScalar())
                 try p.errStr(.invalid_argument_un, tok, try p.typeStr(operand.ty));
             if (operand.ty.isComplex())
@@ -7179,6 +7184,8 @@ fn unExpr(p: *Parser) Error!Result {
 
             var operand = try p.castExpr();
             try operand.expect(p);
+            if (operand.ty.isVoidStar())
+                try p.errTok(.gnu_pointer_arith, tok);
             if (!operand.ty.isScalar())
                 try p.errStr(.invalid_argument_un, tok, try p.typeStr(operand.ty));
             if (operand.ty.isComplex())
@@ -7478,6 +7485,8 @@ fn suffixExpr(p: *Parser, lhs: Result) Error!Result {
             defer p.tok_i += 1;
 
             var operand = lhs;
+            if (operand.ty.isVoidStar())
+                try p.errTok(.gnu_pointer_arith, p.tok_i);
             if (!operand.ty.isScalar())
                 try p.errStr(.invalid_argument_un, p.tok_i, try p.typeStr(operand.ty));
             if (operand.ty.isComplex())
@@ -7496,6 +7505,8 @@ fn suffixExpr(p: *Parser, lhs: Result) Error!Result {
             defer p.tok_i += 1;
 
             var operand = lhs;
+            if (operand.ty.isVoidStar())
+                try p.errTok(.gnu_pointer_arith, p.tok_i);
             if (!operand.ty.isScalar())
                 try p.errStr(.invalid_argument_un, p.tok_i, try p.typeStr(operand.ty));
             if (operand.ty.isComplex())

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -5504,7 +5504,7 @@ pub const Result = struct {
                 // if both aren't arithmetic then either both should be pointers or just a
                 if (!a_ptr or !(b_ptr or b_int)) return a.invalidBinTy(tok, b, p);
 
-                if ((a.ty.isPtrTo(.void) or b.ty.isPtrTo(.void)) and
+                if ((a.ty.isVoidStar() or b.ty.isVoidStar()) and
                     (p.comp.diagnostics.options.@"gnu-pointer-arith" == .warning or p.comp.diagnostics.options.pedantic == .warning))
                     try p.errTok(.gnu_pointer_arith, tok);
 

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -5504,8 +5504,7 @@ pub const Result = struct {
                 // if both aren't arithmetic then either both should be pointers or just a
                 if (!a_ptr or !(b_ptr or b_int)) return a.invalidBinTy(tok, b, p);
 
-                if ((a.ty.isVoidStar() or b.ty.isVoidStar()) and
-                    (p.comp.diagnostics.options.@"gnu-pointer-arith" == .warning or p.comp.diagnostics.options.pedantic == .warning))
+                if (a.ty.isVoidStar() or b.ty.isVoidStar())
                     try p.errTok(.gnu_pointer_arith, tok);
 
                 if (a_ptr and b_ptr) {

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -535,13 +535,6 @@ pub fn isPtr(ty: Type) bool {
     };
 }
 
-pub fn isPtrTo(ty: Type, specifier: Specifier) bool {
-    return switch (ty.specifier) {
-        .pointer => ty.data.sub_type.specifier == specifier,
-        else => false,
-    };
-}
-
 pub fn isInt(ty: Type) bool {
     return switch (ty.specifier) {
         // zig fmt: off

--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -535,6 +535,13 @@ pub fn isPtr(ty: Type) bool {
     };
 }
 
+pub fn isPtrTo(ty: Type, specifier: Specifier) bool {
+    return switch (ty.specifier) {
+        .pointer => ty.data.sub_type.specifier == specifier,
+        else => false,
+    };
+}
+
 pub fn isInt(ty: Type) bool {
     return switch (ty.specifier) {
         // zig fmt: off

--- a/test/cases/gnu pointer arith.c
+++ b/test/cases/gnu pointer arith.c
@@ -1,8 +1,19 @@
 //aro-args -Wgnu-pointer-arith
 
-#include <stddef.h>
-ptrdiff_t foo(void *a, void *b) {
-    return b - a;
+void foo(void *a, void *b) {
+    b - a;
+    a - 1;
+    a + 1;
+    ++a;
+    --a;
+    b++;
+    b--;
 }
 
-#define EXPECTED_ERRORS "gnu pointer arith.c:5:14: warning: arithmetic on pointers to void is a GNU extension [-Wgnu-pointer-arith]"
+#define EXPECTED_ERRORS "gnu pointer arith.c:4:7: warning: arithmetic on pointers to void is a GNU extension [-Wgnu-pointer-arith]"\
+                        "gnu pointer arith.c:5:7: warning: arithmetic on pointers to void is a GNU extension [-Wgnu-pointer-arith]"\
+                        "gnu pointer arith.c:6:7: warning: arithmetic on pointers to void is a GNU extension [-Wgnu-pointer-arith]"\
+                        "gnu pointer arith.c:7:5: warning: arithmetic on pointers to void is a GNU extension [-Wgnu-pointer-arith]"\
+                        "gnu pointer arith.c:8:5: warning: arithmetic on pointers to void is a GNU extension [-Wgnu-pointer-arith]"\
+                        "gnu pointer arith.c:9:6: warning: arithmetic on pointers to void is a GNU extension [-Wgnu-pointer-arith]"\
+                        "gnu pointer arith.c:10:6: warning: arithmetic on pointers to void is a GNU extension [-Wgnu-pointer-arith]"

--- a/test/cases/gnu pointer arith.c
+++ b/test/cases/gnu pointer arith.c
@@ -1,0 +1,8 @@
+//aro-args -Wgnu-pointer-arith
+
+#include <stddef.h>
+ptrdiff_t foo(void *a, void *b) {
+    return b - a;
+}
+
+#define EXPECTED_ERRORS "gnu pointer arith.c:5:14: warning: arithmetic on pointers to void is a GNU extension [-Wgnu-pointer-arith]"


### PR DESCRIPTION
Closes https://github.com/Vexu/arocc/issues/759
In this request I implemented the ```Type.isPtrTo``` function but only for the ```.pointer``` type specifier. I'm not sure if it is right approach to do that. Maybe other specifiers should be considered as well. I'm open for the conversation.