### PR TITLE
Toolchain: Darwin toolchain for SDK paths

### DIFF
--- a/include/stdint.h
+++ b/include/stdint.h
@@ -7,6 +7,29 @@
 
 # include_next <stdint.h>
 
+# if defined(__APPLE__) && __ARO_EMULATE__ == __ARO_EMULATE_NO__
+
+#  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#   define INTMAX_WIDTH   __INTMAX_WIDTH__
+#   define UINTMAX_WIDTH  __UINTMAX_WIDTH__
+#   define INTPTR_WIDTH   __INTPTR_WIDTH__
+#   define UINTPTR_WIDTH  __UINTPTR_WIDTH__
+#   define PTRDIFF_WIDTH  __PTRDIFF_WIDTH__
+#   define SIZE_WIDTH     __SIZE_WIDTH__
+#   define WCHAR_WIDTH    __WCHAR_WIDTH__
+
+#   define UINT8_WIDTH    8
+#   define UINT16_WIDTH   16
+#   define UINT32_WIDTH   32
+#   define UINT64_WIDTH   64
+#   define INT8_WIDTH     UINT8_WIDTH
+#   define INT16_WIDTH    UINT16_WIDTH
+#   define INT32_WIDTH    UINT32_WIDTH
+#   define INT64_WIDTH    UINT64_WIDTH
+#  endif
+
+# endif
+
 #else
 
 #define __stdint_int_c_cat(X, Y) X ## Y

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -7,7 +7,7 @@
 
 # include_next <stdint.h>
 
-# if defined(__APPLE__) && __ARO_EMULATE__ == __ARO_EMULATE_NO__
+# if defined(__APPLE__)
 
 #  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
 #   define INTMAX_WIDTH   __INTMAX_WIDTH__

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -1269,6 +1269,7 @@ pub fn main(d: *Driver, tc: *Toolchain, args: []const []const u8, comptime fast_
 
     tc.discover() catch |er| switch (er) {
         error.OutOfMemory => return error.OutOfMemory,
+        error.FatalError => return error.FatalError,
         error.TooManyMultilibs => return d.fatal("found more than one multilib with the same priority", .{}),
     };
     tc.defineSystemIncludes() catch |er| switch (er) {

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -1269,7 +1269,6 @@ pub fn main(d: *Driver, tc: *Toolchain, args: []const []const u8, comptime fast_
 
     tc.discover() catch |er| switch (er) {
         error.OutOfMemory => return error.OutOfMemory,
-        error.FatalError => return error.FatalError,
         error.TooManyMultilibs => return d.fatal("found more than one multilib with the same priority", .{}),
     };
     tc.defineSystemIncludes() catch |er| switch (er) {

--- a/src/aro/Toolchain.zig
+++ b/src/aro/Toolchain.zig
@@ -529,6 +529,11 @@ pub fn defineSystemIncludes(tc: *Toolchain) !void {
     };
 }
 
+pub fn addSystemIncludeDirJoined(tc: *const Toolchain, components: []const []const u8) !void {
+    const path = try std.fs.path.join(tc.driver.comp.arena, components);
+    try tc.addSystemIncludeDir(path);
+}
+
 pub fn addSystemIncludeDir(tc: *const Toolchain, path: []const u8) !void {
     const d = tc.driver;
     _ = try d.includes.append(d.comp.gpa, .{ .kind = .system, .path = try d.comp.arena.dupe(u8, path) });

--- a/src/aro/Toolchain.zig
+++ b/src/aro/Toolchain.zig
@@ -8,6 +8,7 @@ const Driver = @import("Driver.zig");
 const Multilib = @import("Driver/Multilib.zig");
 const Target = @import("Target.zig");
 const Linux = @import("toolchains/Linux.zig");
+const Darwin = @import("toolchains/Darwin.zig");
 
 pub const PathList = std.ArrayList([]const u8);
 
@@ -36,13 +37,14 @@ pub const UnwindLibKind = enum {
 
 const Inner = union(enum) {
     uninitialized,
+    darwin: Darwin,
     linux: Linux,
     unknown: void,
 
     fn deinit(self: *Inner, allocator: mem.Allocator) void {
         switch (self.*) {
             .linux => |*linux| linux.deinit(allocator),
-            .uninitialized, .unknown => {},
+            .darwin, .uninitialized, .unknown => {},
         }
     }
 };
@@ -72,7 +74,7 @@ fn getDefaultLinker(tc: *const Toolchain) []const u8 {
     return switch (tc.inner) {
         .uninitialized => unreachable,
         .linux => |linux| linux.getDefaultLinker(tc.getTarget()),
-        .unknown => "ld",
+        .darwin, .unknown => "ld",
     };
 }
 
@@ -93,11 +95,15 @@ pub fn discover(tc: *Toolchain) !void {
             .{ .unknown = {} } // TODO
         else
             .{ .linux = .{} },
-        else => .{ .unknown = {} }, // TODO
+        else => if (target.os.tag.isDarwin())
+            .{ .darwin = .{ .sdk = .fromTarget(tc.getTarget().*) } }
+        else
+            .{ .unknown = {} }, // TODO
     };
     return switch (tc.inner) {
         .uninitialized => unreachable,
         .linux => |*linux| linux.discover(tc),
+        .darwin => |*darwin| try darwin.discover(tc),
         .unknown => {},
     };
 }
@@ -357,7 +363,7 @@ pub fn buildLinkerArgs(tc: *Toolchain, argv: *std.ArrayList([]const u8)) !void {
     return switch (tc.inner) {
         .uninitialized => unreachable,
         .linux => |*linux| linux.buildLinkerArgs(tc, argv),
-        .unknown => @panic("This toolchain does not support linking yet"),
+        .darwin, .unknown => @panic("This toolchain does not support linking yet"),
     };
 }
 
@@ -509,6 +515,7 @@ pub fn defineSystemIncludes(tc: *Toolchain) !void {
     return switch (tc.inner) {
         .uninitialized => unreachable,
         .linux => |*linux| linux.defineSystemIncludes(tc),
+        .darwin => |*darwin| darwin.defineSystemIncludes(tc),
         .unknown => {
             if (tc.driver.nostdinc) return;
 

--- a/src/aro/Toolchain.zig
+++ b/src/aro/Toolchain.zig
@@ -103,8 +103,7 @@ pub fn discover(tc: *Toolchain) !void {
     return switch (tc.inner) {
         .uninitialized => unreachable,
         .linux => |*linux| linux.discover(tc),
-        .darwin => |*darwin| try darwin.discover(tc),
-        .unknown => {},
+        .darwin, .unknown => {},
     };
 }
 

--- a/src/aro/toolchains/Darwin.zig
+++ b/src/aro/toolchains/Darwin.zig
@@ -1,0 +1,150 @@
+const Target = @import("../Target.zig");
+const Toolchain = @import("../Toolchain.zig");
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const Darwin = @This();
+
+sdk: Sdk,
+sdk_path: ?[]const u8 = null,
+
+pub fn discover(darwin: *Darwin, tc: *Toolchain) !void {
+    if (tc.driver.sysroot) |sysroot| {
+        darwin.sdk_path = sysroot;
+    } else if (builtin.target.os.tag.isDarwin()) {
+        try tc.driver.diagnostics.add(.{ .kind = .note, .text = "--sysroot may be required when cross-compiling to Darwin targets", .location = null });
+    } else {
+        darwin.sdk_path = try darwin.sdk.xcrun(tc, "--show-sdk-path");
+    }
+}
+
+// clang args (via --verbose):
+// -resource-dir <toolchain-path>/usr/lib/clang/21
+// -isysroot <sdk-path>
+// -I/usr/local/include
+// -internal-isystem <sdk-path>/usr/local/include
+// -internal-isystem <toolchain-path>/usr/lib/clang/21/include
+// -internal-externc-isystem <sdk-path>/usr/include
+// -internal-externc-isystem <toolchain-path>/usr/include
+// -internal-iframework <sdk-path>/System/Library/Frameworks
+// -internal-iframework <sdk-path>/System/Library/SubFrameworks
+// -internal-iframework <sdk-path>/Library/Frameworks
+//
+// clang messages (via -E):
+// ignoring nonexistent directory "/usr/local/include"
+// ignoring nonexistent directory "<sdk-path>/usr/local/include"
+// ignoring nonexistent directory "<sdk-path>/Library/Frameworks"
+// #include "..." search starts here:
+// #include <...> search starts here:
+//  <toolchain-path>/usr/lib/clang/21/include
+//  <sdk-path>/usr/include
+//  <toolchain-path>/usr/include
+//  <sdk-path>/System/Library/Frameworks (framework directory)
+//  <sdk-path>/System/Library/SubFrameworks (framework directory)
+pub fn defineSystemIncludes(self: *Darwin, tc: *Toolchain) !void {
+    if (tc.driver.nostdinc) return;
+
+    var effective = self.*;
+    if (tc.driver.nostdlibinc) {
+        effective = .{ .sdk = self.sdk };
+    } else {
+        // -I/usr/local/include
+        try tc.addPathIfExists(&.{ "usr", "local", "include" }, .file);
+    }
+
+    // -internal-isystem <sdk-path>/usr/local/include
+    if (effective.sdk_path) |sdk| try tc.addPathIfExists(&.{ sdk, "usr", "local", "include" }, .file);
+    // -internal-isystem <toolchain-path>/usr/lib/clang/21/include but aro
+    if (!tc.driver.nobuiltininc) try tc.addBuiltinIncludeDir();
+
+    // -internal-externc-isystem <sdk-path>/usr/include
+    if (effective.sdk_path) |sdk| try tc.addPathIfExists(&.{ sdk, "usr", "include" }, .file);
+    // <toolchain-path>/usr/include is unnecessary - it's FlexLexer.h, libcodedirectory.h, and swift bridging
+}
+
+const Sdk = union(enum) {
+    driverkit,
+    iphoneos,
+    iphonesimulator,
+    macosx: packed struct { catalyst: bool },
+    appletvos,
+    appletvsimulator,
+    xros,
+    xrsimulator,
+    watchos,
+    watchsimulator,
+
+    pub fn fromTarget(target: Target) Sdk {
+        return switch (target.os.tag) {
+            .driverkit => .driverkit,
+            .ios => if (target.abi == .simulator) .iphonesimulator else .iphoneos,
+            .maccatalyst => .{ .macosx = .{ .catalyst = true } },
+            .macos => .{ .macosx = .{ .catalyst = false } },
+            .tvos => if (target.abi == .simulator) .appletvsimulator else .appletvos,
+            .watchos => if (target.abi == .simulator) .watchsimulator else .watchos,
+            else => {
+                std.debug.assert(!target.os.tag.isDarwin());
+                unreachable;
+            },
+        };
+    }
+
+    fn xcrun(sdk: Sdk, tc: *Toolchain, arg: []const u8) !?[]const u8 {
+        const arena = tc.driver.comp.arena;
+        const gpa = tc.driver.comp.gpa;
+
+        var message_writer = std.Io.Writer.Allocating.init(gpa);
+        defer message_writer.deinit();
+        const msg: *std.Io.Writer = &message_writer.writer;
+
+        msg.print("`xcrun --sdk {t} {s}` ", .{ sdk, arg }) catch return error.OutOfMemory;
+        const msg_reset = msg.end;
+
+        const result = std.process.run(tc.driver.comp.gpa, tc.driver.comp.io, .{
+            .argv = &.{ "xcrun", "--sdk", @tagName(sdk), arg },
+        }) catch |err| {
+            msg.print("failed to run: {t}", .{err}) catch return error.OutOfMemory;
+            return null;
+        };
+        defer gpa.free(result.stderr);
+        defer gpa.free(result.stdout);
+
+        if (result.term != .exited) {
+            msg.print("stopped unexpectedly: {}\n{s}", .{ result.term, result.stderr }) catch return error.OutOfMemory;
+            try tc.driver.diagnostics.add(.{ .kind = .@"error", .text = try arena.dupe(u8, msg.buffered()), .location = null });
+            return null;
+        } else if (result.term.exited != 0) {
+            msg.print("exited with exit code {d}\n{s}", .{ result.term.exited, result.stderr }) catch return error.OutOfMemory;
+            try tc.driver.diagnostics.add(.{ .kind = .@"error", .text = try arena.dupe(u8, msg.buffered()), .location = null });
+            return null;
+        } else if (result.stderr.len > 0) {
+            msg.print("stderr:\n{s}", .{result.stderr}) catch return error.OutOfMemory;
+            try tc.driver.diagnostics.add(.{ .kind = .warning, .text = try arena.dupe(u8, msg.buffered()), .location = null });
+            msg.end = msg_reset;
+        }
+
+        const nl = std.mem.indexOfScalar(u8, result.stdout, '\n');
+        if (nl == null or nl.? == 0) {
+            msg.writeAll("had no output") catch return error.OutOfMemory;
+            try tc.driver.diagnostics.add(.{ .kind = .@"error", .text = "had no output", .location = null });
+            return null;
+        }
+
+        if (result.stdout[nl.? + 1 ..].len > 0) {
+            msg.print("had unexpected output:\n{s}", .{result.stdout}) catch return error.OutOfMemory;
+            try tc.driver.diagnostics.add(.{ .kind = .@"error", .text = try arena.dupe(u8, msg.buffered()), .location = null });
+            return null;
+        }
+
+        const path = result.stdout[0..nl.?];
+
+        if (!tc.exists(path)) {
+            msg.print("returned non-existent path '{s}'", .{path}) catch return error.OutOfMemory;
+            try tc.driver.diagnostics.add(.{ .kind = .warning, .text = try arena.dupe(u8, msg.buffered()), .location = null });
+            msg.end = msg_reset;
+        }
+
+        return try arena.dupe(u8, path);
+    }
+};

--- a/src/aro/toolchains/Darwin.zig
+++ b/src/aro/toolchains/Darwin.zig
@@ -9,58 +9,25 @@ const Darwin = @This();
 sdk: Sdk,
 sdk_path: ?[]const u8 = null,
 
-pub fn discover(darwin: *Darwin, tc: *Toolchain) !void {
-    if (tc.driver.sysroot) |sysroot| {
-        darwin.sdk_path = sysroot;
-    } else if (builtin.target.os.tag.isDarwin()) {
-        try tc.driver.diagnostics.add(.{ .kind = .note, .text = "--sysroot may be required when cross-compiling to Darwin targets", .location = null });
-    } else {
-        darwin.sdk_path = try darwin.sdk.xcrun(tc, "--show-sdk-path");
-    }
-}
-
-// clang args (via --verbose):
-// -resource-dir <toolchain-path>/usr/lib/clang/21
-// -isysroot <sdk-path>
-// -I/usr/local/include
-// -internal-isystem <sdk-path>/usr/local/include
-// -internal-isystem <toolchain-path>/usr/lib/clang/21/include
-// -internal-externc-isystem <sdk-path>/usr/include
-// -internal-externc-isystem <toolchain-path>/usr/include
-// -internal-iframework <sdk-path>/System/Library/Frameworks
-// -internal-iframework <sdk-path>/System/Library/SubFrameworks
-// -internal-iframework <sdk-path>/Library/Frameworks
-//
-// clang messages (via -E):
-// ignoring nonexistent directory "/usr/local/include"
-// ignoring nonexistent directory "<sdk-path>/usr/local/include"
-// ignoring nonexistent directory "<sdk-path>/Library/Frameworks"
-// #include "..." search starts here:
-// #include <...> search starts here:
-//  <toolchain-path>/usr/lib/clang/21/include
-//  <sdk-path>/usr/include
-//  <toolchain-path>/usr/include
-//  <sdk-path>/System/Library/Frameworks (framework directory)
-//  <sdk-path>/System/Library/SubFrameworks (framework directory)
 pub fn defineSystemIncludes(self: *Darwin, tc: *Toolchain) !void {
     if (tc.driver.nostdinc) return;
 
-    var effective = self.*;
-    if (tc.driver.nostdlibinc) {
-        effective = .{ .sdk = self.sdk };
-    } else {
-        // -I/usr/local/include
+    if (!tc.driver.nostdlibinc) {
+        if (tc.driver.sysroot) |sysroot| {
+            self.sdk_path = sysroot;
+        } else if (builtin.target.os.tag.isDarwin()) {
+            std.debug.assert(tc.getTarget().os.tag.isDarwin());
+            try tc.driver.diagnostics.add(.{ .kind = .note, .text = "--sysroot may be required when cross-compiling to Darwin targets", .location = null });
+        } else {
+            self.sdk_path = try self.sdk.xcrun(tc, "--show-sdk-path");
+        }
         try tc.addPathIfExists(&.{ "usr", "local", "include" }, .file);
     }
 
-    // -internal-isystem <sdk-path>/usr/local/include
-    if (effective.sdk_path) |sdk| try tc.addPathIfExists(&.{ sdk, "usr", "local", "include" }, .file);
-    // -internal-isystem <toolchain-path>/usr/lib/clang/21/include but aro
+    if (self.sdk_path) |sdk| try tc.addPathIfExists(&.{ sdk, "usr", "local", "include" }, .file);
     if (!tc.driver.nobuiltininc) try tc.addBuiltinIncludeDir();
 
-    // -internal-externc-isystem <sdk-path>/usr/include
-    if (effective.sdk_path) |sdk| try tc.addPathIfExists(&.{ sdk, "usr", "include" }, .file);
-    // <toolchain-path>/usr/include is unnecessary - it's FlexLexer.h, libcodedirectory.h, and swift bridging
+    if (self.sdk_path) |sdk| try tc.addPathIfExists(&.{ sdk, "usr", "include" }, .file);
 }
 
 const Sdk = union(enum) {
@@ -94,55 +61,45 @@ const Sdk = union(enum) {
         const arena = tc.driver.comp.arena;
         const gpa = tc.driver.comp.gpa;
 
-        var message_writer = std.Io.Writer.Allocating.init(gpa);
-        defer message_writer.deinit();
-        const msg: *std.Io.Writer = &message_writer.writer;
-
-        msg.print("`xcrun --sdk {t} {s}` ", .{ sdk, arg }) catch return error.OutOfMemory;
-        const msg_reset = msg.end;
+        var pretty_cmd_buf: [128]u8 = undefined;
+        var pretty_cmd_writer = std.Io.Writer.fixed(&pretty_cmd_buf);
+        pretty_cmd_writer.print("`xcrun --sdk {t} {s}`", .{ sdk, arg }) catch unreachable;
+        const pretty_cmd = pretty_cmd_writer.buffered();
 
         const result = std.process.run(tc.driver.comp.gpa, tc.driver.comp.io, .{
             .argv = &.{ "xcrun", "--sdk", @tagName(sdk), arg },
         }) catch |err| {
-            msg.print("failed to run: {t}", .{err}) catch return error.OutOfMemory;
+            try tc.driver.err("{s} failed to run: {t}", .{ pretty_cmd, err });
             return null;
         };
         defer gpa.free(result.stderr);
         defer gpa.free(result.stdout);
 
         if (result.term != .exited) {
-            msg.print("stopped unexpectedly: {}\n{s}", .{ result.term, result.stderr }) catch return error.OutOfMemory;
-            try tc.driver.diagnostics.add(.{ .kind = .@"error", .text = try arena.dupe(u8, msg.buffered()), .location = null });
+            try tc.driver.err("{s} stopped unexpectedly: {}\n{s}", .{ pretty_cmd, result.term, result.stderr });
             return null;
         } else if (result.term.exited != 0) {
-            msg.print("exited with exit code {d}\n{s}", .{ result.term.exited, result.stderr }) catch return error.OutOfMemory;
-            try tc.driver.diagnostics.add(.{ .kind = .@"error", .text = try arena.dupe(u8, msg.buffered()), .location = null });
+            try tc.driver.err("{s} exited with exit code {d}\n{s}", .{ pretty_cmd, result.term.exited, result.stderr });
             return null;
         } else if (result.stderr.len > 0) {
-            msg.print("stderr:\n{s}", .{result.stderr}) catch return error.OutOfMemory;
-            try tc.driver.diagnostics.add(.{ .kind = .warning, .text = try arena.dupe(u8, msg.buffered()), .location = null });
-            msg.end = msg_reset;
+            try tc.driver.err("{s} stderr:\n{s}", .{ pretty_cmd, result.stderr });
         }
 
         const nl = std.mem.indexOfScalar(u8, result.stdout, '\n');
         if (nl == null or nl.? == 0) {
-            msg.writeAll("had no output") catch return error.OutOfMemory;
-            try tc.driver.diagnostics.add(.{ .kind = .@"error", .text = "had no output", .location = null });
+            try tc.driver.err("{s} had no output", .{pretty_cmd});
             return null;
         }
 
         if (result.stdout[nl.? + 1 ..].len > 0) {
-            msg.print("had unexpected output:\n{s}", .{result.stdout}) catch return error.OutOfMemory;
-            try tc.driver.diagnostics.add(.{ .kind = .@"error", .text = try arena.dupe(u8, msg.buffered()), .location = null });
+            try tc.driver.err("{s} had unexpected output:\n{s}", .{ pretty_cmd, result.stdout });
             return null;
         }
 
         const path = result.stdout[0..nl.?];
 
         if (!tc.exists(path)) {
-            msg.print("returned non-existent path '{s}'", .{path}) catch return error.OutOfMemory;
-            try tc.driver.diagnostics.add(.{ .kind = .warning, .text = try arena.dupe(u8, msg.buffered()), .location = null });
-            msg.end = msg_reset;
+            try tc.driver.err("{s} returned non-existent path '{s}'", .{ pretty_cmd, path });
         }
 
         return try arena.dupe(u8, path);

--- a/src/aro/toolchains/Darwin.zig
+++ b/src/aro/toolchains/Darwin.zig
@@ -16,18 +16,19 @@ pub fn defineSystemIncludes(self: *Darwin, tc: *Toolchain) !void {
         if (tc.driver.sysroot) |sysroot| {
             self.sdk_path = sysroot;
         } else if (builtin.target.os.tag.isDarwin()) {
+            self.sdk_path = try self.sdk.xcrun(tc, "--show-sdk-path");
+        } else {
             std.debug.assert(tc.getTarget().os.tag.isDarwin());
             try tc.driver.diagnostics.add(.{ .kind = .note, .text = "--sysroot may be required when cross-compiling to Darwin targets", .location = null });
-        } else {
-            self.sdk_path = try self.sdk.xcrun(tc, "--show-sdk-path");
         }
-        try tc.addPathIfExists(&.{ "usr", "local", "include" }, .file);
+
+        try tc.addSystemIncludeDirJoined(&.{ "usr", "local", "include" });
     }
 
-    if (self.sdk_path) |sdk| try tc.addPathIfExists(&.{ sdk, "usr", "local", "include" }, .file);
+    if (self.sdk_path) |sdk| try tc.addSystemIncludeDirJoined(&.{ sdk, "usr", "local", "include" });
     if (!tc.driver.nobuiltininc) try tc.addBuiltinIncludeDir();
 
-    if (self.sdk_path) |sdk| try tc.addPathIfExists(&.{ sdk, "usr", "include" }, .file);
+    if (self.sdk_path) |sdk| try tc.addSystemIncludeDirJoined(&.{ sdk, "usr", "include" });
 }
 
 const Sdk = union(enum) {
@@ -69,17 +70,23 @@ const Sdk = union(enum) {
         const result = std.process.run(tc.driver.comp.gpa, tc.driver.comp.io, .{
             .argv = &.{ "xcrun", "--sdk", @tagName(sdk), arg },
         }) catch |err| {
-            try tc.driver.err("{s} failed to run: {t}", .{ pretty_cmd, err });
+            try tc.driver.err("{s} failed to run: {s}", .{ pretty_cmd, @errorName(err) });
             return null;
         };
         defer gpa.free(result.stderr);
         defer gpa.free(result.stdout);
 
         if (result.term != .exited) {
-            try tc.driver.err("{s} stopped unexpectedly: {}\n{s}", .{ pretty_cmd, result.term, result.stderr });
+            var aw = std.Io.Writer.Allocating.init(gpa);
+            defer aw.deinit();
+            aw.writer.print("{any}", .{result.term}) catch return error.OutOfMemory;
+            try tc.driver.err("{s} stopped unexpectedly: {}\n{s}", .{ pretty_cmd, aw.writer.buffered(), result.stderr });
             return null;
         } else if (result.term.exited != 0) {
-            try tc.driver.err("{s} exited with exit code {d}\n{s}", .{ pretty_cmd, result.term.exited, result.stderr });
+            var aw = std.Io.Writer.Allocating.init(gpa);
+            defer aw.deinit();
+            aw.writer.print("{any}", .{result.term.exited}) catch return error.OutOfMemory;
+            try tc.driver.err("{s} exited with exit code {d}\n{s}", .{ pretty_cmd, aw.writer.buffered(), result.stderr });
             return null;
         } else if (result.stderr.len > 0) {
             try tc.driver.err("{s} stderr:\n{s}", .{ pretty_cmd, result.stderr });

--- a/test/cases/hello world.c
+++ b/test/cases/hello world.c
@@ -1,4 +1,9 @@
+#if defined(__linux) || defined(__APPLE__)
+#include <stdio.h>
+#else
 extern int printf(const char*, ...);
+#endif
+
 static int foo(void);
 
 int main(int argc, char **argv) {

--- a/test/runner.zig
+++ b/test/runner.zig
@@ -199,6 +199,7 @@ fn runCaseExtra(
                     _ = mem.find(u8, msg, "error: ") orelse
                         mem.find(u8, msg, "warning: ") orelse
                         mem.find(u8, msg, "note: ") orelse continue;
+                    if (mem.eql(u8, msg, "note: --sysroot may be required when cross-compiling to Darwin targets")) continue;
 
                     try actual_errors.append(gpa, msg);
                 }


### PR DESCRIPTION
as i'm working on objective-c support (per #970), i've realized that support is somewhat blocked on fetching the SDK path for the target platform - specifically, for objc headers, which i believe are implicitly included in Objective-C files.

this PR adds a new `toolchains/Darwin.zig` file for Darwin-specific target behavior. Right now, this is only used to:
1. add the SDK library path (`$SDKROOT/usr/lib`)
2. add the SDK include path (`$SDKROOT/usr/include`)

In a future PR, this file will be expanded to add the SDK framework path (`$SDKROOT/System/Library/Frameworks`)