### PR TITLE
Type: disallow type specifiers from combining with types specified by typedefed names

### DIFF
--- a/src/aro/Type.zig
+++ b/src/aro/Type.zig
@@ -1905,6 +1905,8 @@ pub const Builder = struct {
     /// Try to combine type from typedef, returns true if successful.
     pub fn combineTypedef(b: *Builder, p: *Parser, typedef_ty: Type, name_tok: TokenIndex) bool {
         if (typedef_ty.is(.invalid)) return false;
+        if (b.specifier != .none) return false;
+
         b.error_on_invalid = true;
         defer b.error_on_invalid = false;
 

--- a/test/cases/duplicate typedef.c
+++ b/test/cases/duplicate typedef.c
@@ -1,0 +1,7 @@
+typedef long foo;
+typedef long foo;
+_Static_assert(__builtin_types_compatible_p(long, foo), "");
+
+typedef foo bar;
+typedef foo bar;
+_Static_assert(__builtin_types_compatible_p(bar, foo), "");

--- a/test/cases/typedef extra specifiers disallowed.c
+++ b/test/cases/typedef extra specifiers disallowed.c
@@ -1,0 +1,13 @@
+typedef long foo;
+typedef unsigned foo bar;
+
+typedef double baz;
+typedef long baz;
+
+#define EXPECTED_ERRORS "typedef extra specifiers disallowed.c:2:18: error: typedef redefinition with different types ('unsigned int' vs 'long')" \
+    "typedef extra specifiers disallowed.c:1:14: note: previous definition is here" \
+    "typedef extra specifiers disallowed.c:2:22: error: expected ';', found 'an identifier'" \
+    "typedef extra specifiers disallowed.c:2:22: warning: type specifier missing, defaults to 'int' [-Wimplicit-int]" \
+    "typedef extra specifiers disallowed.c:5:14: error: typedef redefinition with different types ('long' vs 'double')" \
+    "typedef extra specifiers disallowed.c:4:16: note: previous definition is here" \
+


### PR DESCRIPTION
Closes #731

Previously we would allow things like:
```c
typedef long foo;
typedef unsigned foo bar;
```

To define `bar` as `unsigned long`. Seems reasonable but apparently not allowed by C.