### PR TITLE
Parser: non-outermost arrays can be qualified if they are typedef names

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -3577,7 +3577,7 @@ const Declarator = struct {
                     if (elem_array_ty.len == .static) {
                         try p.err(source_tok, .static_non_outermost_array, .{});
                     }
-                    if (elem_qt.isQualified()) {
+                    if (elem_qt.isQualified() and elem_qt.type(p.comp) != .typedef) {
                         try p.err(source_tok, .qualifier_non_outermost_array, .{});
                     }
                 }

--- a/test/cases/typedef array qualifiers.c
+++ b/test/cases/typedef array qualifiers.c
@@ -1,0 +1,11 @@
+typedef float Pixel_FFFF[4];
+const Pixel_FFFF table[256];
+volatile Pixel_FFFF other_table[2];
+
+void invalid(int a[3][const 4]);
+
+/** manifest:
+syntax
+
+typedef array qualifiers.c:5:19: error: type qualifier used in non-outermost array type
+*/


### PR DESCRIPTION
Fixes #994