### PR TITLE
Parser: Add support for __declspec(thread) for thread local variables

### DIFF
--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -829,7 +829,7 @@ pub fn applyVariableAttributes(p: *Parser, qt: QualType, attr_buf_start: usize, 
         // zig fmt: off
         .alias, .may_alias, .deprecated, .unavailable, .unused, .warn_if_not_aligned, .weak, .used,
         .noinit, .retain, .persistent, .section, .mode, .asm_label, .nullability, .unaligned, .selectany, .internal_linkage,
-        .visibility,
+        .visibility, .thread,
          => try p.attr_application_buf.append(gpa, attr),
         // zig fmt: on
         .common => if (nocommon) {

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1388,7 +1388,7 @@ fn decl(p: *Parser) Error!bool {
                 .variable = .{
                     .name_tok = init_d.d.name,
                     .qt = node_qt,
-                    .thread_local = decl_spec.thread_local != null,
+                    .thread_local = decl_spec.thread_local != null or node_qt.hasAttribute(p.comp, .thread),
                     .implicit = false,
                     .storage_class = switch (decl_spec.storage_class) {
                         .auto => .auto,

--- a/test/cases/ast/declspec thread.c
+++ b/test/cases/ast/declspec thread.c
@@ -1,0 +1,28 @@
+implicit typedef: '__int128'
+ name: __int128_t
+
+implicit typedef: 'unsigned __int128'
+ name: __uint128_t
+
+implicit typedef: '*char'
+ name: __builtin_ms_va_list
+
+implicit typedef: '[1]struct __va_list_tag'
+ name: __builtin_va_list
+
+implicit typedef: 'struct __NSConstantString_tag'
+ name: __NSConstantString
+
+implicit typedef: 'long double'
+ name: __float80
+
+variable: 'attributed(int)'
+ attr: thread
+ extern thread_local name: per_lcore_foo
+
+variable: 'attributed(int)'
+ attr: thread
+ thread_local name: per_lcore_bar
+ init:
+  int_literal: 'int' (value: 0)
+

--- a/test/cases/declspec thread.c
+++ b/test/cases/declspec thread.c
@@ -1,0 +1,7 @@
+__declspec(thread) extern int per_lcore_foo;
+__declspec(thread) int per_lcore_bar = 0;
+
+/** manifest:
+syntax
+args = -fdeclspec --target=x86_64-linux
+*/


### PR DESCRIPTION
Add support for __declspec(thread) for thread local variables.