### PR TITLE
Start adding frontend support for relocations

### DIFF
--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -340,6 +340,7 @@ fn diagnoseField(
         .array_ty,
         .vector_ty,
         .record_ty,
+        .global_var_offset,
         => unreachable,
     });
 }

--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -340,7 +340,7 @@ fn diagnoseField(
         .array_ty,
         .vector_ty,
         .record_ty,
-        .global_var_offset,
+        .pointer,
         => unreachable,
     });
 }

--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -753,6 +753,10 @@ pub fn float80Type(comp: *const Compilation) ?Type {
     return target_util.float80Type(comp.target);
 }
 
+pub fn internString(comp: *Compilation, str: []const u8) !StrInt.StringId {
+    return comp.string_interner.internExtra(comp.gpa, str);
+}
+
 /// Smallest integer type with at least N bits
 pub fn intLeastN(comp: *const Compilation, bits: usize, signedness: std.builtin.Signedness) Type {
     if (bits == 64 and (comp.target.isDarwin() or comp.target.isWasm())) {

--- a/src/aro/Diagnostics/messages.def
+++ b/src/aro/Diagnostics/messages.def
@@ -2545,3 +2545,9 @@ auto_type_self_initialized
 non_constant_initializer
     .msg = "initializer element is not a compile-time constant"
     .kind = .@"error"
+
+subtract_pointers_zero_elem_size
+    .msg = "subtraction of pointers to type '{s}' of zero size has undefined behavior"
+    .kind = .warning
+    .opt = W("pointer-arith")
+    .extra = .str

--- a/src/aro/Diagnostics/messages.def
+++ b/src/aro/Diagnostics/messages.def
@@ -2535,3 +2535,7 @@ auto_type_self_initialized
     .msg = "variable '{s}' declared with deduced type '__auto_type' cannot appear in its own initializer"
     .extra = .str
     .kind = .@"error"
+
+non_constant_initializer
+    .msg = "initializer element is not a compile-time constant"
+    .kind = .@"error"

--- a/src/aro/Diagnostics/messages.def
+++ b/src/aro/Diagnostics/messages.def
@@ -527,6 +527,12 @@ unknown_warning
     .opt = W("unknown-warning-option")
     .kind = .warning
 
+array_overflow
+    .msg = "{s}"
+    .extra = .str
+    .opt = W("array-bounds")
+    .kind = .warning
+
 overflow
     .msg = "overflow in expression; result is '{s}'"
     .extra = .str

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6603,7 +6603,11 @@ fn eqExpr(p: *Parser) Error!Result {
 
         if (try lhs.adjustTypes(ne.?, &rhs, p, .equality)) {
             const op: std.math.CompareOperator = if (tag == .equal_expr) .eq else .neq;
-            const res = lhs.val.compareExtra(op, rhs.val, p.comp);
+            const res: ?bool = if (lhs.ty.isPtr() or rhs.ty.isPtr())
+                lhs.val.comparePointers(op, rhs.val, p.comp)
+            else
+                lhs.val.compare(op, rhs.val, p.comp);
+
             lhs.val = if (res) |val| Value.fromBool(val) else .{};
         } else {
             lhs.val.boolCast(p.comp);
@@ -6634,7 +6638,10 @@ fn compExpr(p: *Parser) Error!Result {
                 .greater_than_equal_expr => .gte,
                 else => unreachable,
             };
-            const res = lhs.val.compareExtra(op, rhs.val, p.comp);
+            const res: ?bool = if (lhs.ty.isPtr() or rhs.ty.isPtr())
+                lhs.val.comparePointers(op, rhs.val, p.comp)
+            else
+                lhs.val.compare(op, rhs.val, p.comp);
             lhs.val = if (res) |val| Value.fromBool(val) else .{};
         } else {
             lhs.val.boolCast(p.comp);

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -899,7 +899,7 @@ fn dumpNode(
     if (tree.value_map.get(node)) |val| {
         try config.setColor(w, LITERAL);
         try w.writeAll(" (value: ");
-        try val.print(ty, tree.comp, w);
+        try val.print(ty, tree.comp, mapper, w);
         try w.writeByte(')');
     }
     if (tag == .implicit_return and data.return_zero) {

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -899,7 +899,7 @@ fn dumpNode(
     if (tree.value_map.get(node)) |val| {
         try config.setColor(w, LITERAL);
         try w.writeAll(" (value: ");
-        try val.print(ty, tree.comp, mapper, w);
+        try val.print(ty, tree.comp, w);
         try w.writeByte(')');
     }
     if (tag == .implicit_return and data.return_zero) {

--- a/test/cases/const decl folding.c
+++ b/test/cases/const decl folding.c
@@ -67,14 +67,14 @@ _Static_assert(4.2, "");
     "const decl folding.c:27:14: note: previous case defined here" \
     "const decl folding.c:34:27: error: '__builtin_choose_expr' requires a constant expression" \
     "const decl folding.c:38:15: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]" \
-    "const decl folding.c:43:16: warning: expression is not an integer constant expression; folding it to a constant is a GNU extension [-Wgnu-folding-constant]" \
     "const decl folding.c:43:16: warning: implicit conversion turns string literal into bool: 'char [1]' to '_Bool' [-Wstring-conversion]" \
+    "const decl folding.c:43:16: error: static_assert expression is not an integral constant expression" \
     "const decl folding.c:44:1: error: static assertion failed \"\"" \
-    "const decl folding.c:46:1: error: static assertion failed \"\"" \
-    "const decl folding.c:47:16: warning: expression is not an integer constant expression; folding it to a constant is a GNU extension [-Wgnu-folding-constant]" \
-    "const decl folding.c:47:16: note: this conversion is not allowed in a constant expression" \
-    "const decl folding.c:50:16: warning: expression is not an integer constant expression; folding it to a constant is a GNU extension [-Wgnu-folding-constant]" \
+    "const decl folding.c:46:16: error: static_assert expression is not an integral constant expression" \
+    "const decl folding.c:47:16: error: static_assert expression is not an integral constant expression" \
     "const decl folding.c:50:16: warning: address of array 'arr' will always evaluate to 'true' [-Wpointer-bool-conversion]" \
+    "const decl folding.c:50:16: error: static_assert expression is not an integral constant expression" \
     "const decl folding.c:51:1: error: static assertion failed \"\"" \
     "const decl folding.c:53:16: warning: implicit conversion from 'double' to '_Bool' changes value from 4.2 to true [-Wfloat-conversion]" \
+    "const decl folding.c:53:16: error: static_assert expression is not an integral constant expression" \
 

--- a/test/cases/relocations.c
+++ b/test/cases/relocations.c
@@ -1,0 +1,44 @@
+//aro-args --target=x86_64-linux -std=c23
+
+int arr[20] = {0};
+_Static_assert(&arr[10] - &arr[0] == 10);
+_Static_assert(&arr[1] + 3 == &arr[4]);
+_Static_assert(&arr[4] - 4 == &arr[0]);
+
+struct Child {
+    int x[10];
+    char c;
+};
+
+struct Parent {
+    int x;
+    struct Child children[20];
+};
+
+struct Parent parents[10];
+_Static_assert(&parents[5].children[10].x[5] - &parents[0].children[0].x[0] == 1220);
+
+int x;
+int y;
+_Static_assert(&x != &y);
+_Static_assert(&x + 1 == &y + 1);
+
+_Static_assert(&x + 1 != &x + 2);
+_Static_assert(&x == &x);
+_Static_assert(&x >= &x);
+_Static_assert(&x > &y);
+_Static_assert(&x);
+
+struct __attribute__((packed)) Packed {
+    int x;
+    char c;
+    int y;
+};
+
+struct Packed packed;
+_Static_assert(&packed.x - &packed.y == -1);
+
+#define EXPECTED_ERRORS "relocations.c:24:1: error: static assertion failed" \
+    "relocations.c:29:16: error: static_assert expression is not an integral constant expression" \
+    "relocations.c:30:16: error: static_assert expression is not an integral constant expression" \
+

--- a/test/cases/relocations.c
+++ b/test/cases/relocations.c
@@ -44,7 +44,15 @@ _Static_assert((char*)(&x+100) - (char*)&x == 400,"");
 _Static_assert(&x - 2 != &x + 2, "");
 _Static_assert(&x - 2 == -2 + &x, "");
 
+union Empty {};
+
+union Empty empty[10];
+_Static_assert(&empty[4] - &empty[0] == 0, "");
+_Static_assert(&empty[4] >= &empty[0], "");
+
 #define EXPECTED_ERRORS "relocations.c:24:1: error: static assertion failed" \
     "relocations.c:29:16: error: static_assert expression is not an integral constant expression" \
     "relocations.c:30:16: error: static_assert expression is not an integral constant expression" \
+    "relocations.c:50:26: warning: subtraction of pointers to type 'union Empty' of zero size has undefined behavior [-Wpointer-arith]" \
+    "relocations.c:50:16: error: static_assert expression is not an integral constant expression" \
 

--- a/test/cases/relocations.c
+++ b/test/cases/relocations.c
@@ -38,6 +38,10 @@ struct __attribute__((packed)) Packed {
 struct Packed packed;
 _Static_assert(&packed.x - &packed.y == -1);
 
+char *p = (char*)(&x + 100);
+
+_Static_assert((char*)(&x+100) - (char*)&x == 400,"");
+
 #define EXPECTED_ERRORS "relocations.c:24:1: error: static assertion failed" \
     "relocations.c:29:16: error: static_assert expression is not an integral constant expression" \
     "relocations.c:30:16: error: static_assert expression is not an integral constant expression" \

--- a/test/cases/relocations.c
+++ b/test/cases/relocations.c
@@ -41,6 +41,8 @@ _Static_assert(&packed.x - &packed.y == -1);
 char *p = (char*)(&x + 100);
 
 _Static_assert((char*)(&x+100) - (char*)&x == 400,"");
+_Static_assert(&x - 2 != &x + 2, "");
+_Static_assert(&x - 2 == -2 + &x, "");
 
 #define EXPECTED_ERRORS "relocations.c:24:1: error: static assertion failed" \
     "relocations.c:29:16: error: static_assert expression is not an integral constant expression" \


### PR DESCRIPTION
Add support for initializing pointers with, and doing static asserts with, offsets from global variables.

I'm very open to bikeshedding on names of things / code organization. I moved `StringInterner` to backend so that `Interner` could hold `StringId` values.

Open areas for enhancement:
   * Should also support static variables and not just globals.
   * Model relocation values with name + bigint instead of name + i64. Right now if the offset overflows we correctly warn but the printed diagnostic is incorrect since the value wraps around.