### PR TITLE
Compilation: Set gnuc_version based on emulated compiler

### DIFF
--- a/src/aro.zig
+++ b/src/aro.zig
@@ -34,6 +34,7 @@ test {
     _ = @import("aro/Driver/Filesystem.zig");
     _ = @import("aro/Driver/GCCVersion.zig");
     _ = @import("aro/InitList.zig");
+    _ = @import("aro/LangOpts.zig");
     _ = @import("aro/Preprocessor.zig");
     _ = @import("aro/target.zig");
     _ = @import("aro/Tokenizer.zig");

--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -240,10 +240,11 @@ fn generateSystemDefines(comp: *Compilation, w: *std.Io.Writer) !void {
     const ptr_width = comp.target.ptrBitWidth();
     const is_gnu = comp.langopts.standard.isGNU();
 
-    if (comp.langopts.gnuc_version > 0) {
-        try w.print("#define __GNUC__ {d}\n", .{comp.langopts.gnuc_version / 10_000});
-        try w.print("#define __GNUC_MINOR__ {d}\n", .{comp.langopts.gnuc_version / 100 % 100});
-        try w.print("#define __GNUC_PATCHLEVEL__ {d}\n", .{comp.langopts.gnuc_version % 100});
+    const gnuc_version = comp.langopts.gnuc_version orelse comp.langopts.emulate.defaultGccVersion();
+    if (gnuc_version > 0) {
+        try w.print("#define __GNUC__ {d}\n", .{gnuc_version / 10_000});
+        try w.print("#define __GNUC_MINOR__ {d}\n", .{gnuc_version / 100 % 100});
+        try w.print("#define __GNUC_PATCHLEVEL__ {d}\n", .{gnuc_version % 100});
     }
 
     if (comp.code_gen_options.optimization_level.hasAnyOptimizations()) {

--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -247,11 +247,18 @@ fn generateSystemDefines(comp: *Compilation, w: *std.Io.Writer) !void {
         try w.print("#define __GNUC_PATCHLEVEL__ {d}\n", .{gnuc_version % 100});
     }
 
-    switch (comp.langopts.emulate) {
-        .clang => try w.writeAll("#define __ARO_EMULATE__ 1\n"),
-        .gcc => try w.writeAll("#define __ARO_EMULATE__ 2\n"),
-        .msvc => try w.writeAll("#define __ARO_EMULATE__ 3\n"),
-    }
+    try w.writeAll(
+        \\#define __ARO_EMULATE_CLANG__ 1
+        \\#define __ARO_EMULATE_GCC__ 2
+        \\#define __ARO_EMULATE_MSVC__ 3
+        \\
+    );
+    const emulated = switch (comp.langopts.emulate) {
+        .clang => "__ARO_EMULATE_CLANG__",
+        .gcc => "__ARO_EMULATE_GCC__",
+        .msvc => "__ARO_EMULATE_MSVC__",
+    };
+    try w.print("#define __ARO_EMULATE__ {s}\n", .{emulated});
 
     if (comp.code_gen_options.optimization_level.hasAnyOptimizations()) {
         try define(w, "__OPTIMIZE__");

--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -247,6 +247,12 @@ fn generateSystemDefines(comp: *Compilation, w: *std.Io.Writer) !void {
         try w.print("#define __GNUC_PATCHLEVEL__ {d}\n", .{gnuc_version % 100});
     }
 
+    switch (comp.langopts.emulate) {
+        .clang => try w.writeAll("#define __ARO_EMULATE__ 1\n"),
+        .gcc => try w.writeAll("#define __ARO_EMULATE__ 2\n"),
+        .msvc => try w.writeAll("#define __ARO_EMULATE__ 3\n"),
+    }
+
     if (comp.code_gen_options.optimization_level.hasAnyOptimizations()) {
         try define(w, "__OPTIMIZE__");
     }

--- a/src/aro/Diagnostics.zig
+++ b/src/aro/Diagnostics.zig
@@ -486,7 +486,7 @@ pub fn addWithLocation(
     if (copy.kind == .@"fatal error") return error.FatalError;
 }
 
-const FormatError = error{ TemplateNotFound, TypeNotHandled } || std.Io.Writer.Error;
+const FormatError = error{TemplateNotFound} || std.Io.Writer.Error;
 
 fn formatArgsSafe(w: *std.Io.Writer, fmt: []const u8, args: anytype) FormatError!void {
     var i: usize = 0;
@@ -497,7 +497,7 @@ fn formatArgsSafe(w: *std.Io.Writer, fmt: []const u8, args: anytype) FormatError
             else => switch (@typeInfo(@TypeOf(arg))) {
                 .int, .comptime_int => try Diagnostics.formatInt(w, fmt[i..], arg),
                 .pointer => try Diagnostics.formatString(w, fmt[i..], arg),
-                else => return error.TypeNotHandled,
+                else => comptime unreachable,
             },
         };
     }
@@ -507,7 +507,6 @@ fn formatArgsSafe(w: *std.Io.Writer, fmt: []const u8, args: anytype) FormatError
 pub fn formatArgs(w: *std.Io.Writer, fmt: []const u8, args: anytype) std.Io.Writer.Error!void {
     formatArgsSafe(w, fmt, args) catch |err| switch (err) {
         error.TemplateNotFound => return w.writeAll("Message template not found (this is a bug in arocc)"),
-        error.TypeNotHandled => return w.writeAll("Argument type cannot be formatted (this is a bug in arocc)"),
         else => |e| return e,
     };
 }

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -1041,7 +1041,7 @@ fn getRandomFilename(d: *Driver, buf: *[std.fs.max_name_bytes]u8, extension: []c
 
     const fmt_template = "/tmp/{s}{s}";
     const fmt_args = .{
-        random_name,
+        @as([]const u8, &random_name),
         extension,
     };
     return std.fmt.bufPrint(buf, fmt_template, fmt_args) catch return d.fatal("Filename too long for filesystem: " ++ fmt_template, fmt_args);

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -789,11 +789,11 @@ pub fn parseArgs(
             d.comp.target.os.tag = .freestanding;
         }
     }
-    const gnuc_version_string = gnuc_version orelse d.comp.langopts.emulate.defaultGccVersion();
+    const gnuc_version_string = gnuc_version orelse d.comp.langopts.emulate.defaultGccVersionString();
     const version = GCCVersion.parse(gnuc_version_string);
     if (version.major == -1) {
         if (gnuc_version) |unwrapped| {
-            return d.fatal("invalid value '{s}' in '-fgnuc-version={s}'", .{unwrapped, unwrapped});
+            return d.fatal("invalid value '{s}' in '-fgnuc-version={s}'", .{ unwrapped, unwrapped });
         }
     }
     d.comp.langopts.gnuc_version = version.toUnsigned();

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -276,7 +276,7 @@ pub fn parseArgs(
     var i: usize = 1;
     var comment_arg: []const u8 = "";
     var hosted: ?bool = null;
-    var gnuc_version: []const u8 = "4.2.1"; // default value set by clang
+    var gnuc_version: ?[]const u8 = null;
     var pic_arg: []const u8 = "";
     var declspec_attrs: ?bool = null;
     var ms_extensions: ?bool = null;
@@ -789,9 +789,12 @@ pub fn parseArgs(
             d.comp.target.os.tag = .freestanding;
         }
     }
-    const version = GCCVersion.parse(gnuc_version);
+    const gnuc_version_string = gnuc_version orelse d.comp.langopts.emulate.defaultGccVersion();
+    const version = GCCVersion.parse(gnuc_version_string);
     if (version.major == -1) {
-        return d.fatal("invalid value '{0s}' in '-fgnuc-version={0s}'", .{gnuc_version});
+        if (gnuc_version) |unwrapped| {
+            return d.fatal("invalid value '{s}' in '-fgnuc-version={s}'", .{unwrapped, unwrapped});
+        }
     }
     d.comp.langopts.gnuc_version = version.toUnsigned();
     const pic_level, const is_pie = try d.getPICMode(pic_arg);

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -789,14 +789,13 @@ pub fn parseArgs(
             d.comp.target.os.tag = .freestanding;
         }
     }
-    const gnuc_version_string = gnuc_version orelse d.comp.langopts.emulate.defaultGccVersionString();
-    const version = GCCVersion.parse(gnuc_version_string);
-    if (version.major == -1) {
-        if (gnuc_version) |unwrapped| {
+    if (gnuc_version) |unwrapped| {
+        const version = GCCVersion.parse(unwrapped);
+        if (version.major == -1) {
             return d.fatal("invalid value '{s}' in '-fgnuc-version={s}'", .{ unwrapped, unwrapped });
         }
+        d.comp.langopts.gnuc_version = version.toUnsigned();
     }
-    d.comp.langopts.gnuc_version = version.toUnsigned();
     const pic_level, const is_pie = try d.getPICMode(pic_arg);
     d.comp.code_gen_options.pic_level = pic_level;
     d.comp.code_gen_options.is_pie = is_pie;

--- a/src/aro/Driver/GCCVersion.zig
+++ b/src/aro/Driver/GCCVersion.zig
@@ -57,7 +57,7 @@ pub fn parse(text: []const u8) GCCVersion {
     var good = bad;
 
     var it = mem.splitScalar(u8, text, '.');
-    const first = it.next().?;
+    const first = it.first();
     const second = it.next() orelse "";
     const rest = it.next() orelse "";
 

--- a/src/aro/LangOpts.zig
+++ b/src/aro/LangOpts.zig
@@ -7,6 +7,15 @@ pub const Compiler = enum {
     clang,
     gcc,
     msvc,
+
+    /// Report ourselves as this GCC version if not explicitly specified by the user via `-fgnuc-version`
+    pub fn defaultGccVersion(self: Compiler) []const u8 {
+        return switch (self) {
+            .clang => "4.2.1",
+            .gcc => "7.1",
+            .msvc => "0",
+        };
+    }
 };
 
 /// The floating-point evaluation method for intermediate results within a single expression

--- a/src/aro/LangOpts.zig
+++ b/src/aro/LangOpts.zig
@@ -8,43 +8,12 @@ pub const Compiler = enum {
     gcc,
     msvc,
 
-    /// Report ourselves as this GCC version if not explicitly specified by the user via `-fgnuc-version`
-    pub fn defaultGccVersionString(self: Compiler) []const u8 {
-        return switch (self) {
-            .clang => "4.2.1",
-            .gcc => "7.1",
-            .msvc => "0",
-        };
-    }
-
     pub fn defaultGccVersion(self: Compiler) u32 {
         return switch (self) {
             .clang => 4 * 10_000 + 2 * 100 + 1,
             .gcc => 7 * 10_000 + 1 * 100 + 0,
             .msvc => 0,
         };
-    }
-
-    test defaultGccVersionString {
-        const S = struct {
-            fn doTheTest(compiler: Compiler) !void {
-                const string = compiler.defaultGccVersionString();
-                var it = std.mem.splitScalar(u8, string, '.');
-                var mul: u32 = 10_000;
-                var sum: u32 = 0;
-                while (it.next()) |part| {
-                    const val = try std.fmt.parseInt(u32, part, 10);
-                    sum += mul * val;
-                    mul /= 100;
-                }
-                if (sum != compiler.defaultGccVersion()) {
-                    return error.TestFailed;
-                }
-            }
-        };
-        try S.doTheTest(Compiler.clang);
-        try S.doTheTest(Compiler.gcc);
-        try S.doTheTest(Compiler.msvc);
     }
 };
 

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -477,22 +477,18 @@ fn formatArgs(p: *Parser, w: *std.Io.Writer, fmt: []const u8, args: anytype) !vo
 }
 
 fn formatTokenId(w: *std.Io.Writer, fmt: []const u8, tok_id: Tree.Token.Id) !usize {
-    const template = "{tok_id}";
-    const i = std.mem.indexOf(u8, fmt, template).?;
-    try w.writeAll(fmt[0..i]);
+    const i = Diagnostics.templateIndex(w, fmt, "{tok_id}");
     try w.writeAll(tok_id.symbol());
-    return i + template.len;
+    return i;
 }
 
 fn formatQualType(p: *Parser, w: *std.Io.Writer, fmt: []const u8, qt: QualType) !usize {
-    const template = "{qt}";
-    const i = std.mem.indexOf(u8, fmt, template).?;
-    try w.writeAll(fmt[0..i]);
+    const i = Diagnostics.templateIndex(w, fmt, "{qt}");
     try w.writeByte('\'');
     try qt.print(p.comp, w);
     try w.writeByte('\'');
 
-    if (qt.isC23Auto()) return i + template.len;
+    if (qt.isC23Auto()) return i;
     if (qt.get(p.comp, .vector)) |vector_ty| {
         try w.print(" (vector of {d} '", .{vector_ty.len});
         try vector_ty.elem.printDesugared(p.comp, w);
@@ -502,14 +498,11 @@ fn formatQualType(p: *Parser, w: *std.Io.Writer, fmt: []const u8, qt: QualType) 
         try qt.printDesugared(p.comp, w);
         try w.writeAll("')");
     }
-    return i + template.len;
+    return i;
 }
 
 fn formatResult(p: *Parser, w: *std.Io.Writer, fmt: []const u8, res: Result) !usize {
-    const template = "{value}";
-    const i = std.mem.indexOf(u8, fmt, template).?;
-    try w.writeAll(fmt[0..i]);
-
+    const i = Diagnostics.templateIndex(w, fmt, "{value}");
     switch (res.val.opt_ref) {
         .none => try w.writeAll("(none)"),
         .null => try w.writeAll("nullptr_t"),
@@ -521,8 +514,7 @@ fn formatResult(p: *Parser, w: *std.Io.Writer, fmt: []const u8, res: Result) !us
             },
         },
     }
-
-    return i + template.len;
+    return i;
 }
 
 const Normalized = struct {
@@ -532,10 +524,8 @@ const Normalized = struct {
         return .{ .str = str };
     }
 
-    pub fn format(ctx: Normalized, w: *std.Io.Writer, fmt_str: []const u8) !usize {
-        const template = "{normalized}";
-        const i = std.mem.indexOf(u8, fmt_str, template).?;
-        try w.writeAll(fmt_str[0..i]);
+    pub fn format(ctx: Normalized, w: *std.Io.Writer, fmt: []const u8) !usize {
+        const i = Diagnostics.templateIndex(w, fmt, "{normalized}");
         var it: std.unicode.Utf8Iterator = .{
             .bytes = ctx.str,
             .i = 0,
@@ -557,7 +547,7 @@ const Normalized = struct {
                 });
             }
         }
-        return i + template.len;
+        return i;
     }
 };
 
@@ -568,12 +558,10 @@ const Codepoint = struct {
         return .{ .codepoint = codepoint };
     }
 
-    pub fn format(ctx: Codepoint, w: *std.Io.Writer, fmt_str: []const u8) !usize {
-        const template = "{codepoint}";
-        const i = std.mem.indexOf(u8, fmt_str, template).?;
-        try w.writeAll(fmt_str[0..i]);
+    pub fn format(ctx: Codepoint, w: *std.Io.Writer, fmt: []const u8) !usize {
+        const i = Diagnostics.templateIndex(w, fmt, "{codepoint}");
         try w.print("{X:0>4}", .{ctx.codepoint});
-        return i + template.len;
+        return i;
     }
 };
 
@@ -584,12 +572,10 @@ const Escaped = struct {
         return .{ .str = str };
     }
 
-    pub fn format(ctx: Escaped, w: *std.Io.Writer, fmt_str: []const u8) !usize {
-        const template = "{s}";
-        const i = std.mem.indexOf(u8, fmt_str, template).?;
-        try w.writeAll(fmt_str[0..i]);
+    pub fn format(ctx: Escaped, w: *std.Io.Writer, fmt: []const u8) !usize {
+        const i = Diagnostics.templateIndex(w, fmt, "{s}");
         try std.zig.stringEscape(ctx.str, w);
-        return i + template.len;
+        return i;
     }
 };
 

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -469,7 +469,7 @@ fn formatArgs(p: *Parser, w: *std.Io.Writer, fmt: []const u8, args: anytype) !vo
             else => switch (@typeInfo(@TypeOf(arg))) {
                 .int, .comptime_int => try Diagnostics.formatInt(w, fmt[i..], arg),
                 .pointer => try Diagnostics.formatString(w, fmt[i..], arg),
-                else => unreachable,
+                else => comptime unreachable,
             },
         };
     }
@@ -626,11 +626,11 @@ pub fn errValueChanged(p: *Parser, tok_i: TokenIndex, diagnostic: Diagnostic, re
 fn checkDeprecatedUnavailable(p: *Parser, ty: QualType, usage_tok: TokenIndex, decl_tok: TokenIndex) !void {
     if (ty.getAttribute(p.comp, .@"error")) |@"error"| {
         const msg_str = p.comp.interner.get(@"error".msg.ref()).bytes;
-        try p.err(usage_tok, .error_attribute, .{ p.tokSlice(@"error".__name_tok), std.zig.fmtString(msg_str) });
+        try p.err(usage_tok, .error_attribute, .{ p.tokSlice(@"error".__name_tok), Escaped.init(msg_str) });
     }
     if (ty.getAttribute(p.comp, .warning)) |warning| {
         const msg_str = p.comp.interner.get(warning.msg.ref()).bytes;
-        try p.err(usage_tok, .warning_attribute, .{ p.tokSlice(warning.__name_tok), std.zig.fmtString(msg_str) });
+        try p.err(usage_tok, .warning_attribute, .{ p.tokSlice(warning.__name_tok), Escaped.init(msg_str) });
     }
     if (ty.getAttribute(p.comp, .unavailable)) |unavailable| {
         try p.errDeprecated(usage_tok, .unavailable, unavailable.msg);
@@ -4734,7 +4734,7 @@ fn asmOperand(p: *Parser, names: *std.ArrayList(?TokenIndex), constraints: *Node
     try constraints.append(gpa, constraint.node);
 
     const l_paren = p.eatToken(.l_paren) orelse {
-        try p.err(p.tok_i, .expected_token, .{ p.tok_ids[p.tok_i], .l_paren });
+        try p.err(p.tok_i, .expected_token, .{ p.tok_ids[p.tok_i], Token.Id.l_paren });
         return error.ParsingFailed;
     };
     const maybe_res = try p.expr();

--- a/src/aro/text_literal.zig
+++ b/src/aro/text_literal.zig
@@ -345,7 +345,7 @@ pub const Parser = struct {
                 else => switch (@typeInfo(@TypeOf(arg))) {
                     .int, .comptime_int => try Diagnostics.formatInt(w, fmt[i..], arg),
                     .pointer => try Diagnostics.formatString(w, fmt[i..], arg),
-                    else => unreachable,
+                    else => comptime unreachable,
                 },
             };
         }

--- a/src/aro/text_literal.zig
+++ b/src/aro/text_literal.zig
@@ -154,17 +154,14 @@ pub const Ascii = struct {
         return .{ .val = @intCast(val) };
     }
 
-    pub fn format(ctx: Ascii, w: *std.Io.Writer, fmt_str: []const u8) !usize {
-        const template = "{c}";
-        const i = std.mem.indexOf(u8, fmt_str, template).?;
-        try w.writeAll(fmt_str[0..i]);
-
+    pub fn format(ctx: Ascii, w: *std.Io.Writer, fmt: []const u8) !usize {
+        const i = Diagnostics.templateIndex(w, fmt, "{c}");
         if (std.ascii.isPrint(ctx.val)) {
             try w.writeByte(ctx.val);
         } else {
             try w.print("x{x:0>2}", .{ctx.val});
         }
-        return i + template.len;
+        return i;
     }
 };
 

--- a/test/cases/gnuc version default clang.c
+++ b/test/cases/gnuc version default clang.c
@@ -1,3 +1,4 @@
+//aro-args --emulate=clang
 _Static_assert(__GNUC__ == 4, "");
 _Static_assert(__GNUC_MINOR__ == 2, "");
 _Static_assert(__GNUC_PATCHLEVEL__ == 1, "");

--- a/test/cases/gnuc version default gcc.c
+++ b/test/cases/gnuc version default gcc.c
@@ -1,0 +1,4 @@
+//aro-args --emulate=gcc
+_Static_assert(__GNUC__ == 7, "");
+_Static_assert(__GNUC_MINOR__ == 1, "");
+_Static_assert(__GNUC_PATCHLEVEL__ == 0, "");

--- a/test/cases/gnuc version default msvc.c
+++ b/test/cases/gnuc version default msvc.c
@@ -1,0 +1,5 @@
+//aro-args --emulate=msvc
+
+#if defined(__GNUC__) || defined(__GNUC_MINOR__) || defined(__GNUC_PATCHLEVEL__)
+#error "__GNUC__ macros should not be defined"
+#endif

--- a/test/cases/gnuc version default.c
+++ b/test/cases/gnuc version default.c
@@ -1,0 +1,24 @@
+#if __ARO_EMULATE__ == 1
+
+/* clang */
+_Static_assert(__GNUC__ == 4, "");
+_Static_assert(__GNUC_MINOR__ == 2, "");
+_Static_assert(__GNUC_PATCHLEVEL__ == 1, "");
+
+#elif __ARO_EMULATE__ == 2
+
+/* gcc */
+_Static_assert(__GNUC__ == 7, "");
+_Static_assert(__GNUC_MINOR__ == 1, "");
+_Static_assert(__GNUC_PATCHLEVEL__ == 0, "");
+
+#elif __ARO_EMULATE__ == 3
+
+/* msvc */
+#if defined(__GNUC__) || defined(__GNUC_MINOR__) || defined(__GNUC_PATCHLEVEL__)
+#error "__GNUC__ macros should not be defined"
+#endif
+
+#else
+#error Invalid value for __ARO_EMULATE__
+#endif

--- a/test/cases/gnuc version default.c
+++ b/test/cases/gnuc version default.c
@@ -1,20 +1,17 @@
-#if __ARO_EMULATE__ == 1
+#if __ARO_EMULATE__ == __ARO_EMULATE_CLANG__
 
-/* clang */
 _Static_assert(__GNUC__ == 4, "");
 _Static_assert(__GNUC_MINOR__ == 2, "");
 _Static_assert(__GNUC_PATCHLEVEL__ == 1, "");
 
-#elif __ARO_EMULATE__ == 2
+#elif __ARO_EMULATE__ == __ARO_EMULATE_GCC__
 
-/* gcc */
 _Static_assert(__GNUC__ == 7, "");
 _Static_assert(__GNUC_MINOR__ == 1, "");
 _Static_assert(__GNUC_PATCHLEVEL__ == 0, "");
 
-#elif __ARO_EMULATE__ == 3
+#elif __ARO_EMULATE__ == __ARO_EMULATE_MSVC__
 
-/* msvc */
 #if defined(__GNUC__) || defined(__GNUC_MINOR__) || defined(__GNUC_PATCHLEVEL__)
 #error "__GNUC__ macros should not be defined"
 #endif

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -23,7 +23,6 @@ fn addCommandLineArgs(comp: *aro.Compilation, file: aro.Source, macro_buf: *std.
     var line_markers: aro.Preprocessor.Linemarkers = .none;
     var system_defines: aro.Compilation.SystemDefinesMode = .include_system_defines;
     var dump_mode: aro.Preprocessor.DumpMode = .result_only;
-    comp.langopts.gnuc_version = 40201; // Set to clang default value since we do not call parseArgs if there are no args
     if (std.mem.startsWith(u8, file.buf, "//aro-args")) {
         var test_args: std.ArrayList([]const u8) = .empty;
         defer test_args.deinit(comp.gpa);


### PR DESCRIPTION
1. Fixes a bug in Driver where an invalid gnuc_version would cause a crash when rendering the error (due to template `{0s}` not being found)
2. If no explicit gnuc_version is set, use the default for the emulated compiler - 4.2.1 for clang, 7.1 for GCC, 0 (none) for MSVC
3. Add `__ARO_EMULATE__` to facilitate testing

I believe this should fix #887
