### PR TITLE
Preprocessor: allow some builtin functions to not expand their arguments

### DIFF
--- a/test/cases/__has_attribute.c
+++ b/test/cases/__has_attribute.c
@@ -7,4 +7,9 @@
 #  endif
 #endif
 
+#define FOO aligned
+#if !__has_attribute(FOO)
+#  error should have attribute aligned
+#endif
+
 #define EXPECTED_ERRORS "__has_attribute.c:3:8: error: attribute exists"

--- a/test/cases/__has_builtin.c
+++ b/test/cases/__has_builtin.c
@@ -7,4 +7,12 @@
 #  endif
 #endif
 
+#if __has_builtin(__has_builtin)
+#  error should not have builtin __has_builtin
+#endif
+
+#if !__has_builtin(__is_target_arch)
+#  error should have builtin __is_target_arch
+#endif
+
 #define EXPECTED_ERRORS "__has_builtin.c:3:8: error: builtin exists"

--- a/test/cases/__is_identifier.c
+++ b/test/cases/__is_identifier.c
@@ -30,5 +30,10 @@ _Static_assert(X == 1, "'foobar' should be an identifier");
 #error not enough arguments
 #endif
 
+#define FOO &
+#if !__is_identifier(FOO)
+#error FOO is an identifier
+#endif
+
 #define EXPECTED_ERRORS "__is_identifier.c:25:25: error: missing ')', after builtin feature-check macro" \
 	"__is_identifier.c:29:5: error: expected 1 argument(s) got 0"


### PR DESCRIPTION
Fixes #906