### PR TITLE
Parser: fix pointer index post increment

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -8732,7 +8732,6 @@ fn unExpr(p: *Parser) Error!?Result {
             if (operand.qt.get(p.comp, .pointer)) |pointer| {
                 try p.checkPtrArithmeticAllowed(pointer, p.tok_i, operand.node);
             }
-            try operand.usualUnaryConversion(p, tok);
 
             if (operand.val.is(.int, p.comp) or operand.val.is(.int, p.comp)) {
                 if (try operand.val.add(operand.val, .one, operand.qt, p.comp))
@@ -8763,7 +8762,6 @@ fn unExpr(p: *Parser) Error!?Result {
             if (operand.qt.get(p.comp, .pointer)) |pointer| {
                 try p.checkPtrArithmeticAllowed(pointer, p.tok_i, operand.node);
             }
-            try operand.usualUnaryConversion(p, tok);
 
             if (operand.val.is(.int, p.comp) or operand.val.is(.int, p.comp)) {
                 if (try operand.val.decrement(operand.val, operand.qt, p.comp))
@@ -9110,7 +9108,6 @@ fn suffixExpr(p: *Parser, lhs: Result) Error!?Result {
             if (operand.qt.get(p.comp, .pointer)) |pointer| {
                 try p.checkPtrArithmeticAllowed(pointer, p.tok_i, operand.node);
             }
-            try operand.usualUnaryConversion(p, p.tok_i);
 
             try operand.un(p, .post_inc_expr, p.tok_i);
             return operand;
@@ -9134,7 +9131,6 @@ fn suffixExpr(p: *Parser, lhs: Result) Error!?Result {
             if (operand.qt.get(p.comp, .pointer)) |pointer| {
                 try p.checkPtrArithmeticAllowed(pointer, p.tok_i, operand.node);
             }
-            try operand.usualUnaryConversion(p, p.tok_i);
 
             try operand.un(p, .post_dec_expr, p.tok_i);
             return operand;

--- a/test/cases/ast/pointer index post increment.c
+++ b/test/cases/ast/pointer index post increment.c
@@ -1,0 +1,37 @@
+implicit typedef: '__int128'
+ name: __int128_t
+
+implicit typedef: 'unsigned __int128'
+ name: __uint128_t
+
+implicit typedef: '*char'
+ name: __builtin_ms_va_list
+
+implicit typedef: '[1]struct __va_list_tag'
+ name: __builtin_va_list
+
+implicit typedef: 'struct __NSConstantString_tag'
+ name: __NSConstantString
+
+implicit typedef: 'long double'
+ name: __float80
+
+function: 'fn () void'
+ name: foo
+ body:
+  compound_stmt
+    variable: '*unsigned short'
+     name: ptr
+
+    post_inc_expr: 'unsigned short'
+     operand:
+      array_access_expr: 'unsigned short' lvalue
+       base:
+        implicit cast: (lval_to_rval) '*unsigned short'
+          decl_ref_expr: '*unsigned short' lvalue
+           name: ptr
+       index:
+        int_literal: 'int' (value: 0)
+
+    implicit return_stmt: 'void'
+

--- a/test/cases/pointer index post increment.c
+++ b/test/cases/pointer index post increment.c
@@ -1,0 +1,9 @@
+void foo(void) {
+    unsigned short *ptr;
+    ptr[0]++;
+}
+
+/** manifest:
+syntax
+args = --target=x86_64-linux
+*/


### PR DESCRIPTION
closes [330](https://codeberg.org/ziglang/translate-c/issues/330) by applying suggested patch from Vexu

removes unExpr/suffixExpr casts