### PR TITLE
Parser: Add support for GCC __thread

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -11,6 +11,7 @@ const char_info = @import("char_info.zig");
 const Compilation = @import("Compilation.zig");
 const Diagnostics = @import("Diagnostics.zig");
 const InitList = @import("InitList.zig");
+pub const Diagnostic = @import("Parser/Diagnostic.zig");
 const Preprocessor = @import("Preprocessor.zig");
 const record_layout = @import("record_layout.zig");
 const Source = @import("Source.zig");
@@ -419,8 +420,6 @@ fn expectClosing(p: *Parser, opening: TokenIndex, id: Token.Id) Error!void {
         return e;
     };
 }
-
-pub const Diagnostic = @import("Parser/Diagnostic.zig");
 
 pub fn err(p: *Parser, tok_i: TokenIndex, diagnostic: Diagnostic, args: anytype) Compilation.Error!void {
     if (p.extension_suppressed) {
@@ -991,6 +990,7 @@ fn nextExternDecl(p: *Parser) void {
             .keyword_register,
             .keyword_thread_local,
             .keyword_c23_thread_local,
+            .keyword_thread,
             .keyword_inline,
             .keyword_inline1,
             .keyword_inline2,
@@ -1750,9 +1750,13 @@ fn storageClassSpec(p: *Parser, d: *DeclSpec) Error!bool {
                     try p.err(p.tok_i, .multiple_storage_class, .{@tagName(d.storage_class)});
                     return error.ParsingFailed;
                 }
-                if (d.thread_local != null) {
+                if (d.thread_local) |thread_tok| {
                     switch (id) {
-                        .keyword_extern, .keyword_static => {},
+                        .keyword_extern, .keyword_static => {
+                            if (p.tok_ids[thread_tok] == .keyword_thread) {
+                                try p.err(thread_tok, .thread_before_storage, .{id.lexeme().?});
+                            }
+                        },
                         else => try p.err(p.tok_i, .cannot_combine_spec, .{id.lexeme().?}),
                     }
                     if (d.constexpr) |tok| try p.err(p.tok_i, .cannot_combine_spec, .{p.tok_ids[tok].lexeme().?});
@@ -1775,6 +1779,7 @@ fn storageClassSpec(p: *Parser, d: *DeclSpec) Error!bool {
             },
             .keyword_thread_local,
             .keyword_c23_thread_local,
+            .keyword_thread,
             => {
                 if (d.thread_local != null) {
                     try p.err(p.tok_i, .duplicate_decl_spec, .{id.lexeme().?});
@@ -5698,6 +5703,7 @@ fn nextStmt(p: *Parser, l_brace: TokenIndex) !void {
             .keyword_register,
             .keyword_thread_local,
             .keyword_c23_thread_local,
+            .keyword_thread,
             .keyword_inline,
             .keyword_inline1,
             .keyword_inline2,

--- a/src/aro/Parser/Diagnostic.zig
+++ b/src/aro/Parser/Diagnostic.zig
@@ -206,6 +206,12 @@ pub const threadlocal_non_var: Diagnostic = .{
     .kind = .@"error",
 };
 
+pub const thread_before_storage: Diagnostic = .{
+    .fmt = "'__thread' before '{s}'",
+    .kind = .off,
+    .extension = true,
+};
+
 pub const func_spec_non_func: Diagnostic = .{
     .fmt = "'{s}' can only appear on functions",
     .kind = .@"error",

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -283,6 +283,7 @@ pub const Token = struct {
         keyword_asm,
         keyword_asm1,
         keyword_asm2,
+        keyword_thread,
         /// __float128
         keyword_float128_1,
         keyword_int128,
@@ -436,6 +437,7 @@ pub const Token = struct {
                 .keyword_noreturn,
                 .keyword_static_assert,
                 .keyword_thread_local,
+                .keyword_thread,
                 .identifier,
                 .extended_identifier,
                 .keyword_typeof,
@@ -708,6 +710,7 @@ pub const Token = struct {
                 .keyword_noreturn => "_Noreturn",
                 .keyword_static_assert => "_Static_assert",
                 .keyword_thread_local => "_Thread_local",
+                .keyword_thread => "__thread",
                 .keyword_bit_int => "_BitInt",
                 .keyword_c23_alignas => "alignas",
                 .keyword_c23_alignof => "alignof",
@@ -1103,6 +1106,7 @@ pub const Token = struct {
         .{ "__imag__", .keyword_imag2 },
         .{ "__real", .keyword_real1 },
         .{ "__real__", .keyword_real2 },
+        .{ "__thread", .keyword_thread },
 
         // clang keywords
         .{ "__fp16", .keyword_fp16 },
@@ -2051,7 +2055,7 @@ test "keywords" {
         \\long register return short signed sizeof static
         \\struct switch typedef union unsigned void volatile
         \\while _Bool _Complex _Imaginary inline restrict _Alignas
-        \\_Alignof _Atomic _Generic _Noreturn _Static_assert _Thread_local
+        \\_Alignof _Atomic _Generic _Noreturn _Static_assert _Thread_local __thread
         \\__attribute __attribute__
         \\
     , &.{
@@ -2105,6 +2109,7 @@ test "keywords" {
         .keyword_noreturn,
         .keyword_static_assert,
         .keyword_thread_local,
+        .keyword_thread,
         .nl,
         .keyword_attribute1,
         .keyword_attribute2,

--- a/test/cases/ast/gcc thread.c
+++ b/test/cases/ast/gcc thread.c
@@ -1,0 +1,35 @@
+implicit typedef: '__int128'
+ name: __int128_t
+
+implicit typedef: 'unsigned __int128'
+ name: __uint128_t
+
+implicit typedef: '*char'
+ name: __builtin_ms_va_list
+
+implicit typedef: '[1]struct __va_list_tag'
+ name: __builtin_va_list
+
+implicit typedef: 'struct __NSConstantString_tag'
+ name: __NSConstantString
+
+implicit typedef: 'long double'
+ name: __float80
+
+variable: 'int'
+ thread_local name: per_lcore_bar
+ init:
+  int_literal: 'int' (value: 0)
+
+variable: 'int'
+ extern thread_local name: pedantic_extern
+
+variable: 'int'
+ static thread_local name: pedantic_static
+
+variable: 'int'
+ extern thread_local name: quiet_extern
+
+variable: 'int'
+ static thread_local name: quiet_static
+

--- a/test/cases/gcc thread.c
+++ b/test/cases/gcc thread.c
@@ -1,0 +1,13 @@
+__thread int per_lcore_bar = 0;
+__thread extern int pedantic_extern;
+__thread static int pedantic_static;
+extern __thread int quiet_extern;
+static __thread int quiet_static;
+
+/** manifest:
+syntax
+args = --target=x86_64-linux -Wpedantic
+
+gcc thread.c:2:1: warning: '__thread' before 'extern' [-Wpedantic]
+gcc thread.c:3:1: warning: '__thread' before 'static' [-Wpedantic]
+*/


### PR DESCRIPTION
Adding support for GCC __thread with pedantic warning if before `extern`/`static`.
I've imitated `__Thread_local` keyword for `nextStmt` and the `"keyword"` test.

Closes: #1005 