### PR TITLE
Some things for ziglang/translate-c

### DIFF
--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -188,7 +188,8 @@ pub const usage =
     \\  -fno-use-line-directives
     \\                          Use `# <num>` linemarkers in preprocessed output
     \\  -I <dir>                Add directory to include search path
-    \\  -isystem                Add directory to SYSTEM include search path
+    \\  -isystem <dir>          Add directory to SYSTEM include search path
+    \\  --embed-dir=<dir>       Add directory to `#embed` search path
     \\  --emulate=[clang|gcc|msvc]
     \\                          Select which C compiler to emulate (default clang)
     \\  -mabicalls              Enable SVR4-style position-independent code (Mips only)
@@ -444,6 +445,8 @@ pub fn parseArgs(
                 const duped = try d.comp.gpa.dupe(u8, path);
                 errdefer d.comp.gpa.free(duped);
                 try d.comp.system_include_dirs.append(d.comp.gpa, duped);
+            } else if (option(arg, "--embed-dir=")) |path| {
+                try d.comp.embed_dirs.append(d.comp.gpa, path);
             } else if (option(arg, "--emulate=")) |compiler_str| {
                 const compiler = std.meta.stringToEnum(LangOpts.Compiler, compiler_str) orelse {
                     try d.err("invalid compiler '{s}'", .{arg});

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -48,6 +48,7 @@ inputs: std.ArrayListUnmanaged(Source) = .{},
 link_objects: std.ArrayListUnmanaged([]const u8) = .{},
 output_name: ?[]const u8 = null,
 sysroot: ?[]const u8 = null,
+resource_dir: ?[]const u8 = null,
 system_defines: Compilation.SystemDefinesMode = .include_system_defines,
 temp_file_count: u32 = 0,
 /// If false, do not emit line directives in -E mode
@@ -195,6 +196,7 @@ pub const usage =
     \\  -mcmodel=<code-model>   Generate code for the given code model
     \\  -mkernel                Enable kernel development mode
     \\  -nobuiltininc           Do not search the compiler's builtin directory for include files
+    \\  -resource-dir <dir>     Override the path to the compiler's builtin resource directory
     \\  -nostdinc, --no-standard-includes
     \\                          Do not search the standard system directories or compiler builtin directories for include files.
     \\  -nostdlibinc            Do not search the standard system directories for include files, but do search compiler builtin include directories
@@ -567,6 +569,13 @@ pub fn parseArgs(
                 d.nolibc = true;
             } else if (mem.eql(u8, arg, "-nobuiltininc")) {
                 d.nobuiltininc = true;
+            } else if (mem.eql(u8, arg, "-resource-dir")) {
+                i += 1;
+                if (i >= args.len) {
+                    try d.err("expected argument after -resource-dir", .{});
+                    continue;
+                }
+                d.resource_dir = args[i];
             } else if (mem.eql(u8, arg, "-nostdinc") or mem.eql(u8, arg, "--no-standard-includes")) {
                 d.nostdinc = true;
             } else if (mem.eql(u8, arg, "-nostdlibinc")) {

--- a/src/aro/Toolchain.zig
+++ b/src/aro/Toolchain.zig
@@ -507,7 +507,7 @@ pub fn defineSystemIncludes(tc: *Toolchain) !void {
 
             const comp = tc.driver.comp;
             if (!tc.driver.nobuiltininc) {
-                try comp.addBuiltinIncludeDir(tc.driver.aro_name);
+                try comp.addBuiltinIncludeDir(tc.driver.aro_name, tc.driver.resource_dir);
             }
 
             if (!tc.driver.nostdlibinc) {

--- a/src/aro/toolchains/Linux.zig
+++ b/src/aro/toolchains/Linux.zig
@@ -374,7 +374,7 @@ pub fn defineSystemIncludes(self: *const Linux, tc: *const Toolchain) !void {
     // musl prefers /usr/include before builtin includes, so musl targets will add builtins
     // at the end of this function (unless disabled with nostdlibinc)
     if (!tc.driver.nobuiltininc and (!target.abi.isMusl() or tc.driver.nostdlibinc)) {
-        try comp.addBuiltinIncludeDir(tc.driver.aro_name);
+        try comp.addBuiltinIncludeDir(tc.driver.aro_name, tc.driver.resource_dir);
     }
 
     if (tc.driver.nostdlibinc) return;
@@ -405,7 +405,7 @@ pub fn defineSystemIncludes(self: *const Linux, tc: *const Toolchain) !void {
 
     std.debug.assert(!tc.driver.nostdlibinc);
     if (!tc.driver.nobuiltininc and target.abi.isMusl()) {
-        try comp.addBuiltinIncludeDir(tc.driver.aro_name);
+        try comp.addBuiltinIncludeDir(tc.driver.aro_name, tc.driver.resource_dir);
     }
 }
 

--- a/test/cases/hide warnings.c
+++ b/test/cases/hide warnings.c
@@ -1,0 +1,5 @@
+//aro-args -w
+
+int arr[2] = { 0, [0] = 10 };
+
+#define EXPECTED_ERRORS

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -235,7 +235,7 @@ fn singleRun(alloc: std.mem.Allocator, test_dir: []const u8, test_case: TestCase
     defer comp.deinit();
 
     try comp.addDefaultPragmaHandlers();
-    try comp.addBuiltinIncludeDir(test_dir);
+    try comp.addBuiltinIncludeDir(test_dir, null);
 
     try setTarget(&comp, test_case.target);
     switch (comp.target.os.tag) {

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -180,11 +180,13 @@ pub fn main() !void {
     defer gpa.free(cases_include_dir);
 
     try initial_comp.include_dirs.append(gpa, cases_include_dir);
+    try initial_comp.embed_dirs.append(gpa, cases_include_dir);
 
     const cases_next_include_dir = try std.fs.path.join(gpa, &.{ args[1], "include", "next" });
     defer gpa.free(cases_next_include_dir);
 
     try initial_comp.include_dirs.append(gpa, cases_next_include_dir);
+    try initial_comp.embed_dirs.append(gpa, cases_next_include_dir);
 
     try initial_comp.addDefaultPragmaHandlers();
     try initial_comp.addBuiltinIncludeDir(test_dir, null);
@@ -212,6 +214,7 @@ pub fn main() !void {
             // preserve some values
             comp.include_dirs = .{};
             comp.system_include_dirs = .{};
+            comp.embed_dirs = .{};
             comp.pragma_handlers = .{};
             comp.environment = .{};
             // reset everything else

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -67,7 +67,7 @@ fn testOne(allocator: std.mem.Allocator, path: []const u8, test_dir: []const u8)
     defer comp.deinit();
 
     try comp.addDefaultPragmaHandlers();
-    try comp.addBuiltinIncludeDir(test_dir);
+    try comp.addBuiltinIncludeDir(test_dir, null);
 
     const file = try comp.addSourceFromPath(path);
     var macro_buf = std.ArrayList(u8).init(comp.gpa);
@@ -187,7 +187,7 @@ pub fn main() !void {
     try initial_comp.include_dirs.append(gpa, cases_next_include_dir);
 
     try initial_comp.addDefaultPragmaHandlers();
-    try initial_comp.addBuiltinIncludeDir(test_dir);
+    try initial_comp.addBuiltinIncludeDir(test_dir, null);
 
     // apparently we can't use setAstCwd without libc on windows yet
     const win = @import("builtin").os.tag == .windows;


### PR DESCRIPTION
I was reworking the build logic for `ziglang/translate-c`, and ultimately hit one bug and two missing features:
* Bug: `-w` does hide warnings, but *doesn't* hide their associated notes.
  * Now, `Diagnostics` tracks whether it skipped the last diagnostic it was given, and if it did, it will also skip an immediately following note.
* Missing feature: there should be a way to tell Aro where its `include` directory is instead of having Aro search for it. This means Aro can be invoked programmatically *without* having to copy everything to an install prefix; particularly helpful when trying to run Aro through the Zig build system.
  * I have introduced `--aro-include-dir=<dir>`, which uses the given path instead of searching for the `include` directory. This option is highly analagous to the Zig compiler's `--zig-lib-dir` option.
* Missing feature: search paths for `#embed` should be specified through another option, `--embed-dir=<dir>` (well, that's what Clang calls it). Notably, `#embed`s should *not* check normal include directories [according to the author of the Clang and GCC implementions](https://thephd.dev/implementing-embed-c-and-c++#the-first-step-is-obviously-adding-flags-to-ensure-that-the-comp).
  * I have introduced `--embed-dir=<dir>`, and we now scan that instead of the normal include directories when resolving `#embed`s.