### PR TITLE
Pragma, Preprocessor: add "beforeInclude" hook, extend "once"

### DIFF
--- a/src/aro/Pragma.zig
+++ b/src/aro/Pragma.zig
@@ -4,9 +4,12 @@ const Compilation = @import("Compilation.zig");
 const Diagnostics = @import("Diagnostics.zig");
 const Parser = @import("Parser.zig");
 const Preprocessor = @import("Preprocessor.zig");
+const Source = @import("Source.zig");
 const TokenIndex = @import("Tree.zig").TokenIndex;
 
 pub const Error = Compilation.Error || error{ UnknownPragma, StopPreprocessing };
+
+pub const BeforeIncludeError = Compilation.Error || error{SkipInclude};
 
 const Pragma = @This();
 
@@ -28,6 +31,10 @@ afterParse: ?*const fn (*Pragma, *Compilation) void = null,
 
 /// Called during Compilation.deinit
 deinit: *const fn (*Pragma, *Compilation) void,
+
+/// Called during Preprocessor.include. Return SkipInclude to skip the include
+/// altogether (see once.zig).
+beforeInclude: ?*const fn (*Pragma, *Preprocessor, Source) BeforeIncludeError!void = null,
 
 /// Called whenever the preprocessor encounters this pragma. `start_idx` is the index
 /// within `pp.tokens` of the pragma name token. The pragma end is indicated by a

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -3553,6 +3553,39 @@ fn include(pp: *Preprocessor, tokenizer: *Tokenizer, which: Compilation.WhichInc
         if (pp.defines.contains(guard)) return;
     }
 
+    // Run any beforeInclude pragma hooks.
+    //
+    // NOTE: This is currently the only deep-preprocessor hook other than the
+    // actual token handler itself. If more are added, an event hook system
+    // similar to the compilation-scoped one should be considered with a
+    // payload structure that can handle context-relevant event data (e.g.,
+    // here, the source file data is needed).
+    {
+        var pragma_handler_it = pp.comp.pragma_handlers.iterator();
+        while (pragma_handler_it.next()) |pragma_handler| {
+            const handler_pragma_name = pragma_handler.key_ptr.*;
+            const handler_pragma = pragma_handler.value_ptr.*;
+            if (handler_pragma.beforeInclude) |func| {
+                func(handler_pragma, pp, new_source) catch |handler_err| {
+                    switch (handler_err) {
+                        error.SkipInclude => {
+                            if (pp.verbose) {
+                                pp.verboseLog(
+                                    first,
+                                    "skipping include file {s} under direction of \"{s}\" pragma",
+                                    .{ new_source.path, handler_pragma_name },
+                                );
+                            }
+
+                            return;
+                        },
+                        else => |e| return e,
+                    }
+                };
+            }
+        }
+    }
+
     if (pp.dep_file) |dep| try dep.addDependency(gpa, new_source.path);
     if (pp.verbose) {
         pp.verboseLog(first, "include file {s}", .{new_source.path});

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -829,6 +829,9 @@ fn preprocessExtra(pp: *Preprocessor, source: Source) MacroError!TokenWithExpans
                         }
 
                         _ = pp.defines.orderedRemove(macro_name);
+                        if (pp.verbose) {
+                            pp.verboseLog(directive, "macro {s} undefined", .{macro_name});
+                        }
                         try pp.expectNl(&tokenizer);
                     },
                     .keyword_include => {

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -3560,29 +3560,24 @@ fn include(pp: *Preprocessor, tokenizer: *Tokenizer, which: Compilation.WhichInc
     // similar to the compilation-scoped one should be considered with a
     // payload structure that can handle context-relevant event data (e.g.,
     // here, the source file data is needed).
-    {
-        var pragma_handler_it = pp.comp.pragma_handlers.iterator();
-        while (pragma_handler_it.next()) |pragma_handler| {
-            const handler_pragma_name = pragma_handler.key_ptr.*;
-            const handler_pragma = pragma_handler.value_ptr.*;
-            if (handler_pragma.beforeInclude) |func| {
-                func(handler_pragma, pp, new_source) catch |handler_err| {
-                    switch (handler_err) {
-                        error.SkipInclude => {
-                            if (pp.verbose) {
-                                pp.verboseLog(
-                                    first,
-                                    "skipping include file {s} under direction of \"{s}\" pragma",
-                                    .{ new_source.path, handler_pragma_name },
-                                );
-                            }
+    for (pp.comp.pragma_handlers.keys(), pp.comp.pragma_handlers.values()) |handler_pragma_name, handler_pragma| {
+        if (handler_pragma.beforeInclude) |func| {
+            func(handler_pragma, pp, new_source) catch |handler_err| {
+                switch (handler_err) {
+                    error.SkipInclude => {
+                        if (pp.verbose) {
+                            pp.verboseLog(
+                                first,
+                                "skipping include file {s} under direction of \"{s}\" pragma",
+                                .{ new_source.path, handler_pragma_name },
+                            );
+                        }
 
-                            return;
-                        },
-                        else => |e| return e,
-                    }
-                };
-            }
+                        return;
+                    },
+                    else => |e| return e,
+                }
+            };
         }
     }
 

--- a/src/aro/pragmas/once.zig
+++ b/src/aro/pragmas/once.zig
@@ -14,6 +14,7 @@ const Once = @This();
 pragma: Pragma = .{
     .afterParse = afterParse,
     .deinit = deinit,
+    .beforeInclude = beforeInclude,
     .preprocessorHandler = preprocessorHandler,
     .preserveTokens = preserveTokens,
 },
@@ -35,6 +36,11 @@ fn deinit(pragma: *Pragma, comp: *Compilation) void {
     var self: *Once = @fieldParentPtr("pragma", pragma);
     self.pragma_once.deinit(comp.gpa);
     comp.gpa.destroy(self);
+}
+
+fn beforeInclude(pragma: *Pragma, _: *Preprocessor, source: Source) Pragma.BeforeIncludeError!void {
+    var self: *Once = @fieldParentPtr("pragma", pragma);
+    if (self.pragma_once.contains(source.id)) return error.SkipInclude;
 }
 
 fn preprocessorHandler(pragma: *Pragma, pp: *Preprocessor, start_idx: TokenIndex) Pragma.Error!void {

--- a/test/cases/include/pragma_once_not_at_start/a.h
+++ b/test/cases/include/pragma_once_not_at_start/a.h
@@ -1,0 +1,2 @@
+#include <b.h>
+#include <c.h>

--- a/test/cases/include/pragma_once_not_at_start/b.h
+++ b/test/cases/include/pragma_once_not_at_start/b.h
@@ -1,0 +1,5 @@
+#define __B_INSIDE__
+
+#include <c.h>
+
+#undef __B_INSIDE__

--- a/test/cases/include/pragma_once_not_at_start/c.h
+++ b/test/cases/include/pragma_once_not_at_start/c.h
@@ -1,0 +1,5 @@
+#if !defined(__B_INSIDE__)
+#error "expected test macros to be present"
+#endif
+
+#pragma once

--- a/test/cases/pragma once not at start of file.c
+++ b/test/cases/pragma once not at start of file.c
@@ -1,0 +1,6 @@
+#include <a.h> // include/pragma_once_not_at_start/a.h
+
+/** manifest:
+syntax
+args = -I include/pragma_once_not_at_start
+*/


### PR DESCRIPTION
This adds the `beforeInclude` pragma hook, which fires before a file is included. Its current and only implementation is in the "once" pragma, which has been extended to use it to ensure that `#pragma once` causes future inclusions of a file to be skipped outright, versus processed until the pragma is hit again.

This prevents scenarios where the directive has not been placed at the top of the file. This is a practice that is carried out in at least the GTK headers, and the current control flow causes inner-inclusion guards
to be hit when they should not be.

Note that since this is a deep-preprocessor event, it has not been added to the compilation-scoped `PragmaEvent` set, and just implemented as a hook local in the include function. If more event hooks get added in the future, it might be a good idea to review the event system to allow for scope-agnostic event types and payloads.