### PR TITLE
GenerateDef: make tag enum exhaustive

### DIFF
--- a/build/GenerateDef.zig
+++ b/build/GenerateDef.zig
@@ -245,7 +245,13 @@ fn generate(self: *GenerateDef, input: []const u8) ![]const u8 {
             \\
             \\/// Integer starting at 0 derived from the unique index,
             \\/// corresponds with the data array index.
-            \\pub const Tag = enum(u16) { _ };
+            \\pub const Tag = enum(u16) {
+        );
+        for (values_array) |value| {
+            try writer.print("    {},\n", .{std.zig.fmtId(value.name)});
+        }
+        try writer.writeAll(
+            \\};
             \\
             \\const Self = @This();
             \\
@@ -459,9 +465,8 @@ fn writeData(writer: anytype, values: []const Value) !void {
     try writer.writeAll("pub const data = blk: {\n");
     try writer.print("    @setEvalBranchQuota({d});\n", .{values.len * 7});
     try writer.writeAll("    break :blk [_]@This(){\n");
-    for (values, 0..) |value, i| {
-        try writer.print("        // {s}\n", .{value.name});
-        try writer.print("        .{{ .tag = @enumFromInt({}), .properties = .{{", .{i});
+    for (values) |value| {
+        try writer.print("        .{{ .tag = .{}, .properties = .{{", .{std.zig.fmtId(value.name)});
         for (value.properties, 0..) |property, j| {
             if (j != 0) try writer.writeByte(',');
             try writer.writeByte(' ');

--- a/src/aro/Builtins/eval.zig
+++ b/src/aro/Builtins/eval.zig
@@ -26,14 +26,14 @@ pub fn eval(tag: Builtin.Tag, p: *Parser, args: []const Tree.Node.Index) !Value 
     if (!builtin.properties.attributes.const_evaluable) return .{};
 
     switch (tag) {
-        Builtin.tagFromName("__builtin_inff").?,
-        Builtin.tagFromName("__builtin_inf").?,
-        Builtin.tagFromName("__builtin_infl").?,
+        .__builtin_inff,
+        .__builtin_inf,
+        .__builtin_infl,
         => {
             const ty: Type = switch (tag) {
-                Builtin.tagFromName("__builtin_inff").? => .{ .specifier = .float },
-                Builtin.tagFromName("__builtin_inf").? => .{ .specifier = .double },
-                Builtin.tagFromName("__builtin_infl").? => .{ .specifier = .long_double },
+                .__builtin_inff => .{ .specifier = .float },
+                .__builtin_inf => .{ .specifier = .double },
+                .__builtin_infl => .{ .specifier = .long_double },
                 else => unreachable,
             };
             const f: Interner.Key.Float = switch (ty.bitSizeof(p.comp).?) {
@@ -45,12 +45,12 @@ pub fn eval(tag: Builtin.Tag, p: *Parser, args: []const Tree.Node.Index) !Value 
             };
             return Value.intern(p.comp, .{ .float = f });
         },
-        Builtin.tagFromName("__builtin_isinf").? => blk: {
+        .__builtin_isinf => blk: {
             if (args.len == 0) break :blk;
             const val = p.tree.value_map.get(args[0]) orelse break :blk;
             return Value.fromBool(val.isInf(p.comp));
         },
-        Builtin.tagFromName("__builtin_isinf_sign").? => blk: {
+        .__builtin_isinf_sign => blk: {
             if (args.len == 0) break :blk;
             const val = p.tree.value_map.get(args[0]) orelse break :blk;
             switch (val.isInfSign(p.comp)) {
@@ -60,12 +60,12 @@ pub fn eval(tag: Builtin.Tag, p: *Parser, args: []const Tree.Node.Index) !Value 
                 .negative => return Value.int(@as(i64, -1), p.comp),
             }
         },
-        Builtin.tagFromName("__builtin_isnan").? => blk: {
+        .__builtin_isnan => blk: {
             if (args.len == 0) break :blk;
             const val = p.tree.value_map.get(args[0]) orelse break :blk;
             return Value.fromBool(val.isNan(p.comp));
         },
-        Builtin.tagFromName("__builtin_nan").? => blk: {
+        .__builtin_nan => blk: {
             if (args.len == 0) break :blk;
             const val = p.getDecayedStringLiteral(args[0]) orelse break :blk;
             const bytes = p.comp.interner.get(val.ref()).bytes;

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -4876,9 +4876,9 @@ const CallExpr = union(enum) {
         return switch (self) {
             .standard => true,
             .builtin => |builtin| switch (builtin.tag) {
-                Builtin.tagFromName("__builtin_va_start").?,
-                Builtin.tagFromName("__va_start").?,
-                Builtin.tagFromName("va_start").?,
+                .__builtin_va_start,
+                .__va_start,
+                .va_start,
                 => arg_idx != 1,
                 else => true,
             },
@@ -4889,17 +4889,17 @@ const CallExpr = union(enum) {
         return switch (self) {
             .standard => true,
             .builtin => |builtin| switch (builtin.tag) {
-                Builtin.tagFromName("__builtin_va_start").?,
-                Builtin.tagFromName("__va_start").?,
-                Builtin.tagFromName("va_start").?,
+                .__builtin_va_start,
+                .__va_start,
+                .va_start,
                 => arg_idx != 1,
-                Builtin.tagFromName("__builtin_add_overflow").?,
-                Builtin.tagFromName("__builtin_complex").?,
-                Builtin.tagFromName("__builtin_isinf").?,
-                Builtin.tagFromName("__builtin_isinf_sign").?,
-                Builtin.tagFromName("__builtin_mul_overflow").?,
-                Builtin.tagFromName("__builtin_isnan").?,
-                Builtin.tagFromName("__builtin_sub_overflow").?,
+                .__builtin_add_overflow,
+                .__builtin_complex,
+                .__builtin_isinf,
+                .__builtin_isinf_sign,
+                .__builtin_mul_overflow,
+                .__builtin_isnan,
+                .__builtin_sub_overflow,
                 => false,
                 else => true,
             },
@@ -4917,14 +4917,14 @@ const CallExpr = union(enum) {
 
         const builtin_tok = self.builtin.builtin_tok;
         switch (self.builtin.tag) {
-            Builtin.tagFromName("__builtin_va_start").?,
-            Builtin.tagFromName("__va_start").?,
-            Builtin.tagFromName("va_start").?,
+            .__builtin_va_start,
+            .__va_start,
+            .va_start,
             => return p.checkVaStartArg(builtin_tok, first_after, param_tok, arg, arg_idx),
-            Builtin.tagFromName("__builtin_complex").? => return p.checkComplexArg(builtin_tok, first_after, param_tok, arg, arg_idx),
-            Builtin.tagFromName("__builtin_add_overflow").?,
-            Builtin.tagFromName("__builtin_sub_overflow").?,
-            Builtin.tagFromName("__builtin_mul_overflow").?,
+            .__builtin_complex => return p.checkComplexArg(builtin_tok, first_after, param_tok, arg, arg_idx),
+            .__builtin_add_overflow,
+            .__builtin_sub_overflow,
+            .__builtin_mul_overflow,
             => return p.checkArithOverflowArg(builtin_tok, first_after, param_tok, arg, arg_idx),
 
             else => {},
@@ -4940,49 +4940,49 @@ const CallExpr = union(enum) {
         return switch (self) {
             .standard => null,
             .builtin => |builtin| switch (builtin.tag) {
-                Builtin.tagFromName("__c11_atomic_thread_fence").?,
-                Builtin.tagFromName("__c11_atomic_signal_fence").?,
-                Builtin.tagFromName("__c11_atomic_is_lock_free").?,
-                Builtin.tagFromName("__builtin_isinf").?,
-                Builtin.tagFromName("__builtin_isinf_sign").?,
-                Builtin.tagFromName("__builtin_isnan").?,
+                .__c11_atomic_thread_fence,
+                .__c11_atomic_signal_fence,
+                .__c11_atomic_is_lock_free,
+                .__builtin_isinf,
+                .__builtin_isinf_sign,
+                .__builtin_isnan,
                 => 1,
 
-                Builtin.tagFromName("__builtin_complex").?,
-                Builtin.tagFromName("__c11_atomic_load").?,
-                Builtin.tagFromName("__c11_atomic_init").?,
+                .__builtin_complex,
+                .__c11_atomic_load,
+                .__c11_atomic_init,
                 => 2,
 
-                Builtin.tagFromName("__c11_atomic_store").?,
-                Builtin.tagFromName("__c11_atomic_exchange").?,
-                Builtin.tagFromName("__c11_atomic_fetch_add").?,
-                Builtin.tagFromName("__c11_atomic_fetch_sub").?,
-                Builtin.tagFromName("__c11_atomic_fetch_or").?,
-                Builtin.tagFromName("__c11_atomic_fetch_xor").?,
-                Builtin.tagFromName("__c11_atomic_fetch_and").?,
-                Builtin.tagFromName("__atomic_fetch_add").?,
-                Builtin.tagFromName("__atomic_fetch_sub").?,
-                Builtin.tagFromName("__atomic_fetch_and").?,
-                Builtin.tagFromName("__atomic_fetch_xor").?,
-                Builtin.tagFromName("__atomic_fetch_or").?,
-                Builtin.tagFromName("__atomic_fetch_nand").?,
-                Builtin.tagFromName("__atomic_add_fetch").?,
-                Builtin.tagFromName("__atomic_sub_fetch").?,
-                Builtin.tagFromName("__atomic_and_fetch").?,
-                Builtin.tagFromName("__atomic_xor_fetch").?,
-                Builtin.tagFromName("__atomic_or_fetch").?,
-                Builtin.tagFromName("__atomic_nand_fetch").?,
-                Builtin.tagFromName("__builtin_add_overflow").?,
-                Builtin.tagFromName("__builtin_sub_overflow").?,
-                Builtin.tagFromName("__builtin_mul_overflow").?,
+                .__c11_atomic_store,
+                .__c11_atomic_exchange,
+                .__c11_atomic_fetch_add,
+                .__c11_atomic_fetch_sub,
+                .__c11_atomic_fetch_or,
+                .__c11_atomic_fetch_xor,
+                .__c11_atomic_fetch_and,
+                .__atomic_fetch_add,
+                .__atomic_fetch_sub,
+                .__atomic_fetch_and,
+                .__atomic_fetch_xor,
+                .__atomic_fetch_or,
+                .__atomic_fetch_nand,
+                .__atomic_add_fetch,
+                .__atomic_sub_fetch,
+                .__atomic_and_fetch,
+                .__atomic_xor_fetch,
+                .__atomic_or_fetch,
+                .__atomic_nand_fetch,
+                .__builtin_add_overflow,
+                .__builtin_sub_overflow,
+                .__builtin_mul_overflow,
                 => 3,
 
-                Builtin.tagFromName("__c11_atomic_compare_exchange_strong").?,
-                Builtin.tagFromName("__c11_atomic_compare_exchange_weak").?,
+                .__c11_atomic_compare_exchange_strong,
+                .__c11_atomic_compare_exchange_weak,
                 => 5,
 
-                Builtin.tagFromName("__atomic_compare_exchange").?,
-                Builtin.tagFromName("__atomic_compare_exchange_n").?,
+                .__atomic_compare_exchange,
+                .__atomic_compare_exchange_n,
                 => 6,
                 else => null,
             },
@@ -4993,12 +4993,12 @@ const CallExpr = union(enum) {
         return switch (self) {
             .standard => callable_ty.returnType(),
             .builtin => |builtin| switch (builtin.tag) {
-                Builtin.tagFromName("__c11_atomic_exchange").? => {
+                .__c11_atomic_exchange => {
                     if (p.list_buf.items.len != 4) return Type.invalid; // wrong number of arguments; already an error
                     const second_param = p.list_buf.items[2];
                     return second_param.type(&p.tree);
                 },
-                Builtin.tagFromName("__c11_atomic_load").? => {
+                .__c11_atomic_load => {
                     if (p.list_buf.items.len != 3) return Type.invalid; // wrong number of arguments; already an error
                     const first_param = p.list_buf.items[1];
                     const ty = first_param.type(&p.tree);
@@ -5006,47 +5006,47 @@ const CallExpr = union(enum) {
                     return ty.elemType();
                 },
 
-                Builtin.tagFromName("__atomic_fetch_add").?,
-                Builtin.tagFromName("__atomic_add_fetch").?,
-                Builtin.tagFromName("__c11_atomic_fetch_add").?,
+                .__atomic_fetch_add,
+                .__atomic_add_fetch,
+                .__c11_atomic_fetch_add,
 
-                Builtin.tagFromName("__atomic_fetch_sub").?,
-                Builtin.tagFromName("__atomic_sub_fetch").?,
-                Builtin.tagFromName("__c11_atomic_fetch_sub").?,
+                .__atomic_fetch_sub,
+                .__atomic_sub_fetch,
+                .__c11_atomic_fetch_sub,
 
-                Builtin.tagFromName("__atomic_fetch_and").?,
-                Builtin.tagFromName("__atomic_and_fetch").?,
-                Builtin.tagFromName("__c11_atomic_fetch_and").?,
+                .__atomic_fetch_and,
+                .__atomic_and_fetch,
+                .__c11_atomic_fetch_and,
 
-                Builtin.tagFromName("__atomic_fetch_xor").?,
-                Builtin.tagFromName("__atomic_xor_fetch").?,
-                Builtin.tagFromName("__c11_atomic_fetch_xor").?,
+                .__atomic_fetch_xor,
+                .__atomic_xor_fetch,
+                .__c11_atomic_fetch_xor,
 
-                Builtin.tagFromName("__atomic_fetch_or").?,
-                Builtin.tagFromName("__atomic_or_fetch").?,
-                Builtin.tagFromName("__c11_atomic_fetch_or").?,
+                .__atomic_fetch_or,
+                .__atomic_or_fetch,
+                .__c11_atomic_fetch_or,
 
-                Builtin.tagFromName("__atomic_fetch_nand").?,
-                Builtin.tagFromName("__atomic_nand_fetch").?,
-                Builtin.tagFromName("__c11_atomic_fetch_nand").?,
+                .__atomic_fetch_nand,
+                .__atomic_nand_fetch,
+                .__c11_atomic_fetch_nand,
                 => {
                     if (p.list_buf.items.len != 3) return Type.invalid; // wrong number of arguments; already an error
                     const second_param = p.list_buf.items[2];
                     return second_param.type(&p.tree);
                 },
-                Builtin.tagFromName("__builtin_complex").? => {
+                .__builtin_complex => {
                     if (p.list_buf.items.len < 1) return Type.invalid; // not enough arguments; already an error
                     const last_param = p.list_buf.items[p.list_buf.items.len - 1];
                     return last_param.type(&p.tree).makeComplex();
                 },
-                Builtin.tagFromName("__atomic_compare_exchange").?,
-                Builtin.tagFromName("__atomic_compare_exchange_n").?,
-                Builtin.tagFromName("__c11_atomic_is_lock_free").?,
+                .__atomic_compare_exchange,
+                .__atomic_compare_exchange_n,
+                .__c11_atomic_is_lock_free,
                 => .{ .specifier = .bool },
                 else => callable_ty.returnType(),
 
-                Builtin.tagFromName("__c11_atomic_compare_exchange_strong").?,
-                Builtin.tagFromName("__c11_atomic_compare_exchange_weak").?,
+                .__c11_atomic_compare_exchange_strong,
+                .__c11_atomic_compare_exchange_weak,
                 => {
                     if (p.list_buf.items.len != 6) return Type.invalid; // wrong number of arguments
                     const third_param = p.list_buf.items[3];


### PR DESCRIPTION
This enables using enum literals instead of `Builtin.tagFromName("str").?`.