### PR TITLE
Define __OPTIMIZE__ and __OPTIMIZE_SIZE__ flags if relevant

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -246,6 +246,13 @@ fn generateSystemDefines(comp: *Compilation, w: *std.Io.Writer) !void {
         try w.print("#define __GNUC_PATCHLEVEL__ {d}\n", .{comp.langopts.gnuc_version % 100});
     }
 
+    if (comp.code_gen_options.optimization_level.hasAnyOptimizations()) {
+        try define(w, "__OPTIMIZE__");
+    }
+    if (comp.code_gen_options.optimization_level.isSizeOptimized()) {
+        try define(w, "__OPTIMIZE_SIZE__");
+    }
+
     // os macros
     switch (comp.target.os.tag) {
         .linux => try defineStd(w, "linux", is_gnu),

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -322,7 +322,7 @@ pub fn parseArgs(
                 }
                 try macro_buf.print(d.comp.gpa, "#undef {s}\n", .{macro});
             } else if (mem.eql(u8, arg, "-O")) {
-                d.comp.code_gen_options.optimization_level = .@"0";
+                d.comp.code_gen_options.optimization_level = .@"1";
             } else if (mem.startsWith(u8, arg, "-O")) {
                 d.comp.code_gen_options.optimization_level = backend.CodeGenOptions.OptimizationLevel.fromString(arg["-O".len..]) orelse {
                     try d.err("invalid optimization level '{s}'", .{arg});

--- a/src/backend/CodeGenOptions.zig
+++ b/src/backend/CodeGenOptions.zig
@@ -66,6 +66,20 @@ pub const OptimizationLevel = enum {
     pub fn fromString(str: []const u8) ?OptimizationLevel {
         return level_map.get(str);
     }
+
+    pub fn isSizeOptimized(self: OptimizationLevel) bool {
+        return switch (self) {
+            .s, .z => true,
+            .@"0", .@"1", .@"2", .@"3", .fast, .g => false,
+        };
+    }
+
+    pub fn hasAnyOptimizations(self: OptimizationLevel) bool {
+        return switch (self) {
+            .@"0" => false,
+            .@"1", .@"2", .@"3", .s, .fast, .g, .z => true,
+        };
+    }
 };
 
 pub const default: @This() = .{

--- a/test/cases/no optimizations.c
+++ b/test/cases/no optimizations.c
@@ -1,0 +1,8 @@
+#if defined(__OPTIMIZE__)
+#error Optimize flag should not be defined
+#endif
+
+
+#if defined(__OPTIMIZE_SIZE__)
+#error Optimize size flag should not be defined
+#endif

--- a/test/cases/optimize define.c
+++ b/test/cases/optimize define.c
@@ -1,0 +1,8 @@
+//aro-args -O
+#if !defined(__OPTIMIZE__)
+#error Optimize flag not defined
+#endif
+
+#if defined(__OPTIMIZE_SIZE__)
+#error Optimize size flag should not be defined
+#endif

--- a/test/cases/optimize size flags.c
+++ b/test/cases/optimize size flags.c
@@ -1,0 +1,9 @@
+//aro-args -Os
+#if !defined(__OPTIMIZE__)
+#error Optimize flag should be defined
+#endif
+
+
+#if !defined(__OPTIMIZE_SIZE__)
+#error Optimize size flag should be defined
+#endif


### PR DESCRIPTION
Also fix a bug in Driver where `-O` would set optimization level 0. In GCC and clang it's equivalent to `-O1`