### PR TITLE
Parser: allow casting to the same non-scalar type as an extension

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -6904,6 +6904,9 @@ pub const Result = struct {
                 try p.err(l_paren, .invalid_union_cast, .{res.qt});
                 return error.ParsingFailed;
             }
+        } else if (dest_qt.eql(res.qt, p.comp)) {
+            try p.err(l_paren, .cast_to_same_type, .{dest_qt});
+            cast_kind = .no_op;
         } else {
             try p.err(l_paren, .invalid_cast_type, .{dest_qt});
             return error.ParsingFailed;

--- a/src/aro/Parser/Diagnostic.zig
+++ b/src/aro/Parser/Diagnostic.zig
@@ -694,6 +694,12 @@ pub const invalid_cast_type: Diagnostic = .{
     .kind = .@"error",
 };
 
+pub const cast_to_same_type: Diagnostic = .{
+    .fmt = "C99 forbids casting nonscalar type {qt} to the same type",
+    .kind = .off,
+    .extension = true,
+};
+
 pub const invalid_cast_operand_type: Diagnostic = .{
     .fmt = "operand of type {qt} where arithmetic or pointer type is required",
     .kind = .@"error",

--- a/test/cases/cast to same type.c
+++ b/test/cases/cast to same type.c
@@ -1,0 +1,12 @@
+//aro-args -pedantic
+struct S {
+    int x;
+};
+
+void foo(void) {
+    struct S s = {.x = 5 };
+    s = (struct S)s;
+}
+
+#define EXPECTED_ERRORS "cast to same type.c:8:9: warning: C99 forbids casting nonscalar type 'struct S' to the same type [-Wpedantic]" \
+


### PR DESCRIPTION
In general, casting to a non-scalar type is disallowed. However, casting to the same type can be treated as a no-op, which is what GCC and Clang do.