### PR TITLE
Compilation: add support for -iquote include dirs

### DIFF
--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -204,6 +204,7 @@ pub const usage =
     \\  -fuse-line-directives   Use `#line <num>` linemarkers in preprocessed output
     \\  -fno-use-line-directives
     \\                          Use `# <num>` linemarkers in preprocessed output
+    \\  -iquote <dir>           Add directory to QUOTE include search path
     \\  -I <dir>                Add directory to include search path
     \\  -idirafter <dir>        Add directory to AFTER include search path
     \\  -isystem <dir>          Add directory to SYSTEM include search path
@@ -530,6 +531,17 @@ pub fn parseArgs(
                     path = args[i];
                 }
                 try d.comp.system_include_dirs.append(d.comp.gpa, path);
+            } else if (mem.startsWith(u8, arg, "-iquote")) {
+                var path = arg["-iquote".len..];
+                if (path.len == 0) {
+                    i += 1;
+                    if (i >= args.len) {
+                        try d.err("expected argument after -iquote", .{});
+                        continue;
+                    }
+                    path = args[i];
+                }
+                try d.comp.iquote_include_dirs.append(d.comp.gpa, path);
             } else if (mem.startsWith(u8, arg, "-F")) {
                 var path = arg["-F".len..];
                 if (path.len == 0) {

--- a/test/cases/include/iquote/iquote_test.h
+++ b/test/cases/include/iquote/iquote_test.h
@@ -1,0 +1,1 @@
+#define FOO 42

--- a/test/cases/iquote.c
+++ b/test/cases/iquote.c
@@ -1,0 +1,10 @@
+#if __has_include(<iquote_test.h>)
+#error Should not find this
+#endif
+
+#if !__has_include("iquote_test.h")
+#error Should find this
+#endif
+
+#include "iquote_test.h"
+_Static_assert(FOO == 42, "FOO is incorrect");

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -197,6 +197,9 @@ pub fn main() !void {
     const cases_frameworks_dir = try std.fs.path.join(arena, &.{ args[1], "frameworks" });
     try initial_comp.framework_dirs.append(gpa, cases_frameworks_dir);
 
+    const cases_iquote_dir = try std.fs.path.join(arena, &.{ args[1], "include", "iquote" });
+    try initial_comp.iquote_include_dirs.append(gpa, cases_iquote_dir);
+
     try initial_comp.addDefaultPragmaHandlers();
     try initial_comp.addBuiltinIncludeDir(test_dir, null);
 
@@ -224,6 +227,7 @@ pub fn main() !void {
         defer {
             // preserve some values
             comp.include_dirs = .{};
+            comp.iquote_include_dirs = .{};
             comp.system_include_dirs = .{};
             comp.after_include_dirs = .{};
             comp.framework_dirs = .{};


### PR DESCRIPTION
for quote-form include directives, iquote directories are searched before `-I` directories

https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/Directory-Options.html