### PR TITLE
Parser: computeOffsetExtra allows int_to_pointer cast kind

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -8093,9 +8093,8 @@ fn computeOffsetExtra(p: *Parser, node: Node.Index, offset_so_far: *Value) !Valu
     switch (node.get(&p.tree)) {
         .cast => |cast| {
             return switch (cast.kind) {
-                .array_to_pointer, .no_op, .bitcast => p.computeOffsetExtra(cast.operand, offset_so_far),
                 .lval_to_rval => .{},
-                else => unreachable,
+                else => p.computeOffsetExtra(cast.operand, offset_so_far),
             };
         },
         .paren_expr => |un| return p.computeOffsetExtra(un.operand, offset_so_far),

--- a/test/cases/member expr.c
+++ b/test/cases/member expr.c
@@ -41,6 +41,14 @@ int f2(void) {
     return c->a;
 }
 
+void f3(void) {
+    (void)&((struct Foo *)(0x100000u))->a;
+    (void)&((struct Foo **)0x100000u)[0];
+    (void)&((struct Foo (*)[1])0x100000u)[0]->a;
+    (void)&((struct Foo **)(int)(_Complex int)1)[0];
+    (void)&((struct Foo **)(_Bool)1)[0];
+}
+
 #define EXPECTED_ERRORS "member expr.c:7:8: error: member reference base type 'int' is not a structure or union" \
     "member expr.c:10:8: error: member reference type 'struct Foo' is not a pointer; did you mean to use '.'?" \
     "member expr.c:13:8: error: member reference type 'struct Foo' is not a pointer; did you mean to use '.'?" \


### PR DESCRIPTION
In Debug/ReleaseSafe builds, the modified test case crashes due to reaching unreachable code.

Although `computeOffsetExtra` will currently often (always?) eventually return a `.none` Value when an int to pointer cast is encountered, I still placed it in the switch prong with `.array_to_pointer`, `.no_op`, ..., (as opposed to immediately returning a none Value like for `.lval_to_rval`) as an indicator that, eventually, actually attempting to constexpr-evaluate the underlying integer expression might be desirable. E.g. with GNU extensions, expressions involving things like `&(ptr_t*)(const_int_1 + const_int_2)->member` are accepted in static_assert and friends