### PR TITLE
Parser: support second argument to deprecated attribute

### DIFF
--- a/src/aro/Attribute.zig
+++ b/src/aro/Attribute.zig
@@ -431,6 +431,7 @@ const attributes = struct {
     };
     pub const deprecated = struct {
         msg: ?Value = null,
+        alternative: ?Value = null, // C23 deprecated attribute only takes 1 argument
         __name_tok: TokenIndex,
     };
     pub const designated_init = struct {};

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -631,6 +631,10 @@ fn checkDeprecatedUnavailable(p: *Parser, ty: QualType, usage_tok: TokenIndex, d
     }
     if (ty.getAttribute(p.comp, .deprecated)) |deprecated| {
         try p.errDeprecated(usage_tok, .deprecated_declarations, deprecated.msg);
+        if (deprecated.alternative) |alternative| {
+            const alt_str = p.comp.interner.get(alternative.ref()).bytes;
+            try p.err(usage_tok, .deprecated_alternative, .{alt_str});
+        }
         try p.err(deprecated.__name_tok, .deprecated_note, .{p.tokSlice(decl_tok)});
     }
 }

--- a/src/aro/Parser/Diagnostic.zig
+++ b/src/aro/Parser/Diagnostic.zig
@@ -1607,9 +1607,13 @@ pub const deprecated_declarations: Diagnostic = .{
     .kind = .warning,
 };
 
+pub const deprecated_alternative: Diagnostic = .{
+    .fmt = "use '{s}' instead",
+    .kind = .note,
+};
+
 pub const deprecated_note: Diagnostic = .{
     .fmt = "'{s}' has been explicitly marked deprecated here",
-    .opt = .@"deprecated-declarations",
     .kind = .note,
 };
 

--- a/test/cases/attribute errors.c
+++ b/test/cases/attribute errors.c
@@ -56,7 +56,7 @@ attribute errors.c:19:24: warning: attribute 'simd' ignored on variables [-Wigno
 attribute errors.c:20:29: warning: unknown `simd` argument. Possible values are: "notinbranch", "inbranch" [-Wignored-attributes]
 attribute errors.c:21:24: warning: unknown attribute 'invalid_attribute' ignored [-Wunknown-attributes]
 attribute errors.c:22:24: warning: unknown attribute 'invalid_attribute' ignored [-Wunknown-attributes]
-attribute errors.c:23:49: error: 'deprecated' attribute takes at most 1 argument(s)
+attribute errors.c:23:49: error: attribute argument is invalid, expected a string but got an integer constant
 attribute errors.c:27:24: warning: attribute 'cold' ignored on types [-Wignored-attributes]
 attribute errors.c:30:5: warning: '__thiscall' calling convention is not supported for this target [-Wignored-attributes]
 attribute errors.c:31:36: error: attribute value '4294967296' out of range

--- a/test/cases/deprecated vars.c
+++ b/test/cases/deprecated vars.c
@@ -20,7 +20,7 @@ void baz(void) {
 }
 
 struct S {
-    int __attribute__((deprecated("foo"), packed)) p;
+    int __attribute__((deprecated("foo", "bar"), packed)) p;
 };
 
 int deprecated_field(struct S s) {
@@ -47,5 +47,6 @@ deprecated vars.c:13:29: note: 'arg' has been explicitly marked deprecated here
 deprecated vars.c:19:5: warning: 'x' is deprecated [-Wdeprecated-declarations]
 deprecated vars.c:18:12: note: 'x' has been explicitly marked deprecated here
 deprecated vars.c:28:14: warning: 'p' is deprecated: foo [-Wdeprecated-declarations]
+deprecated vars.c:28:14: note: use 'bar' instead
 deprecated vars.c:23:24: note: 'p' has been explicitly marked deprecated here
 */


### PR DESCRIPTION
https://codeberg.org/ziglang/translate-c/issues/306