### PR TITLE
build: update zig version

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
 
     .fingerprint = 0x76501fb842f52025, // Changing this has security and trust implications.
 
-    .minimum_zig_version = "0.17.0-dev.298+ad1b746e2",
+    .minimum_zig_version = "0.17.0-dev.644+3de725074",
 
     .dependencies = .{},
 


### PR DESCRIPTION
Updates Zig to newest master. This is already used in CI.

Aro currently does not build with the Zig version in the Zon file.