### PR TITLE
Compilation: define macros for riscv

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -848,6 +848,10 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
                 try define(w, "__VX__");
             }
         },
+        .riscv32, .riscv32be, .riscv64, .riscv64be => {
+            try define(w, "__riscv");
+            try w.print("#define __riscv_xlen {d}\n", .{ptr_width});
+        },
         else => {},
     }
 


### PR DESCRIPTION
Needed by zig: https://codeberg.org/ziglang/zig/src/commit/76dd39d5316d302de6aa9bcab45ccb3f5a123bcb/lib/libc/include/riscv-linux-gnu/bits/wordsize.h#L19

Ref https://codeberg.org/ziglang/zig/pulls/30794