### PR TITLE
Driver: treat `-isysroot` as an alias to `--sysroot`

### DIFF
--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -664,7 +664,7 @@ pub fn parseArgs(
                     continue;
                 }
                 d.sysroot = args[i];
-            } else if (mem.startsWith(u8, arg, "-isysroot")){
+            } else if (mem.startsWith(u8, arg, "-isysroot")) {
                 var path = arg["-isysroot".len..];
                 if (path.len == 0) {
                     i += 1;


### PR DESCRIPTION
This isn't correct because `-isysroot` should only be used for finding headers, except for MacOS where it is also used for libraries if `--sysroot` isn't specified, but it shouldn't matter since we don't even have `-l` yet.