### PR TITLE
Once: fix use-after-free at deinit

### DIFF
--- a/src/aro/pragmas/once.zig
+++ b/src/aro/pragmas/once.zig
@@ -34,7 +34,6 @@ fn afterParse(pragma: *Pragma, _: *Compilation) void {
 fn deinit(pragma: *Pragma, comp: *Compilation) void {
     var self: *Once = @fieldParentPtr("pragma", pragma);
     self.pragma_once.deinit(comp.gpa);
-    pragma.* = undefined;
     comp.gpa.destroy(self);
 }
 


### PR DESCRIPTION
This was caught using the `std.heap.raw_c_allocator` which segfaulted at deinit with: `malloc_consolidate(): unaligned fastbin chunk detected`

Valgrind helped figure out the culprit line:

```
==1458369== Invalid write of size 8
==1458369==    at 0x123100F: aro.pragmas.once.deinit (once.zig:38)
==1458369==    by 0x11FC827: aro.Compilation.deinit (Compilation.zig:213)
==1458369==    by 0x11F8344: main.main (main.zig:51)
==1458369==    by 0x11F76EB: callMain (start.zig:709)
==1458369==    by 0x11F76EB: callMainWithArgs (start.zig:674)
==1458369==    by 0x11F76EB: main (start.zig:689)
==1458369==  Address 0x4a96230 is 48 bytes inside a block of size 96 free'd
==1458369==    at 0x484D8BF: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1458369==    by 0x16E3C60: heap.rawCFree (heap.zig:356)
==1458369==    by 0x129E477: rawFree (Allocator.zig:160)
==1458369==    by 0x129E477: mem.Allocator.destroy__anon_48635 (Allocator.zig:182)
==1458369==    by 0x1231000: aro.pragmas.once.deinit (once.zig:37)
==1458369==    by 0x11FC827: aro.Compilation.deinit (Compilation.zig:213)
==1458369==    by 0x11F8344: main.main (main.zig:51)
==1458369==    by 0x11F76EB: callMain (start.zig:709)
==1458369==    by 0x11F76EB: callMainWithArgs (start.zig:674)
==1458369==    by 0x11F76EB: main (start.zig:689)
==1458369==  Block was alloc'd at
==1458369==    at 0x484A858: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1458369==    by 0x16E3B59: heap.rawCAlloc (heap.zig:316)
==1458369==    by 0x1181B76: rawAlloc (Allocator.zig:142)
==1458369==    by 0x1181B76: mem.Allocator.allocBytesWithAlignment__anon_15633 (Allocator.zig:296)
==1458369==    by 0x1230ED8: mem.Allocator.create__anon_38055 (Allocator.zig:170)
==1458369==    by 0x1230DAF: aro.pragmas.once.init (once.zig:24)
==1458369==    by 0x11FC15B: aro.Compilation.addDefaultPragmaHandlers (Compilation.zig:2111)
==1458369==    by 0x11FBF6D: aro.Compilation.initDefault (Compilation.zig:206)
==1458369==    by 0x11F7C68: main.main (main.zig:44)
==1458369==    by 0x11F76EB: callMain (start.zig:709)
==1458369==    by 0x11F76EB: callMainWithArgs (start.zig:674)
==1458369==    by 0x11F76EB: main (start.zig:689)
```