### PR TITLE
TypeStore: do not desugar typedefs that equal their base type

### DIFF
--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -1252,7 +1252,12 @@ pub const QualType = packed struct(u32) {
                 continue :loop func.return_type.type(comp);
             },
             .typeof => return true,
-            .typedef => |typedef| return !typedef.base.is(comp, .nullptr_t),
+            .typedef => |typedef| {
+                if (Builder.fromType(comp, typedef.base).str(comp.langopts)) |some| {
+                    return !std.mem.eql(u8, some, typedef.name.lookup(comp));
+                }
+                return true;
+            },
             else => return false,
         }
     }
@@ -1340,6 +1345,13 @@ pub const QualType = packed struct(u32) {
             .typeof => |typeof| if (desugar) {
                 continue :loop typeof.base.type(comp);
             } else {
+                if (qt.@"const" and !typeof.base.@"const") {
+                    try w.writeAll("const ");
+                }
+                if (qt.@"volatile" and !typeof.base.@"volatile") {
+                    try w.writeAll("volatile ");
+                }
+
                 try w.writeAll("typeof(");
                 try typeof.base.print(comp, w);
                 try w.writeAll(")");
@@ -1348,6 +1360,9 @@ pub const QualType = packed struct(u32) {
             .typedef => |typedef| if (desugar) {
                 continue :loop typedef.base.type(comp);
             } else {
+                if (qt.@"const") try w.writeAll("const ");
+                if (qt.@"volatile") try w.writeAll("volatile ");
+
                 try w.writeAll(typedef.name.lookup(comp));
                 return true;
             },

--- a/test/cases/__mfp8 invalid.c
+++ b/test/cases/__mfp8 invalid.c
@@ -54,47 +54,47 @@ void foo(__mfp8 a, __mfp8 b) {
 syntax
 args = -std=c23 --target=aarch64-linux-gnu
 
-__mfp8 invalid.c:2:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:3:5: error: invalid argument type '__mfp8' (aka '__mfp8') to unary expression
-__mfp8 invalid.c:4:5: error: invalid argument type '__mfp8' (aka '__mfp8') to unary expression
-__mfp8 invalid.c:5:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:6:9: error: statement requires expression with scalar type ('__mfp8' (aka '__mfp8') invalid)
-__mfp8 invalid.c:7:13: error: initializing 'int' from incompatible type '__mfp8' (aka '__mfp8')
-__mfp8 invalid.c:8:15: error: initializing 'float' from incompatible type '__mfp8' (aka '__mfp8')
-__mfp8 invalid.c:9:16: error: initializing '__mfp8' (aka '__mfp8') from incompatible type 'int'
-__mfp8 invalid.c:10:14: error: initializing '__mfp8' (aka '__mfp8') from incompatible type 'int'
-__mfp8 invalid.c:11:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:12:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:13:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:14:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:15:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:16:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:17:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:18:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:19:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and 'int')
-__mfp8 invalid.c:20:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and 'int')
-__mfp8 invalid.c:21:10: error: operand of type '__mfp8' (aka '__mfp8') where arithmetic or pointer type is required
-__mfp8 invalid.c:22:12: error: operand of type '__mfp8' (aka '__mfp8') where arithmetic or pointer type is required
-__mfp8 invalid.c:23:5: error: cannot cast to non arithmetic or pointer type '__mfp8' (aka '__mfp8')
-__mfp8 invalid.c:24:5: error: cannot cast to non arithmetic or pointer type '__mfp8' (aka '__mfp8')
-__mfp8 invalid.c:26:7: error: cannot assign to variable 'c' with const-qualified type '__mfp8' (aka 'const __mfp8')
+__mfp8 invalid.c:2:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:3:5: error: invalid argument type '__mfp8' to unary expression
+__mfp8 invalid.c:4:5: error: invalid argument type '__mfp8' to unary expression
+__mfp8 invalid.c:5:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:6:9: error: statement requires expression with scalar type ('__mfp8' invalid)
+__mfp8 invalid.c:7:13: error: initializing 'int' from incompatible type '__mfp8'
+__mfp8 invalid.c:8:15: error: initializing 'float' from incompatible type '__mfp8'
+__mfp8 invalid.c:9:16: error: initializing '__mfp8' from incompatible type 'int'
+__mfp8 invalid.c:10:14: error: initializing '__mfp8' from incompatible type 'int'
+__mfp8 invalid.c:11:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:12:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:13:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:14:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:15:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:16:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:17:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:18:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:19:7: error: invalid operands to binary expression ('__mfp8' and 'int')
+__mfp8 invalid.c:20:7: error: invalid operands to binary expression ('__mfp8' and 'int')
+__mfp8 invalid.c:21:10: error: operand of type '__mfp8' where arithmetic or pointer type is required
+__mfp8 invalid.c:22:12: error: operand of type '__mfp8' where arithmetic or pointer type is required
+__mfp8 invalid.c:23:5: error: cannot cast to non arithmetic or pointer type '__mfp8'
+__mfp8 invalid.c:24:5: error: cannot cast to non arithmetic or pointer type '__mfp8'
+__mfp8 invalid.c:26:7: error: cannot assign to variable 'c' with const-qualified type 'const __mfp8'
 __mfp8 invalid.c:25:18: note: variable 'c' declared const here
-__mfp8 invalid.c:27:12: error: statement requires expression with scalar type ('__mfp8' (aka '__mfp8') invalid)
-__mfp8 invalid.c:28:10: error: statement requires expression with scalar type ('__mfp8' (aka '__mfp8') invalid)
-__mfp8 invalid.c:29:18: error: statement requires expression with scalar type ('__mfp8' (aka '__mfp8') invalid)
-__mfp8 invalid.c:30:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:31:7: error: invalid operands to binary expression ('__mfp8' (aka '__mfp8') and '__mfp8' (aka '__mfp8'))
-__mfp8 invalid.c:32:5: error: invalid argument type '__mfp8' (aka '__mfp8') to unary expression
-__mfp8 invalid.c:33:13: error: statement requires expression with integer type ('__mfp8' (aka '__mfp8') invalid)
-__mfp8 invalid.c:34:27: error: initializing '__mfp8' (aka '__mfp8') from incompatible type 'int'
-__mfp8 invalid.c:37:22: error: initializing '__mfp8' (aka '__mfp8') from incompatible type 'int'
-__mfp8 invalid.c:42:15: error: assignment to '__mfp8' (aka '__mfp8') from incompatible type 'int'
-__mfp8 invalid.c:43:19: error: assignment to '__mfp8' (aka '__mfp8') from incompatible type 'int'
-__mfp8 invalid.c:46:15: error: passing 'int' to parameter of incompatible type '__mfp8' (aka '__mfp8')
+__mfp8 invalid.c:27:12: error: statement requires expression with scalar type ('__mfp8' invalid)
+__mfp8 invalid.c:28:10: error: statement requires expression with scalar type ('__mfp8' invalid)
+__mfp8 invalid.c:29:18: error: statement requires expression with scalar type ('__mfp8' invalid)
+__mfp8 invalid.c:30:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:31:7: error: invalid operands to binary expression ('__mfp8' and '__mfp8')
+__mfp8 invalid.c:32:5: error: invalid argument type '__mfp8' to unary expression
+__mfp8 invalid.c:33:13: error: statement requires expression with integer type ('__mfp8' invalid)
+__mfp8 invalid.c:34:27: error: initializing '__mfp8' from incompatible type 'int'
+__mfp8 invalid.c:37:22: error: initializing '__mfp8' from incompatible type 'int'
+__mfp8 invalid.c:42:15: error: assignment to '__mfp8' from incompatible type 'int'
+__mfp8 invalid.c:43:19: error: assignment to '__mfp8' from incompatible type 'int'
+__mfp8 invalid.c:46:15: error: passing 'int' to parameter of incompatible type '__mfp8'
 __mfp8 invalid.c:44:26: note: passing argument to parameter here
-__mfp8 invalid.c:47:15: error: passing 'float' to parameter of incompatible type '__mfp8' (aka '__mfp8')
+__mfp8 invalid.c:47:15: error: passing 'float' to parameter of incompatible type '__mfp8'
 __mfp8 invalid.c:44:26: note: passing argument to parameter here
-__mfp8 invalid.c:48:14: error: passing '__mfp8' (aka '__mfp8') to parameter of incompatible type 'int'
+__mfp8 invalid.c:48:14: error: passing '__mfp8' to parameter of incompatible type 'int'
 __mfp8 invalid.c:45:22: note: passing argument to parameter here
 __mfp8 invalid.c:49:5: warning: plain '_Complex' requires a type specifier; assuming '_Complex double'
 __mfp8 invalid.c:49:21: error: expected ';', found 'an identifier'

--- a/test/cases/assignment.c
+++ b/test/cases/assignment.c
@@ -166,7 +166,7 @@ assignment.c:86:23: error: cannot assign to variable 'nested_struct' with const-
 assignment.c:85:24: note: variable 'nested_struct' declared const here
 assignment.c:88:15: error: cannot assign to variable 'func' with const-qualified type 'const int *(void)'
 assignment.c:99:12: error: variable has incomplete type 'enum E'
-assignment.c:106:7: error: cannot assign to variable 'a' with const-qualified type 'A' (aka 'const int')
+assignment.c:106:7: error: cannot assign to variable 'a' with const-qualified type 'const A' (aka 'const int')
 assignment.c:105:7: note: variable 'a' declared const here
 assignment.c:113:7: warning: incompatible pointer types assigning to 'unsigned int *' from incompatible type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]
 assignment.c:117:23: warning: implicit conversion from 'int' to 'unsigned char' changes value from 1000 to 232 [-Wconstant-conversion]

--- a/test/cases/typeof.c
+++ b/test/cases/typeof.c
@@ -135,27 +135,27 @@ skip = typeof type in error message missing const
 typeof.c:23:9: warning: incompatible pointer types assigning to 'typeof(typeof(int)) *' (aka 'int *') from incompatible type 'typeof(float) *' (aka 'float *') [-Wincompatible-pointer-types]
 typeof.c:27:7: error: cannot assign to variable 'x' with const-qualified type 'typeof(const int)' (aka 'const int')
 typeof.c:26:22: note: variable 'x' declared const here
-typeof.c:29:7: error: cannot assign to variable 'y' with const-qualified type 'typeof(typeof(typeof(int)))' (aka 'const int')
+typeof.c:29:7: error: cannot assign to variable 'y' with const-qualified type 'const typeof(typeof(typeof(int)))' (aka 'const int')
 typeof.c:28:23: note: variable 'y' declared const here
 typeof.c:33:30: error: initializing 'typeof(int *)' (aka 'int *') from incompatible type 'float'
 typeof.c:34:8: error: expected expression
 typeof.c:58:13: error: cannot assign to variable 'arr1' with const-qualified type 'const int [2]'
 typeof.c:57:25: note: variable 'arr1' declared const here
-typeof.c:60:13: error: cannot assign to variable 'arr2' with const-qualified type 'typeof(int [2])' (aka 'const int [2]')
+typeof.c:60:13: error: cannot assign to variable 'arr2' with const-qualified type 'const typeof(int [2])' (aka 'const int [2]')
 typeof.c:59:26: note: variable 'arr2' declared const here
 typeof.c:63:13: error: cannot assign to variable 'arr3' with const-qualified type 'const int [2]'
 typeof.c:62:25: note: variable 'arr3' declared const here
 typeof.c:65:13: error: cannot assign to variable 'arr4' with const-qualified type 'typeof(const int [2])' (aka 'const int [2]')
 typeof.c:64:26: note: variable 'arr4' declared const here
-typeof.c:68:13: error: cannot assign to variable 'arr5' with const-qualified type 'typeof(int) [2]'
+typeof.c:68:13: error: cannot assign to variable 'arr5' with const-qualified type 'const typeof(int) [2]'
 typeof.c:67:23: note: variable 'arr5' declared const here
 typeof.c:70:13: error: cannot assign to variable 'arr6' with const-qualified type 'typeof(const int) [2]'
 typeof.c:69:23: note: variable 'arr6' declared const here
 typeof.c:73:13: error: cannot assign to variable 'arr7' with const-qualified type 'const int [2]'
 typeof.c:72:15: note: variable 'arr7' declared const here
-typeof.c:76:13: error: cannot assign to variable 'arr8' with const-qualified type 'typeof(typeof(typeof(int [2])))' (aka 'const int [2]')
+typeof.c:76:13: error: cannot assign to variable 'arr8' with const-qualified type 'typeof(const typeof(typeof(int [2])))' (aka 'const int [2]')
 typeof.c:75:42: note: variable 'arr8' declared const here
-typeof.c:97:29: warning: initializing 'typeof(int *)' (aka 'int *const') from incompatible type 'const int [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
+typeof.c:97:29: warning: initializing 'const typeof(int *)' (aka 'int *const') from incompatible type 'const int [2]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 typeof.c:112:5: error: invalid argument type 'char *' to unary expression
 typeof.c:118:5: warning: declaration does not declare anything [-Wmissing-declaration]
 typeof.c:127:26: error: array initializer must be an initializer list or wide string literal


### PR DESCRIPTION
This check was already being done for `nullptr_t` but now it applies more generally. Also adds logic to print qualifiers of sugared typedef and typeof types.