### PR TITLE
Preprocessor: preprocessor expressions must end with eof

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -5905,12 +5905,16 @@ fn returnStmt(p: *Parser) Error!?Node.Index {
 
 // ====== expressions ======
 
-pub fn macroExpr(p: *Parser) Compilation.Error!bool {
+pub fn macroExpr(p: *Parser, check_trailing: bool) Compilation.Error!bool {
     const res = p.expect(condExpr) catch |e| switch (e) {
         error.OutOfMemory => return error.OutOfMemory,
         error.FatalError => return error.FatalError,
         error.ParsingFailed => return false,
     };
+    if (check_trailing and p.tok_ids[p.tok_i] != .eof) {
+        try p.err(p.tok_i, .invalid_preproc_operator, .{});
+        return false;
+    }
     return res.val.toBool(p.comp);
 }
 

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -1154,6 +1154,7 @@ fn restoreTokenState(pp: *Preprocessor, state: TokenState) void {
 fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
     const gpa = pp.comp.gpa;
     const token_state = pp.getTokenState();
+    const error_count = pp.diagnostics.errors;
     defer {
         for (pp.top_expansion_buf.items) |tok| TokenWithExpansionLocs.free(tok.expansion_locs, gpa);
         pp.restoreTokenState(token_state);
@@ -1278,7 +1279,7 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
         .string_ids = undefined,
     };
     defer parser.strings.deinit(gpa);
-    return parser.macroExpr();
+    return parser.macroExpr(pp.diagnostics.errors == error_count);
 }
 
 /// Turns macro_tok from .keyword_defined into .zero or .one depending on whether the argument is defined

--- a/test/cases/msp430 builtin types.c
+++ b/test/cases/msp430 builtin types.c
@@ -1,7 +1,7 @@
 #include <stddef.h>
 #include <stdarg.h>
 
-#if !defined(MSP430) or !defined(__MSP430__)
+#if !defined(MSP430) || !defined(__MSP430__)
 #error "Missing target macros"
 #endif
 

--- a/test/cases/preprocessor binary operators.c
+++ b/test/cases/preprocessor binary operators.c
@@ -62,6 +62,9 @@ error "failed"
 #if 1 + &x
 #endif
 
+#if 1 < ABC 2
+#endif
+
 /** manifest:
 syntax
 
@@ -80,4 +83,5 @@ preprocessor binary operators.c:53:13: note: expanded from here
 preprocessor binary operators.c:58:5: error: invalid token at start of a preprocessor expression
 preprocessor binary operators.c:53:13: note: expanded from here
 preprocessor binary operators.c:62:9: error: token is not a valid binary operator in a preprocessor subexpression
+preprocessor binary operators.c:65:13: error: token is not a valid binary operator in a preprocessor subexpression
 */


### PR DESCRIPTION
Fixes #687