### PR TITLE
Add RISC-V floating-point predefined macros

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -853,6 +853,28 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
         .riscv32, .riscv32be, .riscv64, .riscv64be => {
             try define(w, "__riscv");
             try w.print("#define __riscv_xlen {d}\n", .{ptr_width});
+            const has_f = target.cpu.has(.riscv, .f);
+            const has_d = target.cpu.has(.riscv, .d);
+            const has_q = target.cpu.has(.riscv, .q);
+            if (has_f) {
+                try w.writeAll("#define __riscv_f 2002000\n");
+            }
+            if (has_d) {
+                try w.writeAll("#define __riscv_d 2002000\n");
+            }
+            if (has_q) {
+                try w.writeAll("#define __riscv_q 2002000\n");
+            }
+            if (has_q) {
+                try w.writeAll("#define __riscv_flen 128\n");
+            } else if (has_d) {
+                try w.writeAll("#define __riscv_flen 64\n");
+            } else if (has_f) {
+                try w.writeAll("#define __riscv_flen 32\n");
+            }
+            try w.print("#define __riscv_float_abi_{s} 1\n", .{
+                @tagName(riscvFloatAbi(target)),
+            });
         },
         else => {},
     }
@@ -1040,6 +1062,21 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
             }
         },
     }
+}
+
+const RiscvFloatAbi = enum { soft, single, double };
+
+fn riscvFloatAbi(target: *const Target) RiscvFloatAbi {
+    return switch (target.abi) {
+        .gnusf, .muslsf => .soft,
+        .gnuf32, .muslf32 => .single,
+        else => if (target.cpu.has(.riscv, .d))
+            .double
+        else if (target.cpu.has(.riscv, .f))
+            .single
+        else
+            .soft,
+    };
 }
 
 /// Generate builtin macros that will be available to each source file.

--- a/test/cases/riscv hard-float predefined macros.c
+++ b/test/cases/riscv hard-float predefined macros.c
@@ -1,0 +1,30 @@
+#if !defined(__riscv)
+#error missing __riscv
+#endif
+
+#if __riscv_xlen != 64
+#error invalid __riscv_xlen
+#endif
+
+#if !defined(__riscv_f) || !defined(__riscv_d)
+#error missing floating-point extension macro
+#endif
+
+#if __riscv_flen != 64
+#error invalid __riscv_flen
+#endif
+
+#if !defined(__riscv_float_abi_double)
+#error missing double-float ABI macro
+#endif
+
+#if defined(__riscv_float_abi_soft) || defined(__riscv_float_abi_single)
+#error incorrect floating-point ABI macro
+#endif
+
+int ok;
+
+/** manifest:
+syntax
+args = --target=riscv64-linux-gnu -mcpu=baseline
+*/

--- a/test/cases/riscv no-float predefined macros.c
+++ b/test/cases/riscv no-float predefined macros.c
@@ -1,0 +1,18 @@
+#if !defined(__riscv_float_abi_soft)
+#error missing soft-float ABI macro
+#endif
+
+#if defined(__riscv_float_abi_single) || defined(__riscv_float_abi_double)
+#error incorrect floating-point ABI macro
+#endif
+
+#if defined(__riscv_flen)
+#error unexpected __riscv_flen
+#endif
+
+int ok;
+
+/** manifest:
+syntax
+args = --target=riscv64-linux-gnu -mcpu=generic_rv64
+*/

--- a/test/cases/riscv single-float predefined macros.c
+++ b/test/cases/riscv single-float predefined macros.c
@@ -1,0 +1,14 @@
+#if !defined(__riscv_float_abi_single)
+#error missing single-float ABI macro
+#endif
+
+#if defined(__riscv_float_abi_soft) || defined(__riscv_float_abi_double)
+#error incorrect floating-point ABI macro
+#endif
+
+int ok;
+
+/** manifest:
+syntax
+args = --target=riscv64-linux-gnuf32 -mcpu=baseline
+*/

--- a/test/cases/riscv soft-float predefined macros.c
+++ b/test/cases/riscv soft-float predefined macros.c
@@ -1,0 +1,18 @@
+#if !defined(__riscv_float_abi_soft)
+#error missing soft-float ABI macro
+#endif
+
+#if defined(__riscv_float_abi_single) || defined(__riscv_float_abi_double)
+#error incorrect floating-point ABI macro
+#endif
+
+#if __riscv_flen != 64
+#error invalid __riscv_flen
+#endif
+
+int ok;
+
+/** manifest:
+syntax
+args = --target=riscv64-linux-gnusf -mcpu=baseline
+*/


### PR DESCRIPTION
Fix build failure for ly:
```text
install
+- install ly
   +- compile exe ly ReleaseSafe native-linux.6.6-gnu.2.40
      +- translate-c generated failure
/usr/include/bits/setjmp.h:35:3: error: unsupported FLEN
# error unsupported FLEN
   ^
error: process exited with error code 1
failed command: ./.zig-cache/o/dc8bb0e89d00524f047724590252b3e6/translate-c ./.zig-cache/o/6a8a29fe9dd81cad3d097e5ca0193296/xcb.h -o ./.zig-cache/tmp/eb366256a49f1797/generated.zig -MD -MV -MF ./.zig-cache/tmp/
eb366256a49f1797/deps.d --target=native-linux.6.6-gnu.2.40 -nostdlibinc -isystem /usr/lib/zig/libc/include/riscv-linux-gnu -isystem /usr/lib/zig/libc/include/generic-glibc -isystem /usr/lib/zig/libc/include/
riscv-linux-any -isystem /usr/lib/zig/libc/include/any-linux-any -idirafter /usr/lib/zig/include -I /usr/include -w -resource-dir ./zig-pkg/aro-0.0.0-JSD1Qi7QNgDnfcrdEJf82v3o6MhZySjYVrtdfEf3E4Se -fmodule-libs

Build Summary: 44/48 steps succeeded (1 failed)
install transitive failure
+- install ly transitive failure
   +- compile exe ly ReleaseSafe native-linux.6.6-gnu.2.40 transitive failure
      +- translate-c generated failure

error: the following build command failed with exit code 1:
.zig-cache/o/e46b02d903b6004bff48e9d15161836a/build /usr/bin/zig /usr/lib/zig /build/ly/src/ly .zig-cache /build/ly/src/zig-global-cache --seed 0xa92fe01a -Z960c1c42115dedb8 --search-prefix /usr
-Ddest_directory=/build/ly/pkg/ly -Dname=ly-dm --system --build-id=sha1 -Dtarget=native-linux.6.6-gnu.2.40 -Dcpu=baseline -Doptimize=ReleaseSafe
```