### PR TITLE
Fix long double casting when same size as double

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -5804,8 +5804,8 @@ pub const Result = struct {
         // if either is a float cast to that type
         if (a.ty.isFloat() or b.ty.isFloat()) {
             const float_types = [6][2]Type.Specifier{
-                .{ .complex_long_double, .long_double },
                 .{ .complex_float128, .float128 },
+                .{ .complex_long_double, .long_double },
                 .{ .complex_double, .double },
                 .{ .complex_float, .float },
                 // No `_Complex __fp16` type
@@ -5814,20 +5814,9 @@ pub const Result = struct {
             };
             const a_spec = a.ty.canonicalize(.standard).specifier;
             const b_spec = b.ty.canonicalize(.standard).specifier;
-            if (p.comp.target.cTypeBitSize(.longdouble) == 128) {
-                if (try a.floatConversion(b, a_spec, b_spec, p, float_types[0])) return;
+            for (float_types) |ft| {
+                if (try a.floatConversion(b, a_spec, b_spec, p, ft)) return;
             }
-            if (try a.floatConversion(b, a_spec, b_spec, p, float_types[1])) return;
-            if (p.comp.target.cTypeBitSize(.longdouble) >= p.comp.target.cTypeBitSize(.double)) {
-                if (try a.floatConversion(b, a_spec, b_spec, p, float_types[0])) return;
-            }
-            if (try a.floatConversion(b, a_spec, b_spec, p, float_types[2])) return;
-            if (p.comp.target.cTypeBitSize(.longdouble) >= p.comp.target.cTypeBitSize(.float)) {
-                if (try a.floatConversion(b, a_spec, b_spec, p, float_types[0])) return;
-            }
-            if (try a.floatConversion(b, a_spec, b_spec, p, float_types[3])) return;
-            if (try a.floatConversion(b, a_spec, b_spec, p, float_types[4])) return;
-            if (try a.floatConversion(b, a_spec, b_spec, p, float_types[5])) return;
             unreachable;
         }
 

--- a/src/backend/Object/Elf.zig
+++ b/src/backend/Object/Elf.zig
@@ -174,7 +174,7 @@ pub fn finish(elf: *Elf, file: std.fs.File) !void {
     var buf_writer = std.io.bufferedWriter(file.writer());
     const w = buf_writer.writer();
 
-    var num_sections: std.elf.Elf64_Half = additional_sections;
+    var num_sections: std.elf.Half = additional_sections;
     var relocations_len: std.elf.Elf64_Off = 0;
     var sections_len: std.elf.Elf64_Off = 0;
     {

--- a/test/cases/fp16 parameter.c
+++ b/test/cases/fp16 parameter.c
@@ -1,7 +1,8 @@
+//aro-args --target=x86_64-linux-gnu
 __fp16 foo(__fp16 param) {
     return 0;
 }
 
-#define EXPECTED_ERRORS "fp16 parameter.c:1:19: error: parameters cannot have __fp16 type; did you forget * ?" \
-    "fp16 parameter.c:1:11: error: function return value cannot have __fp16 type; did you forget * ?" \
+#define EXPECTED_ERRORS "fp16 parameter.c:2:19: error: parameters cannot have __fp16 type; did you forget * ?" \
+    "fp16 parameter.c:2:11: error: function return value cannot have __fp16 type; did you forget * ?" \
 


### PR DESCRIPTION
https://github.com/Vexu/arocc/commit/59e6078df83e45e2898d89689ce8914e81bcb4ab moved the CI MacOS runner to aarch64 which broke `test/cases/arithmetic conversion floats.c`, this should fix it.