### PR TITLE
Improve clang compat in __is_target and add some more test cases

### DIFF
--- a/src/aro/Target.zig
+++ b/src/aro/Target.zig
@@ -878,16 +878,14 @@ test parseArchName {
 pub fn parseOsName(query: []const u8) ?Os.Tag {
     var buf: [64]u8 = undefined;
     const lower = toLower(query, &buf) orelse return null;
-    
-    return std.meta.stringToEnum(Os.Tag, lower) orelse std.StaticStringMap(Os.Tag).initComptime(.{
-        .{ "darwin", .macos },
-        .{ "macosx", .macos },
-        .{ "tvos", .tvos },
-        .{ "visionos", .visionos },
-        .{ "watchos", .watchos },
-        .{ "win32", .windows },
-        .{ "xros", .visionos },
-    }).get(lower) orelse return null;
+
+    return std.meta.stringToEnum(Os.Tag, lower) orelse
+        std.StaticStringMap(Os.Tag).initComptime(.{
+            .{ "darwin", .macos },
+            .{ "macosx", .macos },
+            .{ "win32", .windows },
+            .{ "xros", .visionos },
+        }).get(lower) orelse return null;
 }
 
 pub fn isOs(target: *const Target, query_str: []const u8) bool {

--- a/src/aro/Target.zig
+++ b/src/aro/Target.zig
@@ -878,7 +878,6 @@ test parseArchName {
 pub fn parseOsName(query: []const u8) ?Os.Tag {
     var buf: [64]u8 = undefined;
     const lower = toLower(query, &buf) orelse return null;
-
     return std.meta.stringToEnum(Os.Tag, lower) orelse
         std.StaticStringMap(Os.Tag).initComptime(.{
             .{ "darwin", .macos },

--- a/src/aro/Target.zig
+++ b/src/aro/Target.zig
@@ -867,23 +867,29 @@ test parseArchName {
 pub fn parseOsName(query: []const u8) ?Os.Tag {
     var buf: [64]u8 = undefined;
     const lower = toLower(query, &buf) orelse return null;
-    return std.meta.stringToEnum(Os.Tag, lower) orelse
-        std.StaticStringMap(Os.Tag).initComptime(.{
-            .{ "darwin", .macos },
-            .{ "macosx", .macos },
-            .{ "win32", .windows },
-            .{ "xros", .visionos },
-        }).get(lower) orelse return null;
+    
+    return std.meta.stringToEnum(Os.Tag, lower) orelse std.StaticStringMap(Os.Tag).initComptime(.{
+        .{ "darwin", .macos },
+        .{ "macosx", .macos },
+        .{ "tvos", .tvos },
+        .{ "visionos", .visionos },
+        .{ "watchos", .watchos },
+        .{ "win32", .windows },
+        .{ "xros", .visionos },
+    }).get(lower) orelse return null;
 }
 
-pub fn isOs(target: *const Target, query: []const u8) bool {
-    const parsed = parseOsName(query) orelse return false;
-
-    if (parsed.isDarwin()) {
-        // clang treats all darwin OS's as equivalent
-        return target.os.tag.isDarwin();
+pub fn isOs(target: *const Target, query_str: []const u8) bool {
+    var query: std.Target.Query = .{};
+    parseOs(&query, query_str, null) catch return false;
+    if (query.os_tag) |tag| {
+        if (tag.isDarwin()) {
+            // clang treats all darwin OS's as equivalent
+            return target.os.tag.isDarwin();
+        }
+        return target.os.tag == tag;
     }
-    return parsed == target.os.tag;
+    return false;
 }
 
 pub fn parseVendorName(query: []const u8) ?Vendor {
@@ -1645,6 +1651,32 @@ test parseAbi {
     try testing.expect(query.abi == .ilp32);
 }
 
+/// Version of `std.Target.Query.parseVersion`, but with following changes:
+/// * Supports only 1, 2 or 3 version components (major, minor, [patch]). If 2nd or 3rd component is omitted, it will be 0.
+pub fn parseVersion(ver: []const u8) error{ InvalidVersion, Overflow }!std.SemanticVersion {
+    const parseVersionComponentFn = (struct {
+        fn parseVersionComponentInner(component: []const u8) error{ InvalidVersion, Overflow }!usize {
+            return std.fmt.parseUnsigned(usize, component, 10) catch |err| switch (err) {
+                error.InvalidCharacter => return error.InvalidVersion,
+                error.Overflow => |e| return e,
+            };
+        }
+    }).parseVersionComponentInner;
+
+    var version_components = mem.splitScalar(u8, ver, '.');
+
+    const major = version_components.first();
+    const minor = version_components.next() orelse "0";
+    const patch = version_components.next() orelse "0";
+    if (version_components.next() != null) return error.InvalidVersion;
+
+    return .{
+        .major = try parseVersionComponentFn(major),
+        .minor = try parseVersionComponentFn(minor),
+        .patch = try parseVersionComponentFn(patch),
+    };
+}
+
 /// Parse OS string with common aliases in `<os>(.?<version>(...<version>))?` format.
 ///
 /// `native` <os> results in `builtin.os.tag`.
@@ -1679,6 +1711,7 @@ pub fn parseOs(result: *std.Target.Query, text: []const u8, version_string: ?*[]
             }
         },
     } else .{ checkOs(text) orelse return error.UnknownOs, "" };
+
     result.os_tag = tag;
     if (version_string) |ptr| ptr.* = version_text;
 
@@ -1687,13 +1720,13 @@ pub fn parseOs(result: *std.Target.Query, text: []const u8, version_string: ?*[]
         .semver, .hurd, .linux => {
             var range_it = mem.splitSequence(u8, version_text, "...");
             result.os_version_min = .{
-                .semver = std.Target.Query.parseVersion(range_it.first()) catch |er| switch (er) {
+                .semver = parseVersion(range_it.first()) catch |er| switch (er) {
                     error.Overflow, error.InvalidVersion => return error.InvalidOsVersion,
                 },
             };
             if (range_it.next()) |v| {
                 result.os_version_max = .{
-                    .semver = std.Target.Query.parseVersion(v) catch |er| switch (er) {
+                    .semver = parseVersion(v) catch |er| switch (er) {
                         error.Overflow, error.InvalidVersion => return error.InvalidOsVersion,
                     },
                 };
@@ -1749,4 +1782,12 @@ test parseOs {
     try parseOs(&query, "win32.win10", null);
     try testing.expect(query.os_tag == .windows);
     try testing.expectEqual(query.os_version_min, V{ .windows = .win10 });
+
+    try parseOs(&query, "ios17", null);
+    try testing.expect(query.os_tag == .ios);
+    try testing.expectEqual(query.os_version_min, V{ .semver = .{ .major = 17, .minor = 0, .patch = 0 } });
+
+    try parseOs(&query, "darwin26", null);
+    try testing.expect(query.os_tag == .macos);
+    try testing.expectEqual(query.os_version_min, V{ .semver = .{ .major = 26, .minor = 0, .patch = 0 } });
 }

--- a/test/cases/__is_target_clang_compat.c
+++ b/test/cases/__is_target_clang_compat.c
@@ -1,0 +1,84 @@
+// This file it based on https://github.com/llvm/llvm-project/blob/main/clang/test/Preprocessor/is_target.c
+
+#if !__is_target_arch(x86_64) || !__is_target_arch(X86_64)
+#error "mismatching arch"
+#endif
+
+#if __is_target_arch(arm64)
+#error "mismatching arch"
+#endif
+
+// Silently ignore invalid archs. This will ensure that older compilers will
+// accept headers that support new arches/vendors/os variants.
+#if __is_target_arch(foo)
+#error "invalid arch"
+#endif
+
+#if !__is_target_vendor(apple) || !__is_target_vendor(APPLE)
+#error "mismatching vendor"
+#endif
+
+#if __is_target_vendor(unknown)
+#error "mismatching vendor"
+#endif
+
+#if __is_target_vendor(foo)
+#error "invalid vendor"
+#endif
+
+#if !__is_target_os(darwin) || !__is_target_os(DARWIN)
+#error "mismatching os"
+#endif
+
+// When Zig supports the OS tag `darwin`, we can make this work.
+// #if __is_target_os(ios)
+// #error "mismatching os"
+// #endif
+
+#if __is_target_os(foo)
+#error "invalid os"
+#endif
+
+#if !__is_target_environment(simulator) || !__is_target_environment(SIMULATOR)
+#error "mismatching environment"
+#endif
+
+#if __is_target_environment(unknown)
+#error "mismatching environment"
+#endif
+
+#if __is_target_environment(foo)
+#error "invalid environment"
+#endif
+
+#if !__has_builtin(__is_target_arch) || !__has_builtin(__is_target_os) || !__has_builtin(__is_target_vendor) || !__has_builtin(__is_target_environment)
+#error "has builtin doesn't work"
+#endif
+
+#if __is_target_arch(11)
+#error "invalid arch"
+#endif
+
+#if __is_target_arch x86
+#error "invalid arch"
+#endif
+
+#if __is_target_arch ( x86
+#error "invalid arch"
+#endif
+
+#if __is_target_environment(macabi)
+#error
+#endif
+
+
+
+/** manifest:
+expand_error
+args = --target=x86_64-apple-darwin-simulator
+
+__is_target_clang_compat.c:58:22: error: builtin feature check macro requires a parenthesized identifier
+__is_target_clang_compat.c:62:5: error: Missing '(' after built-in macro '__is_target_arch'
+__is_target_clang_compat.c:66:5: error: unterminated function macro argument list
+__is_target_clang_compat.c:67:27: error: expected value in expression
+*/

--- a/test/cases/__is_target_os_darwin_ios_clang_compat.c
+++ b/test/cases/__is_target_os_darwin_ios_clang_compat.c
@@ -1,0 +1,14 @@
+// This file is based on https://github.com/llvm/llvm-project/blob/main/clang/test/Preprocessor/is_target_os_darwin.c
+
+#if !__is_target_os(darwin)
+  #error "mismatching os"
+#endif
+
+#if !__is_target_os(ios)
+  #error "mismatching os"
+#endif
+
+/** manifest:
+expand_error
+args = --target=x86_64-apple-ios --emulate=clang
+*/

--- a/test/cases/__is_target_os_darwin_macos_clang_compat.c
+++ b/test/cases/__is_target_os_darwin_macos_clang_compat.c
@@ -1,0 +1,19 @@
+// This file is based on https://github.com/llvm/llvm-project/blob/main/clang/test/Preprocessor/is_target_os_darwin.c
+
+#if !__is_target_os(darwin)
+  #error "mismatching os"
+#endif
+
+#if !__is_target_os(macos)
+  #error "mismatching os"
+#endif
+
+#if !__is_target_os(macosx)
+  #error "mismatching os"
+#endif
+
+
+/** manifest:
+expand_error
+args = --target=x86_64-apple-macos --emulate=clang
+*/

--- a/test/cases/__is_target_os_darwin_tvos_clang_compat.c
+++ b/test/cases/__is_target_os_darwin_tvos_clang_compat.c
@@ -1,0 +1,14 @@
+// This file is based on https://github.com/llvm/llvm-project/blob/main/clang/test/Preprocessor/is_target_os_darwin.c
+
+#if !__is_target_os(darwin)
+  #error "mismatching os"
+#endif
+
+#if !__is_target_os(tvos)
+  #error "mismatching os"
+#endif
+
+/** manifest:
+expand_error
+args = --target=x86_64-apple-tvos --emulate=clang
+*/

--- a/test/cases/__is_target_os_darwin_watchos_clang_compat.c
+++ b/test/cases/__is_target_os_darwin_watchos_clang_compat.c
@@ -1,0 +1,14 @@
+// This file is based on https://github.com/llvm/llvm-project/blob/main/clang/test/Preprocessor/is_target_os_darwin.c
+
+#if !__is_target_os(darwin)
+  #error "mismatching os"
+#endif
+
+#if !__is_target_os(watchos)
+  #error "mismatching os"
+#endif
+
+/** manifest:
+expand_error
+args = --target=x86_64-apple-watchos --emulate=clang
+*/

--- a/test/cases/__is_target_vendor_apple.c
+++ b/test/cases/__is_target_vendor_apple.c
@@ -1,0 +1,8 @@
+#if !__is_target_vendor(apple)
+#error
+#endif
+
+/** manifest:
+expand_error
+args = --target=arm64e-apple-ios12-macabi --emulate=clang
+*/


### PR DESCRIPTION
This PR tries to align the __is_targets builtins closer to what clang does. The motivation for this was an error
in [`TargetConditionals.h`](https://codeberg.org/brodo/xcode-frameworks/src/branch/main/include/TargetConditionals.h) when compiling [dvui](https://github.com/david-vanderson/dvui) which I currently can't reproduce. I took the tests for the `__is_targets` builtins from the clang test suite and ported them. I found no incompatibilities that way, but I still kept the tests to make sure that we don't break anything in the future. 

I found several incompatibilities by looking at `TargetContionals.h` and the clang test suite:

- Target OSes like `ios12` are not supported. **This PR fixes that.**
- Zig does not support the `darwin` OS tag and stores it as `.macos`. In clang all Apple OSes are `darwin` but not all of them are Mac. This means we can't be 100% compatible.
- clang does not have `mccatalyst` as an OS tag, but it is supported by Zig. This means we can't be 100% compatible there either.

I've added some tests for OS version postfixes (ios12) and updated `parseOsName` to be prefix-based and `parseOS`
to extract the right version.
