### PR TITLE
Parser: save value for init nodes

### DIFF
--- a/src/aro/Diagnostics/messages.def
+++ b/src/aro/Diagnostics/messages.def
@@ -2546,6 +2546,10 @@ non_constant_initializer
     .msg = "initializer element is not a compile-time constant"
     .kind = .@"error"
 
+constexpr_requires_const
+    .msg = "constexpr variable must be initialized by a constant expression"
+    .kind = .@"error"
+
 subtract_pointers_zero_elem_size
     .msg = "subtraction of pointers to type '{s}' of zero size has undefined behavior"
     .kind = .warning

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -901,9 +901,17 @@ fn dumpNode(
         try w.writeAll(" (value: ");
         if (try val.print(ty, tree.comp, w)) |nested| switch (nested) {
             .pointer => |ptr| {
-                const decl = tree.nodes.items(.data)[ptr.decl].decl;
-                const decl_name = tree.tokSlice(decl.name);
-                try ptr.offset.printPointer(decl_name, tree.comp, w);
+                switch (tree.nodes.items(.tag)[ptr.node]) {
+                    .compound_literal_expr => {
+                        try w.writeAll("(compound literal) ");
+                        _ = try ptr.offset.print(tree.comp.types.ptrdiff, tree.comp, w);
+                    },
+                    else => {
+                        const decl = tree.nodes.items(.data)[ptr.node].decl;
+                        const decl_name = tree.tokSlice(decl.name);
+                        try ptr.offset.printPointer(decl_name, tree.comp, w);
+                    },
+                }
             },
         };
         try w.writeByte(')');

--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -550,7 +550,7 @@ pub fn add(res: *Value, lhs: Value, rhs: Value, ty: Type, comp: *Compilation) !b
         const old_offset = fromRef(rel.offset);
         const add_overflow = try total_offset.add(total_offset, old_offset, comp.types.ptrdiff, comp);
         _ = try total_offset.intCast(comp.types.ptrdiff, comp);
-        res.* = try pointer(.{ .decl = rel.decl, .offset = total_offset.ref() }, comp);
+        res.* = try pointer(.{ .node = rel.node, .offset = total_offset.ref() }, comp);
         return mul_overflow or add_overflow;
     }
 
@@ -610,7 +610,7 @@ pub fn sub(res: *Value, lhs: Value, rhs: Value, ty: Type, elem_size: u64, comp: 
     if (lhs_key == .pointer and rhs_key == .pointer) {
         const lhs_pointer = lhs_key.pointer;
         const rhs_pointer = rhs_key.pointer;
-        if (lhs_pointer.decl != rhs_pointer.decl) {
+        if (lhs_pointer.node != rhs_pointer.node) {
             res.* = .{};
             return false;
         }
@@ -629,7 +629,7 @@ pub fn sub(res: *Value, lhs: Value, rhs: Value, ty: Type, elem_size: u64, comp: 
         const old_offset = fromRef(rel.offset);
         const add_overflow = try total_offset.sub(old_offset, total_offset, comp.types.ptrdiff, undefined, comp);
         _ = try total_offset.intCast(comp.types.ptrdiff, comp);
-        res.* = try pointer(.{ .decl = rel.decl, .offset = total_offset.ref() }, comp);
+        res.* = try pointer(.{ .node = rel.node, .offset = total_offset.ref() }, comp);
         return mul_overflow or add_overflow;
     }
 
@@ -1006,9 +1006,9 @@ pub fn comparePointers(lhs: Value, op: std.math.CompareOperator, rhs: Value, com
         const lhs_pointer = lhs_key.pointer;
         const rhs_pointer = rhs_key.pointer;
         switch (op) {
-            .eq => if (lhs_pointer.decl != rhs_pointer.decl) return false,
-            .neq => if (lhs_pointer.decl != rhs_pointer.decl) return true,
-            else => if (lhs_pointer.decl != rhs_pointer.decl) return null,
+            .eq => if (lhs_pointer.node != rhs_pointer.node) return false,
+            .neq => if (lhs_pointer.node != rhs_pointer.node) return true,
+            else => if (lhs_pointer.node != rhs_pointer.node) return null,
         }
 
         const lhs_offset = fromRef(lhs_pointer.offset);
@@ -1056,7 +1056,7 @@ pub fn maxInt(ty: Type, comp: *Compilation) !Value {
 
 const NestedPrint = union(enum) {
     pointer: struct {
-        decl: u32,
+        node: u32,
         offset: Value,
     },
 };
@@ -1091,7 +1091,7 @@ pub fn print(v: Value, ty: Type, comp: *const Compilation, w: anytype) @TypeOf(w
             .cf32 => |components| try w.print("{d} + {d}i", .{ @round(@as(f64, @floatCast(components[0])) * 1000000) / 1000000, @round(@as(f64, @floatCast(components[1])) * 1000000) / 1000000 }),
             inline else => |components| try w.print("{d} + {d}i", .{ @as(f64, @floatCast(components[0])), @as(f64, @floatCast(components[1])) }),
         },
-        .pointer => |ptr| return .{ .pointer = .{ .decl = ptr.decl, .offset = fromRef(ptr.offset) } },
+        .pointer => |ptr| return .{ .pointer = .{ .node = ptr.node, .offset = fromRef(ptr.offset) } },
         else => unreachable, // not a value
     }
     return null;

--- a/src/backend/Interner.zig
+++ b/src/backend/Interner.zig
@@ -82,8 +82,8 @@ pub const Key = union(enum) {
         cf128: [2]f128,
     };
     pub const Pointer = struct {
-        /// NodeIndex of decl whose address we are offsetting from
-        decl: u32,
+        /// NodeIndex of decl or compound literal whose address we are offsetting from
+        node: u32,
         /// Offset in bytes
         offset: Ref,
     };
@@ -336,7 +336,7 @@ pub const Tag = enum(u8) {
     };
 
     pub const Pointer = struct {
-        decl: u32,
+        node: u32,
         offset: Ref,
     };
 
@@ -628,7 +628,7 @@ pub fn put(i: *Interner, gpa: Allocator, key: Key) !Ref {
             i.items.appendAssumeCapacity(.{
                 .tag = .pointer,
                 .data = try i.addExtra(gpa, Tag.Pointer{
-                    .decl = info.decl,
+                    .node = info.node,
                     .offset = info.offset,
                 }),
             });
@@ -822,7 +822,7 @@ pub fn get(i: *const Interner, ref: Ref) Key {
         .pointer => {
             const pointer = i.extraData(Tag.Pointer, data);
             return .{ .pointer = .{
-                .decl = pointer.decl,
+                .node = pointer.node,
                 .offset = pointer.offset,
             } };
         },

--- a/test/cases/ast/_Float16.c
+++ b/test/cases/ast/_Float16.c
@@ -84,7 +84,7 @@ fn_def: 'fn () void'
     var: '__fp16'
      name: fp16
      init:
-      implicit_cast: (int_to_float) '__fp16'
+      implicit_cast: (int_to_float) '__fp16' (value: 0)
         int_literal: 'int' (value: 0)
 
     assign_expr: 'double'

--- a/test/cases/ast/c23 true false ast.c
+++ b/test/cases/ast/c23 true false ast.c
@@ -11,31 +11,31 @@ var: 'bool'
 var: 'bool'
  name: c
  init:
-  implicit_cast: (int_to_bool) 'bool'
+  implicit_cast: (int_to_bool) 'bool' (value: false)
     int_literal: 'int' (value: 0)
 
 var: 'bool'
  name: d
  init:
-  implicit_cast: (int_to_bool) 'bool'
+  implicit_cast: (int_to_bool) 'bool' (value: true)
     int_literal: 'int' (value: 1)
 
 var: 'int'
  name: e
  init:
-  implicit_cast: (bool_to_int) 'int'
+  implicit_cast: (bool_to_int) 'int' (value: 1)
     bool_literal: 'bool' (value: true)
 
 var: 'int'
  name: f
  init:
-  implicit_cast: (bool_to_int) 'int'
+  implicit_cast: (bool_to_int) 'int' (value: 0)
     bool_literal: 'bool' (value: false)
 
 var: 'int'
  name: g
  init:
-  add_expr: 'int'
+  add_expr: 'int' (value: 2)
    lhs:
     implicit_cast: (bool_to_int) 'int'
       bool_literal: 'bool' (value: true)

--- a/test/cases/ast/complex init.c
+++ b/test/cases/ast/complex init.c
@@ -5,7 +5,7 @@ fn_def: 'fn () void'
     var: '_Complex double'
      name: cd
      init:
-      array_init_expr_two: '_Complex double'
+      array_init_expr_two: '_Complex double' (value: 1 + 2i)
         float_literal: 'double' (value: 1)
 
         float_literal: 'double' (value: 2)
@@ -13,7 +13,7 @@ fn_def: 'fn () void'
     var: '_Complex float'
      name: cf
      init:
-      array_init_expr_two: '_Complex float'
+      array_init_expr_two: '_Complex float' (value: 1 + 2i)
         float_literal: 'float' (value: 1)
 
         float_literal: 'float' (value: 2)
@@ -47,11 +47,11 @@ fn_def: 'fn () void'
      rhs:
       implicit_cast: (lval_to_rval) '_Complex double'
         compound_literal_expr: '_Complex double' lvalue
-         array_init_expr_two: '_Complex double'
-           implicit_cast: (float_cast) 'double'
+         array_init_expr_two: '_Complex double' (value: 1 + 2i)
+           implicit_cast: (float_cast) 'double' (value: 1)
              float_literal: 'float' (value: 1)
 
-           implicit_cast: (float_cast) 'double'
+           implicit_cast: (float_cast) 'double' (value: 2)
              float_literal: 'float' (value: 2)
 
     assign_expr: '_Complex float'
@@ -61,11 +61,11 @@ fn_def: 'fn () void'
      rhs:
       implicit_cast: (lval_to_rval) '_Complex float'
         compound_literal_expr: '_Complex float' lvalue
-         array_init_expr_two: '_Complex float'
-           implicit_cast: (float_cast) 'float'
+         array_init_expr_two: '_Complex float' (value: 1 + 2i)
+           implicit_cast: (float_cast) 'float' (value: 1)
              float_literal: 'double' (value: 1)
 
-           implicit_cast: (float_cast) 'float'
+           implicit_cast: (float_cast) 'float' (value: 2)
              float_literal: 'double' (value: 2)
 
     implicit_return: 'void'

--- a/test/cases/ast/decayed attributed array.c
+++ b/test/cases/ast/decayed attributed array.c
@@ -8,7 +8,7 @@ var: 'attributed([1]int)'
 var: '*int'
  name: ptr
  init:
-  implicit_cast: (array_to_pointer) '*d:attributed([1]int)'
+  implicit_cast: (array_to_pointer) '*d:attributed([1]int)' (value: &arr)
    attr: aligned alignment: null
     decl_ref_expr: 'attributed([1]int)' lvalue
      attr: aligned alignment: null
@@ -25,7 +25,7 @@ fn_def: 'fn () void'
     var: '*char'
      name: y
      init:
-      addr_of_expr: '*char'
+      addr_of_expr: '*char' (value: &x)
        operand:
         array_access_expr: 'char' lvalue
          lhs:

--- a/test/cases/ast/float eval method.c
+++ b/test/cases/ast/float eval method.c
@@ -31,7 +31,7 @@ fn_def: 'fn () void'
     var: '_Complex float'
      name: ca
      init:
-      implicit_cast: (real_to_complex_float) '_Complex float'
+      implicit_cast: (real_to_complex_float) '_Complex float' (value: 0 + 0i)
         float_literal: 'float' (value: 0)
 
     assign_expr: '_Complex float'

--- a/test/cases/ast/generic ast.c
+++ b/test/cases/ast/generic ast.c
@@ -1,7 +1,7 @@
 var: 'int'
  name: x
  init:
-  generic_expr: 'int'
+  generic_expr: 'int' (value: 42)
    controlling:
     int_literal: 'int' (value: 5)
    chosen:
@@ -14,7 +14,7 @@ var: 'int'
 var: 'int'
  name: y
  init:
-  generic_expr: 'int'
+  generic_expr: 'int' (value: 42)
    controlling:
     int_literal: 'int' (value: 5)
    chosen:
@@ -29,7 +29,7 @@ var: 'int'
 var: 'double'
  name: z
  init:
-  implicit_cast: (int_to_float) 'double'
+  implicit_cast: (int_to_float) 'double' (value: 32)
     generic_expr_one: 'int'
      controlling:
       int_literal: 'int' (value: 5)

--- a/test/cases/ast/native half type.c
+++ b/test/cases/ast/native half type.c
@@ -5,13 +5,13 @@ fn_def: 'fn () void'
     var: '__fp16'
      name: x
      init:
-      implicit_cast: (float_cast) '__fp16'
+      implicit_cast: (float_cast) '__fp16' (value: 1)
         float_literal: 'float' (value: 1)
 
     var: '__fp16'
      name: y
      init:
-      implicit_cast: (float_cast) '__fp16'
+      implicit_cast: (float_cast) '__fp16' (value: 2)
         float_literal: 'float' (value: 2)
 
     assign_expr: '__fp16'

--- a/test/cases/ast/promotion edge cases.c
+++ b/test/cases/ast/promotion edge cases.c
@@ -16,7 +16,7 @@ fn_def: 'fn () void'
     var: 'char'
      name: c
      init:
-      implicit_cast: (int_cast) 'char'
+      implicit_cast: (int_cast) 'char' (value: 0)
         int_literal: 'int' (value: 0)
 
     var: 'double'
@@ -82,7 +82,7 @@ fn_def: 'fn () void'
     var: '__fp16'
      name: fp16
      init:
-      implicit_cast: (float_cast) '__fp16'
+      implicit_cast: (float_cast) '__fp16' (value: 0)
         float_literal: 'float' (value: 0)
 
     assign_expr: '__fp16'

--- a/test/cases/ast/stdckdint_ast.c
+++ b/test/cases/ast/stdckdint_ast.c
@@ -5,13 +5,13 @@ fn_def: 'fn () void'
     var: 'char'
      name: x
      init:
-      implicit_cast: (int_cast) 'char'
+      implicit_cast: (int_cast) 'char' (value: 0)
         int_literal: 'int' (value: 0)
 
     var: 'unsigned int'
      name: y
      init:
-      implicit_cast: (int_cast) 'unsigned int'
+      implicit_cast: (int_cast) 'unsigned int' (value: 2)
         int_literal: 'int' (value: 2)
 
     var: '_Bool'

--- a/test/cases/constexpr.c
+++ b/test/cases/constexpr.c
@@ -13,13 +13,22 @@ constexpr int foo(constexpr int param) {
 constexpr _BitInt(b) bit = 4;
 
 int non_const = 4;
-constexpr int invalid = non_const; // TODO
+constexpr int invalid = non_const;
 
 constexpr bool const_bool_true = true;
 static_assert(const_bool_true);
 constexpr bool const_bool_false = false;
 static_assert(!const_bool_false);
 
+struct S {
+    int x;
+    int y;
+};
+
+constexpr struct S s1 = { 1, 2};
+constexpr struct S s2 = { 1, a};
+constexpr struct S s3 = { 1, non_const};
+// constexpr int s1_x = s1.x;
 
 #define TESTS_SKIPPED 1
 
@@ -27,4 +36,6 @@ static_assert(!const_bool_false);
     "constexpr.c:7:19: error: invalid storage class on function parameter" \
     "constexpr.c:7:1: error: illegal storage class on function" \
     "constexpr.c:13:28: warning: implicit conversion from 'int' to 'signed _BitInt(2)' changes non-zero value from 4 to 0 [-Wconstant-conversion]" \
+    "constexpr.c:16:25: error: constexpr variable must be initialized by a constant expression" \
+    "constexpr.c:30:30: error: constexpr variable must be initialized by a constant expression" \
 


### PR DESCRIPTION
Initial work for solving #783

There are still some issues to solve regarding saving complex int values, pointers to compound literals, and accessing record fields in constexpr contexts, but I think this is enough that I can start working on a simple assembly backend.