### PR TITLE
Pragma pack: improve pop behavior

### DIFF
--- a/test/cases/#pragma pack.c
+++ b/test/cases/#pragma pack.c
@@ -18,7 +18,7 @@
 #pragma pack(pop, bar)
 #pragma pack(show)
 #pragma pack(pop, foo)
-#pragma pack(show) // TODO clang says 2
+#pragma pack(show)
 #pragma pack(pop, foo)
 #pragma pack(show)
 #pragma pack(pop, foo)
@@ -31,8 +31,6 @@
 #pragma pack(push, +)
 #pragma pack(push, pop)
 
-#define TESTS_SKIPPED 1
-
 #define EXPECTED_ERRORS "pack.c:2:14: warning: value of #pragma pack(show) == 8" \
     "pack.c:4:14: warning: value of #pragma pack(show) == 4" \
     "pack.c:6:14: warning: value of #pragma pack(show) == 16" \
@@ -42,7 +40,7 @@
     "pack.c:14:14: warning: value of #pragma pack(show) == 4" \
     "pack.c:16:14: warning: value of #pragma pack(show) == 8" \
     "pack.c:19:14: warning: value of #pragma pack(show) == 16" \
-    "pack.c:21:14: warning: value of #pragma pack(show) == 4" \
+    "pack.c:21:14: warning: value of #pragma pack(show) == 2" \
     "pack.c:22:14: warning: #pragma pack(pop, ...) failed: stack empty [-Wignored-pragmas]" \
     "pack.c:23:14: warning: value of #pragma pack(show) == 2" \
     "pack.c:24:14: warning: #pragma pack(pop, ...) failed: stack empty [-Wignored-pragmas]" \

--- a/test/cases/#pragma push then pop.c
+++ b/test/cases/#pragma push then pop.c
@@ -1,0 +1,2 @@
+#pragma pack(push, 16)
+#pragma pack(pop)


### PR DESCRIPTION
1. Popping to a label clears all the items above that label in the stack
2. Only display the empty stack warning if popping an empty stack - previously it would display if the stack became empty after a pop.