### PR TITLE
Fix regression in checking if qt is a pointer

### DIFF
--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -2841,7 +2841,10 @@ pub const Builder = struct {
         }
 
         // We can't use `qt.isPointer()` because `qt` might contain a `.declarator_combine`.
-        const is_pointer = qt.isAutoType() or qt.isC23Auto() or qt.base(b.parser.comp).type == .pointer;
+        const is_pointer = qt.isAutoType() or qt.isC23Auto() or switch (qt.base(b.parser.comp).type) {
+            .array, .pointer => true,
+            else => false,
+        };
 
         if (b.unaligned != null and !is_pointer) {
             result_qt = (try b.parser.comp.type_store.put(gpa, .{ .attributed = .{

--- a/test/cases/ast/msvc attribute keywords.c
+++ b/test/cases/ast/msvc attribute keywords.c
@@ -27,7 +27,7 @@ function: 'attributed(kr (...) *int)'
  attr: calling_convention cc: stdcall
  name: bar
 
-function: 'fn (decayed *[]attributed(int), decayed *attributed([]int)) int'
+function: 'fn (decayed *[]attributed(int), decayed *[]int) int'
  name: baz
 
 function: 'fn (fn_ptr: *fn () void) void'

--- a/test/cases/ast/nullability.c
+++ b/test/cases/ast/nullability.c
@@ -44,3 +44,6 @@ struct_decl: 'struct __sFILE'
 typedef: 'struct __sFILE'
  name: FILE
 
+function: 'fn (attributed(decayed *[2]int)) void'
+ name: f
+

--- a/test/cases/nullability.c
+++ b/test/cases/nullability.c
@@ -11,6 +11,8 @@ typedef	struct __sFILE {
 	int	(* _Nullable _close)(void *);
 } FILE;
 
+void f(int [_Nullable 2]);
+
 /** manifest:
 syntax
 args = --target=x86_64-linux-gnu


### PR DESCRIPTION
Nullability annotations on array parameters now work again.

Please point me to where I should add tests for this.

Closes #989.