### PR TITLE
Provide _MSC_VER and _MSC_FULL_VER in msvc emulation mode

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -263,6 +263,11 @@ fn generateSystemDefines(comp: *Compilation, w: *std.Io.Writer) !void {
     };
     try w.print("#define __ARO_EMULATE__ {s}\n", .{emulated});
 
+    if (comp.langopts.emulate == .msvc) {
+        try w.writeAll("#define _MSC_VER 1933\n");
+        try w.writeAll("#define _MSC_FULL_VER 193300000\n");
+    }
+
     if (comp.code_gen_options.optimization_level.hasAnyOptimizations()) {
         try define(w, "__OPTIMIZE__");
     }


### PR DESCRIPTION
In my project I'm using https://github.com/zig-gamedev/zphysics, which uses these defines to detect compilation with MSVC, in order to match vtable header sizes: https://github.com/zig-gamedev/zphysics/blob/87dbfd003e31623cede1137aa8a70f86619b5d5b/libs/JoltC/JoltPhysicsC.h#L47

The values are the same as the defaults that the clang MSVC driver uses. 