### PR TITLE
update to zig version 0.16.0-dev.3006+94355f192

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
 
     .fingerprint = 0x76501fb842f52025, // Changing this has security and trust implications.
 
-    .minimum_zig_version = "0.16.0-dev.2905+5d71e3051",
+    .minimum_zig_version = "0.16.0-dev.3006+94355f192",
 
     .dependencies = .{},
 

--- a/src/aro/Target.zig
+++ b/src/aro/Target.zig
@@ -1230,6 +1230,7 @@ pub fn toLLVMTriple(target: *const Target, buf: []u8) []const u8 {
         .other,
         .plan9,
         .vita,
+        .psp,
         => "unknown",
     };
     writer.writeAll(llvm_os) catch unreachable;


### PR DESCRIPTION
[`fdf19984`](https://codeberg.org/ziglang/zig/commit/fdf19984b8af9781cd68dda3fcbcc44ac8ade80e) added support for PSP OS in Zig, which [isn't recognized by LLVM](https://github.com/llvm/llvm-project/blob/16e06589e963aadced8a5afeeaa2ec2a95d0a483/llvm/include/llvm/TargetParser/Triple.h#L208-L260)