### PR TITLE
backend: basic x86_64 assembly codegen for some global vars

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -156,6 +156,15 @@ pub fn build(b: *Build) !void {
             GenerateDef.create(b, .{ .name = "Diagnostics/messages.def", .kind = .named }),
         },
     });
+    const assembly_backend = b.addModule("assembly_backend", .{
+        .root_source_file = b.path("src/assembly_backend.zig"),
+        .imports = &.{
+            .{
+                .name = "aro",
+                .module = aro_module,
+            },
+        },
+    });
 
     b.installDirectory(.{
         .source_dir = b.path("include"),
@@ -173,6 +182,7 @@ pub fn build(b: *Build) !void {
         .use_lld = use_llvm,
     });
     exe.root_module.addImport("aro", aro_module);
+    exe.root_module.addImport("assembly_backend", assembly_backend);
 
     // tracy integration
     if (tracy) |tracy_path| {

--- a/src/aro.zig
+++ b/src/aro.zig
@@ -18,6 +18,7 @@ pub const Interner = backend.Interner;
 pub const Ir = backend.Ir;
 pub const Object = backend.Object;
 pub const CallingConvention = backend.CallingConvention;
+pub const Assembly = backend.Assembly;
 
 pub const version_str = backend.version_str;
 pub const version = backend.version;

--- a/src/aro/Diagnostics/messages.def
+++ b/src/aro/Diagnostics/messages.def
@@ -1477,6 +1477,11 @@ cli_invalid_emulate
     .extra = .str
     .kind = .@"error"
 
+cli_invalid_optimization
+    .msg = "invalid optimization level '{s}'"
+    .extra = .str
+    .kind = .@"error"
+
 cli_unknown_arg
     .msg = "unknown argument '{s}'"
     .extra = .str

--- a/src/aro/Toolchain.zig
+++ b/src/aro/Toolchain.zig
@@ -115,6 +115,11 @@ pub fn deinit(tc: *Toolchain) void {
     tc.program_paths.deinit(gpa);
 }
 
+/// Write assembler path to `buf` and return a slice of it
+pub fn getAssemblerPath(tc: *const Toolchain, buf: []u8) ![]const u8 {
+    return tc.getProgramPath("as", buf);
+}
+
 /// Write linker path to `buf` and return a slice of it
 pub fn getLinkerPath(tc: *const Toolchain, buf: []u8) ![]const u8 {
     // --ld-path= takes precedence over -fuse-ld= and specifies the executable

--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -799,7 +799,7 @@ pub fn nodeTok(tree: *const Tree, node: NodeIndex) ?TokenIndex {
 
 pub fn nodeLoc(tree: *const Tree, node: NodeIndex) ?Source.Location {
     const tok_i = tree.nodeTok(node) orelse return null;
-    return tree.tokens.items(.loc)[@intFromEnum(tok_i)];
+    return tree.tokens.items(.loc)[tok_i];
 }
 
 pub fn dump(tree: *const Tree, config: std.io.tty.Config, writer: anytype) !void {

--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -488,6 +488,12 @@ pub fn toInt(v: Value, comptime T: type, comp: *const Compilation) ?T {
     return big_int.to(T) catch null;
 }
 
+pub fn toBytes(v: Value, comp: *const Compilation) []const u8 {
+    assert(v.opt_ref != .none);
+    const key = comp.interner.get(v.ref());
+    return key.bytes;
+}
+
 const ComplexOp = enum {
     add,
     sub,

--- a/src/assembly_backend.zig
+++ b/src/assembly_backend.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+
+const aro = @import("aro");
+pub const Error = aro.Compilation.Error || error{CodegenFailed};
+
+pub const x86_64 = @import("assembly_backend/x86_64.zig");
+
+pub fn genAsm(target: std.Target, tree: aro.Tree) Error!aro.Assembly {
+    return switch (target.cpu.arch) {
+        .x86_64 => x86_64.genAsm(tree),
+        else => std.debug.panic("genAsm not implemented: {s}", .{@tagName(target.cpu.arch)}),
+    };
+}

--- a/src/assembly_backend.zig
+++ b/src/assembly_backend.zig
@@ -1,11 +1,10 @@
 const std = @import("std");
 
 const aro = @import("aro");
-pub const Error = aro.Compilation.Error || error{CodegenFailed};
 
 pub const x86_64 = @import("assembly_backend/x86_64.zig");
 
-pub fn genAsm(target: std.Target, tree: aro.Tree) Error!aro.Assembly {
+pub fn genAsm(target: std.Target, tree: aro.Tree) aro.Compilation.Error!aro.Assembly {
     return switch (target.cpu.arch) {
         .x86_64 => x86_64.genAsm(tree),
         else => std.debug.panic("genAsm not implemented: {s}", .{@tagName(target.cpu.arch)}),

--- a/src/assembly_backend/x86_64.zig
+++ b/src/assembly_backend/x86_64.zig
@@ -14,7 +14,7 @@ const Type = aro.Type;
 const Value = aro.Value;
 
 const AsmCodeGen = @This();
-const Error = @import("../assembly_backend.zig").Error;
+const Error = aro.Compilation.Error;
 const Writer = std.ArrayListUnmanaged(u8).Writer;
 
 tree: Tree,
@@ -81,7 +81,7 @@ pub fn todo(c: *AsmCodeGen, msg: []const u8, node: NodeIndex) Error {
         .loc = loc,
         .extra = .{ .str = msg },
     }, &.{});
-    return error.CodegenFailed;
+    return error.FatalError;
 }
 
 fn emitAggregate(c: *AsmCodeGen, ty: Type, node: NodeIndex) !void {

--- a/src/assembly_backend/x86_64.zig
+++ b/src/assembly_backend/x86_64.zig
@@ -1,0 +1,274 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+
+const aro = @import("aro");
+const Assembly = aro.Assembly;
+const Compilation = aro.Compilation;
+const NodeIndex = Tree.NodeIndex;
+const Source = aro.Source;
+const StrInt = aro.StringInterner;
+const StringId = StrInt.StringId;
+const Tree = aro.Tree;
+const Type = aro.Type;
+const Value = aro.Value;
+
+const AsmCodeGen = @This();
+const Error = @import("../assembly_backend.zig").Error;
+const Writer = std.ArrayListUnmanaged(u8).Writer;
+
+tree: Tree,
+comp: *Compilation,
+node_tag: []const Tree.Tag,
+node_data: []const Tree.Node.Data,
+node_ty: []const Type,
+node_loc: []const Tree.Node.Loc,
+text: Writer,
+data: Writer,
+
+const StorageUnit = enum(u8) {
+    byte = 8,
+    short = 16,
+    long = 32,
+    quad = 64,
+
+    fn trunc(self: StorageUnit, val: u64) u64 {
+        return switch (self) {
+            .byte => @as(u8, @truncate(val)),
+            .short => @as(u16, @truncate(val)),
+            .long => @as(u32, @truncate(val)),
+            .quad => val,
+        };
+    }
+};
+
+fn serializeInt(value: u64, storage_unit: StorageUnit, w: Writer) !void {
+    try w.print("  .{s}  0x{x}\n", .{ @tagName(storage_unit), storage_unit.trunc(value) });
+}
+
+fn serializeFloat(comptime T: type, value: T, w: Writer) !void {
+    switch (T) {
+        f128 => {
+            const bytes = std.mem.asBytes(&value);
+            const first = std.mem.bytesToValue(u64, bytes[0..8]);
+            try serializeInt(first, .quad, w);
+            const second = std.mem.bytesToValue(u64, bytes[8..16]);
+            return serializeInt(second, .quad, w);
+        },
+        f80 => {
+            const bytes = std.mem.asBytes(&value);
+            const first = std.mem.bytesToValue(u64, bytes[0..8]);
+            try serializeInt(first, .quad, w);
+            const second = std.mem.bytesToValue(u16, bytes[8..10]);
+            try serializeInt(second, .short, w);
+            return w.writeAll("  .zero 6\n");
+        },
+        else => {
+            const size = @bitSizeOf(T);
+            const storage_unit = std.meta.intToEnum(StorageUnit, size) catch unreachable;
+            const IntTy = @Type(.{ .int = .{ .signedness = .unsigned, .bits = size } });
+            const int_val: IntTy = @bitCast(value);
+            return serializeInt(int_val, storage_unit, w);
+        },
+    }
+}
+
+pub fn todo(c: *AsmCodeGen, msg: []const u8, node: NodeIndex) Error {
+    const loc: Source.Location = c.tree.nodeLoc(node) orelse .{};
+
+    try c.comp.addDiagnostic(.{
+        .tag = .todo,
+        .loc = loc,
+        .extra = .{ .str = msg },
+    }, &.{});
+    return error.CodegenFailed;
+}
+
+fn emitAggregate(c: *AsmCodeGen, ty: Type, node: NodeIndex) !void {
+    _ = ty;
+    return c.todo("Codegen aggregates", node);
+}
+
+fn emitSingleValue(c: *AsmCodeGen, ty: Type, node: NodeIndex) !void {
+    const value = c.tree.value_map.get(node) orelse return;
+    const bit_size = ty.bitSizeof(c.comp).?;
+    if (ty.isComplex()) {
+        return c.todo("Codegen _Complex values", node);
+    } else if (ty.isInt()) {
+        const storage_unit = std.meta.intToEnum(StorageUnit, bit_size) catch return c.todo("Codegen _BitInt values", node);
+        try c.data.print("  .{s} ", .{@tagName(storage_unit)});
+        _ = try value.print(ty, c.comp, c.data);
+        try c.data.writeByte('\n');
+    } else if (ty.isFloat()) {
+        switch (bit_size) {
+            16 => return serializeFloat(f16, value.toFloat(f16, c.comp), c.data),
+            32 => return serializeFloat(f32, value.toFloat(f32, c.comp), c.data),
+            64 => return serializeFloat(f64, value.toFloat(f64, c.comp), c.data),
+            80 => return serializeFloat(f80, value.toFloat(f80, c.comp), c.data),
+            128 => return serializeFloat(f128, value.toFloat(f128, c.comp), c.data),
+            else => unreachable,
+        }
+    } else if (ty.isPtr()) {
+        return c.todo("Codegen pointer", node);
+    } else if (ty.isArray()) {
+        // Todo:
+        //  Handle truncated initializers e.g. char x[3] = "hello";
+        //  Zero out remaining bytes if initializer is shorter than storage capacity
+        //  Handle non-char strings
+        const bytes = value.toBytes(c.comp);
+        const directive = if (bytes.len > bit_size / 8) "ascii" else "string";
+        try c.data.print("  .{s} ", .{directive});
+        try Value.printString(bytes, ty, c.comp, c.data);
+
+        try c.data.writeByte('\n');
+    } else unreachable;
+}
+
+fn emitValue(c: *AsmCodeGen, ty: Type, node: NodeIndex) !void {
+    const tag = c.node_tag[@intFromEnum(node)];
+    switch (tag) {
+        .array_init_expr,
+        .array_init_expr_two,
+        .struct_init_expr,
+        .struct_init_expr_two,
+        .union_init_expr,
+        => return c.todo("Codegen multiple inits", node),
+        else => return c.emitSingleValue(ty, node),
+    }
+}
+
+pub fn genAsm(tree: Tree) Error!Assembly {
+    var data: std.ArrayListUnmanaged(u8) = .empty;
+    defer data.deinit(tree.comp.gpa);
+
+    var text: std.ArrayListUnmanaged(u8) = .empty;
+    defer text.deinit(tree.comp.gpa);
+
+    const node_tag = tree.nodes.items(.tag);
+    var codegen: AsmCodeGen = .{
+        .tree = tree,
+        .comp = tree.comp,
+        .node_tag = node_tag,
+        .node_data = tree.nodes.items(.data),
+        .node_ty = tree.nodes.items(.ty),
+        .node_loc = tree.nodes.items(.loc),
+        .text = text.writer(tree.comp.gpa),
+        .data = data.writer(tree.comp.gpa),
+    };
+
+    if (tree.comp.code_gen_options.debug) {
+        const sources = tree.comp.sources.values();
+        for (sources) |source| {
+            try codegen.data.print("  .file {d} \"{s}\"\n", .{ @intFromEnum(source.id) - 1, source.path });
+        }
+    }
+
+    for (codegen.tree.root_decls) |decl| {
+        switch (node_tag[@intFromEnum(decl)]) {
+            .static_assert,
+            .typedef,
+            .struct_decl_two,
+            .union_decl_two,
+            .enum_decl_two,
+            .struct_decl,
+            .union_decl,
+            .enum_decl,
+            => {},
+
+            .fn_proto,
+            .static_fn_proto,
+            .inline_fn_proto,
+            .inline_static_fn_proto,
+            .extern_var,
+            .threadlocal_extern_var,
+            => {},
+
+            .fn_def,
+            .static_fn_def,
+            .inline_fn_def,
+            .inline_static_fn_def,
+            => try codegen.genFn(decl),
+
+            .@"var",
+            .static_var,
+            .threadlocal_var,
+            .threadlocal_static_var,
+            => try codegen.genVar(decl),
+
+            else => unreachable,
+        }
+    }
+    try codegen.text.writeAll("  .section  .note.GNU-stack,\"\",@progbits\n");
+    const text_slice = try text.toOwnedSlice(tree.comp.gpa);
+    errdefer tree.comp.gpa.free(text_slice);
+    const data_slice = try data.toOwnedSlice(tree.comp.gpa);
+    return .{
+        .text = text_slice,
+        .data = data_slice,
+    };
+}
+
+fn genFn(c: *AsmCodeGen, node: NodeIndex) !void {
+    return c.todo("Codegen functions", node);
+}
+
+fn genVar(c: *AsmCodeGen, node: NodeIndex) !void {
+    const comp = c.comp;
+    const ty = c.node_ty[@intFromEnum(node)];
+    const tag = c.node_tag[@intFromEnum(node)];
+    const decl_data = c.node_data[@intFromEnum(node)].decl;
+
+    const is_threadlocal = tag == .threadlocal_var or tag == .threadlocal_static_var;
+    const is_static = tag == .static_var or tag == .threadlocal_static_var;
+    const is_tentative = decl_data.node == .none;
+    const size = ty.sizeof(comp) orelse blk: {
+        // tentative array definition assumed to have one element
+        std.debug.assert(is_tentative and ty.isArray());
+        break :blk ty.elemType().sizeof(comp).?;
+    };
+
+    const name = c.tree.tokSlice(decl_data.name);
+    const nat_align = ty.alignof(comp);
+    const alignment = if (ty.isArray() and size >= 16) @max(16, nat_align) else nat_align;
+
+    if (is_static) {
+        try c.data.print("  .local \"{s}\"\n", .{name});
+    } else {
+        try c.data.print("  .globl \"{s}\"\n", .{name});
+    }
+
+    if (is_tentative and comp.code_gen_options.common) {
+        try c.data.print("  .comm \"{s}\", {d}, {d}\n", .{ name, size, alignment });
+        return;
+    }
+    if (!is_tentative) {
+        if (is_threadlocal and comp.code_gen_options.data_sections) {
+            try c.data.print("  .section .tdata.\"{s}\",\"awT\",@progbits\n", .{name});
+        } else if (is_threadlocal) {
+            try c.data.writeAll("  .section .tdata,\"awT\",@progbits\n");
+        } else if (comp.code_gen_options.data_sections) {
+            try c.data.print("  .section .data.\"{s}\",\"aw\",@progbits\n", .{name});
+        } else {
+            try c.data.writeAll("  .data\n");
+        }
+
+        try c.data.print("  .type \"{s}\", @object\n", .{name});
+        try c.data.print("  .size \"{s}\", {d}\n", .{ name, size });
+        try c.data.print("  .align {d}\n", .{alignment});
+        try c.data.print("\"{s}\":\n", .{name});
+        try c.emitValue(ty, decl_data.node);
+        return;
+    }
+    if (is_threadlocal and comp.code_gen_options.data_sections) {
+        try c.data.print("  .section .tbss.\"{s}\",\"awT\",@nobits\n", .{name});
+    } else if (is_threadlocal) {
+        try c.data.writeAll("  .section .tbss,\"awT\",@nobits\n");
+    } else if (comp.code_gen_options.data_sections) {
+        try c.data.print("  .section .bss.\"{s}\",\"aw\",@nobits\n", .{name});
+    } else {
+        try c.data.writeAll("  .bss\n");
+    }
+    try c.data.print("  .align {d}\n", .{alignment});
+    try c.data.print("\"{s}\":\n", .{name});
+    try c.data.print("  .zero {d}\n", .{size});
+}

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -1,3 +1,4 @@
+pub const Assembly = @import("backend/Assembly.zig");
 pub const CodeGenOptions = @import("backend/CodeGenOptions.zig");
 pub const Interner = @import("backend/Interner.zig");
 pub const Ir = @import("backend/Ir.zig");

--- a/src/backend/Assembly.zig
+++ b/src/backend/Assembly.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+data: []const u8,
+text: []const u8,
+
+const Assembly = @This();
+
+pub fn deinit(self: *const Assembly, gpa: Allocator) void {
+    gpa.free(self.data);
+    gpa.free(self.text);
+}
+
+pub fn writeToFile(self: Assembly, file: std.fs.File) !void {
+    var vec: [2]std.posix.iovec_const = .{
+        .{ .base = self.data.ptr, .len = self.data.len },
+        .{ .base = self.text.ptr, .len = self.text.len },
+    };
+    return file.writevAll(&vec);
+}

--- a/src/backend/CodeGenOptions.zig
+++ b/src/backend/CodeGenOptions.zig
@@ -24,7 +24,6 @@ pub const PicLevel = enum(u8) {
 };
 
 pub const OptimizationLevel = enum {
-    unspecified,
     @"0",
     @"1",
     @"2",
@@ -60,6 +59,6 @@ pub const default: @This() = .{
     .data_sections = false,
     .pic_level = .none,
     .is_pie = false,
-    .optimization_level = .unspecified,
+    .optimization_level = .@"0",
     .debug = false,
 };

--- a/src/backend/CodeGenOptions.zig
+++ b/src/backend/CodeGenOptions.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 /// place uninitialized global variables in a common block
 common: bool,
 /// Place each function into its own section in the output file if the target supports arbitrary sections
@@ -7,6 +9,9 @@ data_sections: bool,
 pic_level: PicLevel,
 /// Generate position-independent code that can only be linked into executables
 is_pie: bool,
+optimization_level: OptimizationLevel,
+/// Generate debug information
+debug: bool,
 
 pub const PicLevel = enum(u8) {
     /// Do not generate position-independent code
@@ -18,10 +23,43 @@ pub const PicLevel = enum(u8) {
     two = 2,
 };
 
+pub const OptimizationLevel = enum {
+    unspecified,
+    @"0",
+    @"1",
+    @"2",
+    @"3",
+    /// Optimize for size
+    s,
+    /// Disregard strict standards compliance
+    fast,
+    /// Optimize debugging experience
+    g,
+    /// Optimize aggressively for size rather than speed
+    z,
+
+    const level_map = std.StaticStringMap(OptimizationLevel).initComptime(.{
+        .{ "0", .@"0" },
+        .{ "1", .@"1" },
+        .{ "2", .@"2" },
+        .{ "3", .@"3" },
+        .{ "s", .s },
+        .{ "fast", .fast },
+        .{ "g", .g },
+        .{ "z", .z },
+    });
+
+    pub fn fromString(str: []const u8) ?OptimizationLevel {
+        return level_map.get(str);
+    }
+};
+
 pub const default: @This() = .{
     .common = false,
     .func_sections = false,
     .data_sections = false,
     .pic_level = .none,
     .is_pie = false,
+    .optimization_level = .unspecified,
+    .debug = false,
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,6 +6,7 @@ const aro = @import("aro");
 const Compilation = aro.Compilation;
 const Driver = aro.Driver;
 const Toolchain = aro.Toolchain;
+const assembly_backend = @import("assembly_backend");
 
 var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
 
@@ -52,7 +53,7 @@ pub fn main() u8 {
     var toolchain: Toolchain = .{ .driver = &driver, .arena = arena, .filesystem = .{ .real = comp.cwd } };
     defer toolchain.deinit();
 
-    driver.main(&toolchain, args, fast_exit) catch |er| switch (er) {
+    driver.main(&toolchain, args, fast_exit, assembly_backend.genAsm) catch |er| switch (er) {
         error.OutOfMemory => {
             std.debug.print("out of memory\n", .{});
             if (fast_exit) process.exit(1);


### PR DESCRIPTION
Some basic assembly codegen, tested with:
```c
/* main.c */
int printf(const char *fmt, ...);
extern char foo[];
extern int bar;
extern double baz;

int main(void)
{
    printf("%s\n%d\n%lf\n", foo, bar, baz);
    return 0;
}
```

```c
/* test.c */
char foo[] = "hello";
int bar = 42;
double baz = 3.14;

```

```sh-session
~$ gcc -c main.c
~$ arocc -O0 test.c main.o`
~$ ./a.out
hello
42
3.140000
```

I structured things the way I did so that `aro` (the frontend module) wouldn't depend on this assembly backend (as in, needing to import it so that it can call it from Driver). The way things are set up now, a do-nothing function can be passed as the final argument of `Driver.main`. But I'm not sure if that's the best way to achieve that.

My next goal is to get very basic function generation going and then I can revive the `EXPECTED_OUTPUT` tests.