### PR TITLE
Preprocessor: skip whitespace when evaluating expressions

### DIFF
--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -1176,7 +1176,7 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
         removePlacemarkers(gpa, &pp.top_expansion_buf);
     }
     for (pp.top_expansion_buf.items) |tok| {
-        if (tok.id == .macro_ws) continue;
+        if (tok.id == .macro_ws or tok.id == .whitespace) continue;
         if (!tok.id.validPreprocessorExprStart()) {
             try pp.err(tok, .invalid_preproc_expr_start, .{});
             return false;

--- a/test/cases/placemarker at expr start.c
+++ b/test/cases/placemarker at expr start.c
@@ -10,6 +10,11 @@
 # define SZ_KEYINFO_0   sizeof(KeyInfo)
 #endif
 
+#define FOO
+#if FOO + 1 != 1
+#error
+#endif
+
 
 /** manifest:
 syntax


### PR DESCRIPTION
The existing test in `placemarker at expr start.c` missed this one because the lhs of `#if FLEXARRAY+1 > 1` expands to: `<PLACEMARKER><UNARY PLUS><ONE>` - there are no whitespace tokens