### PR TITLE
Attribute: allow empty statements after fallthrough attributes

### DIFF
--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -1156,7 +1156,7 @@ pub fn applyStatementAttributes(p: *Parser, expr_start: TokenIndex, attr_buf_sta
                         try p.attr_application_buf.append(p.comp.gpa, attr);
                         break;
                     },
-                    .r_brace => {},
+                    .r_brace, .semicolon => {},
                     else => {
                         try p.err(expr_start, .invalid_fallthrough, .{});
                         break;

--- a/test/cases/compound stmt fallthrough.c
+++ b/test/cases/compound stmt fallthrough.c
@@ -5,7 +5,7 @@ int main(void) {
             __attribute__((fallthrough));
         }
         case 2: {
-            __attribute__((fallthrough));
+            __attribute__((fallthrough));;
         }
         default: {
             


### PR DESCRIPTION
Closes https://github.com/Vexu/arocc/issues/926