### PR TITLE
Attribute: allow fallthrough to precede closing braces

### DIFF
--- a/test/cases/compound stmt fallthrough.c
+++ b/test/cases/compound stmt fallthrough.c
@@ -1,0 +1,15 @@
+int main(void) {
+    int x = 5;
+    switch (x) {
+        case 1: {
+            __attribute__((fallthrough));
+        }
+        case 2: {
+            __attribute__((fallthrough));
+        }
+        default: {
+            
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
Previously we would not accept valid code; now we might accept some invalid constructs but a misplaced fallthrough attribute seems fairly harmless.