### PR TITLE
Tree: allow max of 64 expansion locations per token

### DIFF
--- a/src/aro/Tree.zig
+++ b/src/aro/Tree.zig
@@ -22,6 +22,8 @@ pub const Token = struct {
 };
 
 pub const TokenWithExpansionLocs = struct {
+    const max_expansion_locs = 64;
+
     id: Token.Id,
     flags: packed struct {
         expansion_disabled: bool = false,
@@ -51,8 +53,10 @@ pub const TokenWithExpansionLocs = struct {
             // what we ask for.
             if (list.capacity > 0) {
                 list.items.ptr[list.capacity - 1].byte_offset = 1;
+                tok.expansion_locs = list.items.ptr;
+            } else {
+                tok.expansion_locs = null;
             }
-            tok.expansion_locs = list.items.ptr;
         }
 
         if (tok.expansion_locs) |locs| {
@@ -63,13 +67,22 @@ pub const TokenWithExpansionLocs = struct {
             list.capacity = i + 1;
         }
 
-        const min_len = @max(list.items.len + new.len + 1, 4);
+        if (list.items.len >= max_expansion_locs) return;
+        var new_len: usize = 0;
+        for (new) |new_loc| {
+            if (new_loc.id.index != .generated) new_len += 1;
+        }
+        new_len = @min(new_len, max_expansion_locs - list.items.len);
+        if (new_len == 0) return;
+
+        const min_len = @max(list.items.len + new_len + 1, 4);
         const wanted_len = std.math.ceilPowerOfTwo(usize, min_len) catch
             return error.OutOfMemory;
         try list.ensureTotalCapacity(gpa, wanted_len);
 
         for (new) |new_loc| {
             if (new_loc.id.index == .generated) continue;
+            if (list.items.len >= max_expansion_locs) break;
             list.appendAssumeCapacity(new_loc);
         }
     }


### PR DESCRIPTION
Spent some time profiling the preprocessor when trying to preprocess https://github.com/hirrolot/metalang99 and we spend almost all of our time copying expansion tokens around. If we cap it at 64 per token, we can actually handle all the bench tests in that repo (I didn't run the entire test suite but it seems promising). Even with this change `many_call_in_arg_pos.c` uses 22 gigs of RAM and takes 20 seconds on an M4 Max, but it works!

I think the proper solution will be doing a linked list with deduping (probably broadly similar to what hideset is already doing) to track expansion locations instead of arrays. I'm not 100% sure though.