### PR TITLE
Parser: ARM exclusive call type checking

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -705,65 +705,10 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
             }
 
             var arm_version: u8 = 6;
-            const arm_features = target.cpu.features;
-            for ([_]struct { std.Target.arm.Feature, []const u8 }{
-                .{ .v9_6a, "9_6A" },
-                .{ .v9_5a, "9_5A" },
-                .{ .v9_4a, "9_4A" },
-                .{ .v9_3a, "9_3A" },
-                .{ .v9_2a, "9_2A" },
-                .{ .v9_1a, "9_1A" },
-                .{ .v9a, "9A" },
-
-                .{ .v8_9a, "8_9A" },
-                .{ .v8_8a, "8_8A" },
-                .{ .v8_7a, "8_7A" },
-                .{ .v8_6a, "8_6A" },
-                .{ .v8_5a, "8_5A" },
-                .{ .v8_4a, "8_4A" },
-                .{ .v8_3a, "8_3A" },
-                .{ .v8_2a, "8_2A" },
-                .{ .v8_1a, "8_1A" },
-                .{ .v8_1m_main, "8_1M_MAIN" },
-                .{ .v8a, "8A" },
-                .{ .v8r, "8R" },
-                .{ .v8m_main, "8M_MAIN" },
-                .{ .v8m, "8M_BASE" },
-
-                .{ .v7ve, "7VE" },
-                .{ .v7a, "7A" },
-                .{ .v7r, "7R" },
-                .{ .v7m, "7M" },
-                .{ .v7em, "7EM" },
-                .{ .has_v7, "7A" }, // bare armv7 with no profile: default to A
-
-                .{ .v6t2, "6T2" },
-                .{ .v6kz, "6KZ" },
-                .{ .v6k, "6K" },
-                .{ .v6j, "6J" },
-                .{ .v6sm, "6SM" },
-                .{ .v6m, "6M" },
-                .{ .v6, "6" },
-
-                .{ .v5tej, "5TEJ" },
-                .{ .v5te, "5TE" },
-                .{ .v5t, "5T" },
-
-                .{ .v4t, "4T" },
-                .{ .v4, "4" },
-
-                .{ .v3m, "3M" },
-                .{ .v3, "3" },
-
-                .{ .v2a, "2A" },
-                .{ .v2, "2" },
-            }) |fs| {
-                if (arm_features.isEnabled(@intFromEnum(fs[0]))) {
-                    try w.print("#define __ARM_ARCH_{s}__ 1\n", .{fs[1]});
-                    arm_version = fs[1][0] - '0';
-                    try w.print("#define __ARM_ARCH {d}\n", .{arm_version});
-                    break;
-                }
+            if (target.armVersion()) |v| {
+                arm_version = v.version;
+                try w.print("#define __ARM_ARCH_{s}__ 1\n", .{v.string});
+                try w.print("#define __ARM_ARCH {d}\n", .{v.version});
             }
 
             const arm_profile: ?u8 =
@@ -810,29 +755,8 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
                 try define(w, "__ARM_FEATURE_SIMD32");
             }
 
-            // See this: https://arm-software.github.io/acle/main/acle.html#ldrexstrex
-            // These constants define masks containing data sizes are suitable for __builtin_arm_ldrex and __builtin_arm_strex.
-            const ARM_LDREX_B: u4 = 1 << 0; // byte (8-bit)
-            const ARM_LDREX_H: u4 = 1 << 1; // half (16-bit)
-            const ARM_LDREX_W: u4 = 1 << 2; // word (32-bit)
-            const ARM_LDREX_D: u4 = 1 << 3; // double (64-bit)
-
-            const ldrex: u4 = switch (arm_version) {
-                6 => if (target.cpu.has(.arm, .mclass))
-                    0
-                else if (target.cpu.has(.arm, .v6k) or target.cpu.has(.arm, .v6kz))
-                    ARM_LDREX_D | ARM_LDREX_W | ARM_LDREX_H | ARM_LDREX_B
-                else
-                    ARM_LDREX_W,
-                7, 8 => if (target.cpu.has(.arm, .mclass))
-                    ARM_LDREX_W | ARM_LDREX_H | ARM_LDREX_B
-                else
-                    ARM_LDREX_D | ARM_LDREX_W | ARM_LDREX_H | ARM_LDREX_B,
-                9 => ARM_LDREX_D | ARM_LDREX_W | ARM_LDREX_H | ARM_LDREX_B,
-                else => 0,
-            };
-            if (ldrex != 0) {
-                try w.print("#define __ARM_FEATURE_LDREX 0x{x}\n", .{ldrex});
+            if (comp.langopts.arm_ldrex) |ldrex| {
+                try w.print("#define __ARM_FEATURE_LDREX 0x{x}\n", .{@as(u4, @bitCast(ldrex))});
             }
 
             if (!target.cpu.has(.arm, .strict_align)) {
@@ -865,7 +789,9 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
             try define(w, "__ARM_ARCH_ISA_A64");
             try define(w, "__ARM_FEATURE_CLZ");
             try define(w, "__ARM_FEATURE_FMA");
-            try w.writeAll("#define __ARM_FEATURE_LDREX 0xF\n");
+            if (comp.langopts.arm_ldrex) |ldrex| {
+                try w.print("#define __ARM_FEATURE_LDREX 0x{x}\n", .{@as(u4, @bitCast(ldrex))});
+            }
             try define(w, "__ARM_FEATURE_IDIV"); // As specified in ACLE
             try define(w, "__ARM_FEATURE_DIV"); // For backwards compatibility
             try define(w, "__ARM_STATE_ZA");

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -875,6 +875,7 @@ pub fn parseArgs(
         if (d.raw_darwin_variant_target_triple) |darwin_triple| {
             d.comp.darwin_target_variant = try d.parseTarget(darwin_triple, null);
         }
+        d.comp.langopts.setTargetOptions(d.comp.target);
     }
     if (emulate != null or d.raw_target_triple != null) {
         d.comp.langopts.setEmulatedCompiler(emulate orelse d.comp.target.systemCompiler());

--- a/src/aro/LangOpts.zig
+++ b/src/aro/LangOpts.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const char_info = @import("char_info.zig");
 const DiagnosticTag = @import("Diagnostics.zig").Tag;
+const Target = @import("Target.zig");
 
 pub const Compiler = enum {
     clang,
@@ -120,6 +121,20 @@ pub const Standard = enum {
     }
 };
 
+pub const ArmLdrex = packed struct(u4) {
+    b: bool = false, // byte (8-bit)
+    h: bool = false, // half (16-bit)
+    w: bool = false, // word (32-bit)
+    d: bool = false, // double (64-bit)
+
+    pub const b_int: u4 = 1;
+    pub const h_int: u4 = 2;
+    pub const w_int: u4 = 4;
+    pub const d_int: u4 = 8;
+    pub const none: ArmLdrex = .{};
+    pub const all: ArmLdrex = @bitCast(@as(u4, 15));
+};
+
 const LangOpts = @This();
 
 emulate: Compiler = .no,
@@ -161,6 +176,9 @@ default_symbol_visibility: std.builtin.SymbolVisibility = .default,
 
 blocks: bool = false,
 
+/// If non-null, contains ARM LDREX/STREX mask. Only populated on ARM targets.
+arm_ldrex: ?ArmLdrex = null,
+
 pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!void {
     self.standard = Standard.NameMap.get(name) orelse return error.InvalidStandard;
 }
@@ -197,4 +215,65 @@ pub fn allowFixedSizedIntSuffixes(self: *const LangOpts) bool {
         .clang, .no => self.ms_extensions,
         .gcc => false,
     };
+}
+
+pub fn setTargetOptions(self: *LangOpts, target: Target) void {
+    // TODO: Move more stuff here :)
+    switch (target.cpu.arch) {
+        .arm, .armeb, .thumb, .thumbeb => {
+            {
+                // ARM exclusive load/store support.
+                // See this: https://arm-software.github.io/acle/main/acle.html#ldrexstrex
+                // These constants define masks containing data sizes are suitable for
+                // __builtin_arm_ldrex and __builtin_arm_strex.
+
+                const arm_version = if (target.armVersion()) |v| v.version else 6;
+                const ldrex: ArmLdrex = switch (arm_version) {
+                    6 => if (target.cpu.has(.arm, .mclass))
+                        .none
+                    else if (target.cpu.has(.arm, .v6k) or target.cpu.has(.arm, .v6kz))
+                        .all
+                    else
+                        .{ .w = true },
+                    7, 8 => if (target.cpu.has(.arm, .mclass))
+                        .{ .b = true, .h = true, .w = true }
+                    else
+                        .all,
+                    9 => .all,
+                    else => .none,
+                };
+
+                self.arm_ldrex = ldrex;
+            }
+        },
+        .aarch64, .aarch64_be => {
+            // ARM ldrex is always full-width
+            self.arm_ldrex = .all;
+        },
+        else => {},
+    }
+}
+
+test "ArmLdrex versions" {
+    const cases = [_]struct {
+        ldrex: ArmLdrex,
+        val: u4,
+    }{
+        .{ .ldrex = .{ .b = true }, .val = 1 },
+        .{ .ldrex = .{ .b = true, .h = true }, .val = 3 },
+        .{ .ldrex = .{ .b = true, .h = true, .w = true }, .val = 7 },
+        .{ .ldrex = .{ .b = true, .h = true, .w = true, .d = true }, .val = 15 },
+
+        .{ .ldrex = .{ .b = true }, .val = ArmLdrex.b_int },
+        .{ .ldrex = .{ .h = true }, .val = ArmLdrex.h_int },
+        .{ .ldrex = .{ .w = true }, .val = ArmLdrex.w_int },
+        .{ .ldrex = .{ .d = true }, .val = ArmLdrex.d_int },
+
+        .{ .ldrex = .none, .val = 0 },
+        .{ .ldrex = .all, .val = 15 },
+    };
+
+    for (cases) |c| {
+        try std.testing.expectEqual(c.val, @as(u4, @bitCast(c.ldrex)));
+    }
 }

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -30,6 +30,7 @@ const TypeStore = @import("TypeStore.zig");
 const Type = TypeStore.Type;
 const QualType = TypeStore.QualType;
 const Value = @import("Value.zig");
+const ArmLdrex = @import("LangOpts.zig").ArmLdrex;
 
 const NodeList = std.ArrayList(Node.Index);
 const TentativeDefinitionKey = struct {
@@ -6079,6 +6080,24 @@ const CallExpr = union(enum) {
                 => return p.checkSyncArg(param_tok, arg, arg_idx, 3),
                 else => {},
             },
+            .aarch64 => |tag| switch (tag) {
+                .__builtin_arm_ldrex,
+                .__builtin_arm_ldaex,
+                .__builtin_arm_strex,
+                .__builtin_arm_stlex,
+                => return p.checkARMExclusive(self.builtin.expanded.tag, builtin_tok, param_tok, arg, arg_idx),
+                else => {},
+            },
+            .arm => |tag| switch (tag) {
+                .__builtin_arm_ldrex,
+                .__builtin_arm_ldrexd,
+                .__builtin_arm_ldaex,
+                .__builtin_arm_strex,
+                .__builtin_arm_strexd,
+                .__builtin_arm_stlex,
+                => return p.checkARMExclusive(self.builtin.expanded.tag, builtin_tok, param_tok, arg, arg_idx),
+                else => {},
+            },
             else => {},
         }
     }
@@ -6195,6 +6214,28 @@ const CallExpr = union(enum) {
                     .__builtin_elementwise_clzg,
                     .__builtin_elementwise_ctzg,
                     => null,
+                    else => null,
+                },
+                .aarch64 => |tag| switch (tag) {
+                    .__builtin_arm_ldrex,
+                    .__builtin_arm_ldaex,
+                    => 1,
+
+                    .__builtin_arm_strex,
+                    .__builtin_arm_stlex,
+                    => 2,
+                    else => null,
+                },
+                .arm => |tag| switch (tag) {
+                    .__builtin_arm_ldrex,
+                    .__builtin_arm_ldrexd,
+                    .__builtin_arm_ldaex,
+                    => 1,
+
+                    .__builtin_arm_strex,
+                    .__builtin_arm_strexd,
+                    .__builtin_arm_stlex,
+                    => 2,
                     else => null,
                 },
                 else => null,
@@ -6343,6 +6384,34 @@ const CallExpr = union(enum) {
                     if (!first_param.isPointer(p.comp)) return .invalid;
                     return first_param.childType(p.comp);
                 },
+                else => func_ty.return_type,
+            },
+            .aarch64 => |tag| switch (tag) {
+                .__builtin_arm_ldrex,
+                .__builtin_arm_ldaex,
+                => {
+                    const first_param = args[0].qt(&p.tree);
+                    if (!first_param.isPointer(p.comp)) return .invalid;
+                    return first_param.childType(p.comp);
+                },
+                .__builtin_arm_strex,
+                .__builtin_arm_stlex,
+                => .int, // STREX/STREXD returns int
+                else => func_ty.return_type,
+            },
+            .arm => |tag| switch (tag) {
+                .__builtin_arm_ldrex,
+                .__builtin_arm_ldrexd,
+                .__builtin_arm_ldaex,
+                => {
+                    const first_param = args[0].qt(&p.tree);
+                    if (!first_param.isPointer(p.comp)) return .invalid;
+                    return first_param.childType(p.comp);
+                },
+                .__builtin_arm_strex,
+                .__builtin_arm_strexd,
+                .__builtin_arm_stlex,
+                => .int, // STREX/STREXD returns int
                 else => func_ty.return_type,
             },
             else => func_ty.return_type,
@@ -9620,6 +9689,146 @@ fn checkComplexArg(p: *Parser, builtin_tok: TokenIndex, first_after: TokenIndex,
             try p.err(param_tok, .argument_types_differ, .{ prev_qt, arg.qt });
         }
     }
+}
+
+fn checkARMExclusive(
+    p: *Parser,
+    tag: Builtins.Tag,
+    builtin_tok: TokenIndex,
+    param_tok: TokenIndex,
+    arg: *Result,
+    idx: u32,
+) !void {
+    const name = p.tokSlice(builtin_tok);
+    const is_ldrex = switch (tag) {
+        .aarch64 => |t| switch (t) {
+            .__builtin_arm_ldrex, .__builtin_arm_ldaex => true,
+            else => false,
+        },
+        .arm => |t| switch (t) {
+            .__builtin_arm_ldrex, .__builtin_arm_ldrexd, .__builtin_arm_ldaex => true,
+            else => false,
+        },
+        else => false,
+    };
+    const is_dword = switch (tag) {
+        .arm => |t| switch (t) {
+            .__builtin_arm_ldrexd, .__builtin_arm_strexd => true,
+            else => false,
+        },
+        else => false,
+    };
+
+    // Fast-path return based on arg index
+    switch (is_ldrex) {
+        true => switch (idx) {
+            0 => {},
+            else => return, // Too many arguments
+        },
+        false => switch (idx) {
+            0 => return, // We check source args for strex after checking the destination
+            1 => {},
+            else => return, // Too many arguments
+        },
+    }
+
+    // Arg should be a pointer
+    const orig_ptr_arg = arg.qt; // For errors
+    const ptr_arg = orig_ptr_arg.get(p.comp, .pointer) orelse
+        return p.err(param_tok, .builtin_arm_ldrex_strex_invalid_ptr_type, .{ name, orig_ptr_arg });
+
+    const ptr_arg_child = ptr_arg.child;
+    {
+        // Insert implicit cast to "const volatile" (ldrex) or "volatile"
+        // (strex).
+        var ptr_arg_child_coerced = ptr_arg_child.unqualified();
+        switch (is_ldrex) {
+            true => {
+                ptr_arg_child_coerced.@"const" = true;
+                ptr_arg_child_coerced.@"volatile" = true;
+            },
+            false => {
+                ptr_arg_child_coerced.@"volatile" = true;
+            },
+        }
+        const qt = try p.comp.type_store.put(p.comp.gpa, .{ .pointer = .{
+            .child = ptr_arg_child_coerced,
+        } });
+        try arg.coerce(p, qt, param_tok, .{ .arg = null });
+    }
+
+    // Child should be a int, float, or pointer
+    const ptr_arg_child_scalar = ptr_arg_child.scalarKind(p.comp);
+    const is_valid_number = (ptr_arg_child_scalar.isInt() or
+        ptr_arg_child_scalar.isFloat()) and
+        ptr_arg_child_scalar.isReal();
+    if (!is_valid_number and !ptr_arg_child_scalar.isPointer()) {
+        // Cannot continue without a valid child type
+        return p.err(param_tok, .builtin_arm_ldrex_strex_invalid_ptr_type, .{ name, orig_ptr_arg });
+    }
+
+    {
+        // Check child type size
+        const ptr_arg_bit_size = ptr_arg_child.bitSizeof(p.comp);
+        var mask: u4 = @bitCast(p.comp.langopts.arm_ldrex orelse ArmLdrex.none);
+
+        if (is_dword) {
+            // ldrexd has been used explicitly
+            mask &= ArmLdrex.d_int;
+        }
+
+        if (mask == 0) {
+            // Unsupported on this CPU, no point in continuing
+            return p.err(builtin_tok, .builtin_arm_ldrex_strex_unsupported, .{name});
+        }
+
+        const supported = std.math.isPowerOfTwo(ptr_arg_bit_size) and
+            ptr_arg_bit_size <= 64 and
+            ptr_arg_bit_size >= 8 and
+            (mask & (ptr_arg_bit_size / 8) != 0);
+        if (!supported) {
+            // "1, 2, 4 or 8" is max 12 bytes
+            var buf: [12]u8 = undefined;
+            var writer: std.Io.Writer = .fixed(&buf);
+            const sizes: [4]u4 = .{ ArmLdrex.b_int, ArmLdrex.h_int, ArmLdrex.w_int, ArmLdrex.d_int };
+            for (sizes) |size| {
+                if (mask & size != 0) {
+                    mask &= ~size;
+                    if (writer.end == 0) {
+                        // First element
+                        writer.print("{d}", .{size}) catch break;
+                    } else if (mask != 0) {
+                        // Middle item(s) w/separator
+                        writer.print(", {d}", .{size}) catch break;
+                    } else {
+                        // Last size with multiple sizes
+                        writer.print(" or {d}", .{size}) catch break;
+                    }
+                }
+            }
+
+            try p.err(param_tok, .builtin_arm_ldrex_strex_unsupported_size, .{
+                name,
+                writer.buffered(),
+                orig_ptr_arg,
+            });
+        }
+    }
+
+    if (is_ldrex) {
+        return; // Done for ldrex
+    }
+
+    assert(idx == 1); // strex only has 2 args and we skip idx 0 at the start
+
+    // Set up the coercion for the value arg for strex
+    const value_idx = p.list_buf.items[p.list_buf.items.len - 1]; // Always previous arg to ptr arg
+    var value_arg: Result = .{
+        .node = value_idx,
+        .qt = value_idx.qt(&p.tree),
+    };
+    try value_arg.coerce(p, ptr_arg_child, value_idx.tok(&p.tree), .{ .arg = null });
+    p.list_buf.items[p.list_buf.items.len - 1] = value_arg.node;
 }
 
 fn checkElementwiseArg(

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -7604,13 +7604,14 @@ pub const Result = struct {
                         (src_child.@"volatile" and !dest_child.@"volatile") or
                         (src_child.restrict and !dest_child.restrict))
                     {
-                        try p.err(tok, switch (c) {
-                            .assign => .ptr_assign_discards_quals,
-                            .init => .ptr_init_discards_quals,
-                            .ret => .ptr_ret_discards_quals,
-                            .arg => .ptr_arg_discards_quals,
+                        const data: struct { diag: Diagnostic, qts: [2]QualType } = switch (c) {
+                            .assign => .{ .diag = .ptr_assign_discards_quals, .qts = .{ dest_qt, src_original_qt } },
+                            .init => .{ .diag = .ptr_init_discards_quals, .qts = .{ dest_qt, src_original_qt } },
+                            .ret => .{ .diag = .ptr_ret_discards_quals, .qts = .{ src_original_qt, dest_qt } },
+                            .arg => .{ .diag = .ptr_arg_discards_quals, .qts = .{ src_original_qt, dest_qt } },
                             .test_coerce => return error.CoercionFailed,
-                        }, .{ dest_qt, src_original_qt });
+                        };
+                        try p.err(tok, data.diag, .{ data.qts[0], data.qts[1] });
                     }
                     try res.castToPointer(p, dest_unqual, tok);
                     return;

--- a/src/aro/Parser/Diagnostic.zig
+++ b/src/aro/Parser/Diagnostic.zig
@@ -2601,3 +2601,18 @@ pub const c23_attribute: Diagnostic = .{
     .suppress_version = .c23,
     .extension = true,
 };
+
+pub const builtin_arm_ldrex_strex_invalid_ptr_type: Diagnostic = .{
+    .fmt = "address argument to {s} must be a pointer to integer, floating-point, or pointer ({qt} invalid)",
+    .kind = .@"error",
+};
+
+pub const builtin_arm_ldrex_strex_unsupported: Diagnostic = .{
+    .fmt = "{s} is not supported on this architecture",
+    .kind = .@"error",
+};
+
+pub const builtin_arm_ldrex_strex_unsupported_size: Diagnostic = .{
+    .fmt = "address argument to {s} must be a pointer to {s} byte type ({qt} invalid)",
+    .kind = .@"error",
+};

--- a/src/aro/Target.zig
+++ b/src/aro/Target.zig
@@ -10,6 +10,8 @@ const builtin = @import("builtin");
 const LangOpts = @import("LangOpts.zig");
 const QualType = @import("TypeStore.zig").QualType;
 
+const assert = std.debug.assert;
+
 pub const Vendor = enum {
     apple,
     pc,
@@ -1787,6 +1789,71 @@ pub fn parseOs(result: *std.Target.Query, text: []const u8, version_string: ?*[]
             }
         },
     };
+}
+
+pub fn armVersion(target: Target) ?struct { version: u8, string: []const u8 } {
+    assert(target.cpu.arch.isArm());
+    for ([_]struct { std.Target.arm.Feature, []const u8 }{
+        .{ .v9_6a, "9_6A" },
+        .{ .v9_5a, "9_5A" },
+        .{ .v9_4a, "9_4A" },
+        .{ .v9_3a, "9_3A" },
+        .{ .v9_2a, "9_2A" },
+        .{ .v9_1a, "9_1A" },
+        .{ .v9a, "9A" },
+
+        .{ .v8_9a, "8_9A" },
+        .{ .v8_8a, "8_8A" },
+        .{ .v8_7a, "8_7A" },
+        .{ .v8_6a, "8_6A" },
+        .{ .v8_5a, "8_5A" },
+        .{ .v8_4a, "8_4A" },
+        .{ .v8_3a, "8_3A" },
+        .{ .v8_2a, "8_2A" },
+        .{ .v8_1a, "8_1A" },
+        .{ .v8_1m_main, "8_1M_MAIN" },
+        .{ .v8a, "8A" },
+        .{ .v8r, "8R" },
+        .{ .v8m_main, "8M_MAIN" },
+        .{ .v8m, "8M_BASE" },
+
+        .{ .v7ve, "7VE" },
+        .{ .v7a, "7A" },
+        .{ .v7r, "7R" },
+        .{ .v7m, "7M" },
+        .{ .v7em, "7EM" },
+        .{ .has_v7, "7A" }, // bare armv7 with no profile: default to A
+
+        .{ .v6t2, "6T2" },
+        .{ .v6kz, "6KZ" },
+        .{ .v6k, "6K" },
+        .{ .v6j, "6J" },
+        .{ .v6sm, "6SM" },
+        .{ .v6m, "6M" },
+        .{ .v6, "6" },
+
+        .{ .v5tej, "5TEJ" },
+        .{ .v5te, "5TE" },
+        .{ .v5t, "5T" },
+
+        .{ .v4t, "4T" },
+        .{ .v4, "4" },
+
+        .{ .v3m, "3M" },
+        .{ .v3, "3" },
+
+        .{ .v2a, "2A" },
+        .{ .v2, "2" },
+    }) |fs| {
+        if (target.cpu.features.isEnabled(@intFromEnum(fs[0]))) {
+            return .{
+                .version = fs[1][0] - '0',
+                .string = fs[1],
+            };
+        }
+    }
+
+    return null;
 }
 
 test parseOs {

--- a/test/cases/arm-acle-7.5 llvm-21.c
+++ b/test/cases/arm-acle-7.5 llvm-21.c
@@ -1,0 +1,17 @@
+// This is just a basic syntax check for arm_acle.h on LLVM/clang <= 21. Note
+// that Zig 0.17.0 and higher will have LLVM 22, which actually removes these
+// builtins from use in __swp, but the builtins are still present, so we should
+// still test them.
+
+int swp(int x, int *p) {
+  int v;
+  do 
+   v = __builtin_arm_ldrex(p);
+  while (__builtin_arm_strex(x, p));
+  return v;
+}
+
+/** manifest:
+syntax
+args = -target aarch64-linux
+*/

--- a/test/cases/builtins-arm-exclusive.c
+++ b/test/cases/builtins-arm-exclusive.c
@@ -1,0 +1,236 @@
+// Adapted from LLVM: https://github.com/llvm/llvm-project/blob/5ddae7ae330fdd9880ad512c986cbfb2faa26e1f/clang/test/Sema/builtins-arm-exclusive.c
+
+struct Simple {
+  char a, b;
+};
+
+int test_ldrex(char *addr) {
+  int sum = 0;
+  sum += __builtin_arm_ldrex(addr);
+  sum += __builtin_arm_ldrex((short *)addr);
+  sum += __builtin_arm_ldrex((int *)addr);
+  sum += __builtin_arm_ldrex((long long *)addr);
+  sum += __builtin_arm_ldrex((float *)addr);
+  sum += __builtin_arm_ldrex((double *)addr);
+  sum += *__builtin_arm_ldrex((int **)addr);
+  sum += __builtin_arm_ldrex((struct Simple **)addr)->a;
+  sum += __builtin_arm_ldrex((volatile char *)addr);
+  sum += __builtin_arm_ldrex((const volatile char *)addr);
+
+  // In principle this might be valid, but stick to ints and floats for scalar
+  // types at the moment.
+  sum += __builtin_arm_ldrex((struct Simple *)addr).a;
+
+  sum += __builtin_arm_ldrex((__int128 *)addr);
+
+  __builtin_arm_ldrex();
+  __builtin_arm_ldrex(1, 2);
+  return sum;
+}
+
+int test_strex(char *addr) {
+  int res = 0;
+  struct Simple var = {0};
+  res |= __builtin_arm_strex(4, addr);
+  res |= __builtin_arm_strex(42, (short *)addr);
+  res |= __builtin_arm_strex(42, (int *)addr);
+  res |= __builtin_arm_strex(42, (long long *)addr);
+  res |= __builtin_arm_strex(2.71828f, (float *)addr);
+  res |= __builtin_arm_strex(3.14159, (double *)addr);
+  res |= __builtin_arm_strex(&var, (struct Simple **)addr);
+
+  res |= __builtin_arm_strex(42, (volatile char *)addr);
+  res |= __builtin_arm_strex(42, (char *const)addr);
+  res |= __builtin_arm_strex(42, (const char *)addr);
+
+
+  res |= __builtin_arm_strex(var, (struct Simple *)addr);
+  res |= __builtin_arm_strex(var, (struct Simple **)addr);
+  res |= __builtin_arm_strex(&var, (struct Simple **)addr).a;
+
+  res |= __builtin_arm_strex(1, (__int128 *)addr);
+
+  __builtin_arm_strex(1);
+  __builtin_arm_strex(1, 2, 3);
+  return res;
+}
+
+int test_ldrexd(char *addr) {
+  int sum = 0;
+  sum += __builtin_arm_ldrexd(addr);
+  sum += __builtin_arm_ldrexd((short *)addr);
+  sum += __builtin_arm_ldrexd((int *)addr);
+  sum += __builtin_arm_ldrexd((long long *)addr);
+  sum += __builtin_arm_ldrexd((float *)addr);
+  sum += __builtin_arm_ldrexd((double *)addr);
+  sum += *__builtin_arm_ldrexd((int **)addr);
+  sum += __builtin_arm_ldrexd((struct Simple **)addr)->a;
+  sum += __builtin_arm_ldrexd((volatile char *)addr);
+  sum += __builtin_arm_ldrexd((const volatile char *)addr);
+
+  // In principle this might be valid, but stick to ints and floats for scalar
+  // types at the moment.
+  sum += __builtin_arm_ldrexd((struct Simple *)addr).a;
+
+  sum += __builtin_arm_ldrexd((__int128 *)addr);
+
+  __builtin_arm_ldrexd();
+  __builtin_arm_ldrexd(1, 2);
+  return sum;
+}
+
+int test_strexd(char *addr) {
+  int res = 0;
+  struct Simple var = {0};
+  res |= __builtin_arm_strexd(4, addr);
+  res |= __builtin_arm_strexd(42, (short *)addr);
+  res |= __builtin_arm_strexd(42, (int *)addr);
+  res |= __builtin_arm_strexd(42, (long long *)addr);
+  res |= __builtin_arm_strexd(2.71828f, (float *)addr);
+  res |= __builtin_arm_strexd(3.14159, (double *)addr);
+  res |= __builtin_arm_strexd(&var, (struct Simple **)addr);
+
+  res |= __builtin_arm_strexd(42, (volatile char *)addr);
+  res |= __builtin_arm_strexd(42, (char *const)addr);
+  res |= __builtin_arm_strexd(42, (const char *)addr);
+
+
+  res |= __builtin_arm_strexd(var, (struct Simple *)addr);
+  res |= __builtin_arm_strexd(var, (struct Simple **)addr);
+  res |= __builtin_arm_strexd(&var, (struct Simple **)addr).a;
+
+  res |= __builtin_arm_strexd(1, (__int128 *)addr);
+
+  __builtin_arm_strexd(1);
+  __builtin_arm_strexd(1, 2, 3);
+  return res;
+}
+
+int test_ldaex(char *addr) {
+  int sum = 0;
+  sum += __builtin_arm_ldaex(addr);
+  sum += __builtin_arm_ldaex((short *)addr);
+  sum += __builtin_arm_ldaex((int *)addr);
+  sum += __builtin_arm_ldaex((long long *)addr);
+  sum += __builtin_arm_ldaex((float *)addr);
+  sum += __builtin_arm_ldaex((double *)addr);
+  sum += *__builtin_arm_ldaex((int **)addr);
+  sum += __builtin_arm_ldaex((struct Simple **)addr)->a;
+  sum += __builtin_arm_ldaex((volatile char *)addr);
+  sum += __builtin_arm_ldaex((const volatile char *)addr);
+
+  // In principle this might be valid, but stick to ints and floats for scalar
+  // types at the moment.
+  sum += __builtin_arm_ldaex((struct Simple *)addr).a;
+
+  sum += __builtin_arm_ldaex((__int128 *)addr);
+
+  __builtin_arm_ldaex();
+  __builtin_arm_ldaex(1, 2);
+  return sum;
+}
+
+int test_stlex(char *addr) {
+  int res = 0;
+  struct Simple var = {0};
+  res |= __builtin_arm_stlex(4, addr);
+  res |= __builtin_arm_stlex(42, (short *)addr);
+  res |= __builtin_arm_stlex(42, (int *)addr);
+  res |= __builtin_arm_stlex(42, (long long *)addr);
+  res |= __builtin_arm_stlex(2.71828f, (float *)addr);
+  res |= __builtin_arm_stlex(3.14159, (double *)addr);
+  res |= __builtin_arm_stlex(&var, (struct Simple **)addr);
+
+  res |= __builtin_arm_stlex(42, (volatile char *)addr);
+  res |= __builtin_arm_stlex(42, (char *const)addr);
+  res |= __builtin_arm_stlex(42, (const char *)addr);
+
+
+  res |= __builtin_arm_stlex(var, (struct Simple *)addr);
+  res |= __builtin_arm_stlex(var, (struct Simple **)addr);
+  res |= __builtin_arm_stlex(&var, (struct Simple **)addr).a;
+
+  res |= __builtin_arm_stlex(1, (__int128 *)addr);
+
+  __builtin_arm_stlex(1);
+  __builtin_arm_stlex(1, 2, 3);
+  return res;
+}
+
+void test_clrex(void) {
+  __builtin_arm_clrex();
+  __builtin_arm_clrex(1);
+}
+
+/** manifest:
+syntax
+args = -target armv7a
+
+builtins-arm-exclusive.c:22:30: error: address argument to __builtin_arm_ldrex must be a pointer to integer, floating-point, or pointer ('struct Simple *' invalid)
+builtins-arm-exclusive.c:24:31: error: __int128 is not supported on this target
+builtins-arm-exclusive.c:24:30: error: address argument to __builtin_arm_ldrex must be a pointer to 1, 2, 4 or 8 byte type ('__int128 *' invalid)
+builtins-arm-exclusive.c:26:23: error: expected 1 argument(s) got 0
+builtins-arm-exclusive.c:27:23: error: address argument to __builtin_arm_ldrex must be a pointer to integer, floating-point, or pointer ('int' invalid)
+builtins-arm-exclusive.c:27:26: error: expected 1 argument(s) got 2
+builtins-arm-exclusive.c:43:34: warning: cast to type 'char *const' will not preserve qualifiers [-Wcast-qualifiers]
+builtins-arm-exclusive.c:44:34: warning: passing 'const char *' to parameter of incompatible type 'volatile char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
+builtins-arm-exclusive.c:47:35: error: address argument to __builtin_arm_strex must be a pointer to integer, floating-point, or pointer ('struct Simple *' invalid)
+builtins-arm-exclusive.c:48:30: error: passing 'struct Simple' to parameter of incompatible type 'struct Simple *'
+builtins-arm-exclusive.c:49:60: error: member reference base type 'int' is not a structure or union
+builtins-arm-exclusive.c:51:34: error: __int128 is not supported on this target
+builtins-arm-exclusive.c:51:33: error: address argument to __builtin_arm_strex must be a pointer to 1, 2, 4 or 8 byte type ('__int128 *' invalid)
+builtins-arm-exclusive.c:53:24: error: expected 2 argument(s) got 1
+builtins-arm-exclusive.c:54:26: error: address argument to __builtin_arm_strex must be a pointer to integer, floating-point, or pointer ('int' invalid)
+builtins-arm-exclusive.c:54:29: error: expected 2 argument(s) got 3
+builtins-arm-exclusive.c:60:31: error: address argument to __builtin_arm_ldrexd must be a pointer to 8 byte type ('char *' invalid)
+builtins-arm-exclusive.c:61:31: error: address argument to __builtin_arm_ldrexd must be a pointer to 8 byte type ('short *' invalid)
+builtins-arm-exclusive.c:62:31: error: address argument to __builtin_arm_ldrexd must be a pointer to 8 byte type ('int *' invalid)
+builtins-arm-exclusive.c:64:31: error: address argument to __builtin_arm_ldrexd must be a pointer to 8 byte type ('float *' invalid)
+builtins-arm-exclusive.c:66:32: error: address argument to __builtin_arm_ldrexd must be a pointer to 8 byte type ('int **' invalid)
+builtins-arm-exclusive.c:67:31: error: address argument to __builtin_arm_ldrexd must be a pointer to 8 byte type ('struct Simple **' invalid)
+builtins-arm-exclusive.c:68:31: error: address argument to __builtin_arm_ldrexd must be a pointer to 8 byte type ('volatile char *' invalid)
+builtins-arm-exclusive.c:69:31: error: address argument to __builtin_arm_ldrexd must be a pointer to 8 byte type ('const volatile char *' invalid)
+builtins-arm-exclusive.c:73:31: error: address argument to __builtin_arm_ldrexd must be a pointer to integer, floating-point, or pointer ('struct Simple *' invalid)
+builtins-arm-exclusive.c:75:32: error: __int128 is not supported on this target
+builtins-arm-exclusive.c:75:31: error: address argument to __builtin_arm_ldrexd must be a pointer to 8 byte type ('__int128 *' invalid)
+builtins-arm-exclusive.c:77:24: error: expected 1 argument(s) got 0
+builtins-arm-exclusive.c:78:24: error: address argument to __builtin_arm_ldrexd must be a pointer to integer, floating-point, or pointer ('int' invalid)
+builtins-arm-exclusive.c:78:27: error: expected 1 argument(s) got 2
+builtins-arm-exclusive.c:85:34: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('char *' invalid)
+builtins-arm-exclusive.c:86:35: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('short *' invalid)
+builtins-arm-exclusive.c:87:35: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('int *' invalid)
+builtins-arm-exclusive.c:89:41: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('float *' invalid)
+builtins-arm-exclusive.c:91:37: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('struct Simple **' invalid)
+builtins-arm-exclusive.c:93:35: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('volatile char *' invalid)
+builtins-arm-exclusive.c:94:35: warning: cast to type 'char *const' will not preserve qualifiers [-Wcast-qualifiers]
+builtins-arm-exclusive.c:94:35: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('char *' invalid)
+builtins-arm-exclusive.c:95:35: warning: passing 'const char *' to parameter of incompatible type 'volatile char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
+builtins-arm-exclusive.c:95:35: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('const char *' invalid)
+builtins-arm-exclusive.c:98:36: error: address argument to __builtin_arm_strexd must be a pointer to integer, floating-point, or pointer ('struct Simple *' invalid)
+builtins-arm-exclusive.c:99:36: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('struct Simple **' invalid)
+builtins-arm-exclusive.c:99:31: error: passing 'struct Simple' to parameter of incompatible type 'struct Simple *'
+builtins-arm-exclusive.c:100:37: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('struct Simple **' invalid)
+builtins-arm-exclusive.c:100:61: error: member reference base type 'int' is not a structure or union
+builtins-arm-exclusive.c:102:35: error: __int128 is not supported on this target
+builtins-arm-exclusive.c:102:34: error: address argument to __builtin_arm_strexd must be a pointer to 8 byte type ('__int128 *' invalid)
+builtins-arm-exclusive.c:104:25: error: expected 2 argument(s) got 1
+builtins-arm-exclusive.c:105:27: error: address argument to __builtin_arm_strexd must be a pointer to integer, floating-point, or pointer ('int' invalid)
+builtins-arm-exclusive.c:105:30: error: expected 2 argument(s) got 3
+builtins-arm-exclusive.c:124:30: error: address argument to __builtin_arm_ldaex must be a pointer to integer, floating-point, or pointer ('struct Simple *' invalid)
+builtins-arm-exclusive.c:126:31: error: __int128 is not supported on this target
+builtins-arm-exclusive.c:126:30: error: address argument to __builtin_arm_ldaex must be a pointer to 1, 2, 4 or 8 byte type ('__int128 *' invalid)
+builtins-arm-exclusive.c:128:23: error: expected 1 argument(s) got 0
+builtins-arm-exclusive.c:129:23: error: address argument to __builtin_arm_ldaex must be a pointer to integer, floating-point, or pointer ('int' invalid)
+builtins-arm-exclusive.c:129:26: error: expected 1 argument(s) got 2
+builtins-arm-exclusive.c:145:34: warning: cast to type 'char *const' will not preserve qualifiers [-Wcast-qualifiers]
+builtins-arm-exclusive.c:146:34: warning: passing 'const char *' to parameter of incompatible type 'volatile char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
+builtins-arm-exclusive.c:149:35: error: address argument to __builtin_arm_stlex must be a pointer to integer, floating-point, or pointer ('struct Simple *' invalid)
+builtins-arm-exclusive.c:150:30: error: passing 'struct Simple' to parameter of incompatible type 'struct Simple *'
+builtins-arm-exclusive.c:151:60: error: member reference base type 'int' is not a structure or union
+builtins-arm-exclusive.c:153:34: error: __int128 is not supported on this target
+builtins-arm-exclusive.c:153:33: error: address argument to __builtin_arm_stlex must be a pointer to 1, 2, 4 or 8 byte type ('__int128 *' invalid)
+builtins-arm-exclusive.c:155:24: error: expected 2 argument(s) got 1
+builtins-arm-exclusive.c:156:26: error: address argument to __builtin_arm_stlex must be a pointer to integer, floating-point, or pointer ('int' invalid)
+builtins-arm-exclusive.c:156:29: error: expected 2 argument(s) got 3
+builtins-arm-exclusive.c:162:23: error: expected 0 argument(s) got 1
+*/


### PR DESCRIPTION
This adds custom type checking for the following ARM exclusive builtins:

```
__builtin_arm_ldrex
__builtin_arm_ldrexd
__builtin_arm_ldaex
__builtin_arm_strex
__builtin_arm_strexd
__builtin_arm_stlex
```

The custom type checking follows what is in LLVM/clang, although there are some slight divergences on part of the fact that arg count and return types are handled separately from arg checking.

The following breakdown of these exclusive calls are as follows:

* Load calls take 1 argument (pointer source), store calls take two   (scalar value source, pointer destination).
* Pointer arguments must be a int/float/pointer type.
* Pointer arguments are coerced to `const volatile *` (load) or   `volatile *` (store). Warnings are surfaced appropriately through the standard coercion code path.
* Value arguments are coerced to the child type of the pointer argument.
* A check is performed to ensure that the pointer argument child is supported - currently, this is fetched from the compilation through a new optional field - the avoids having to repeat the complex version checking that has already been done by `Compilation`.

Tests are included for the old LLVM/clang 21 section in `arm_acle.h`. This is required by the Arm NEON headers, which is keeping us from using it on appropriate systems, e.g., Zig 0.16.0.

Also currently included is the main test ported from LLVM/clang for armv7a. This adequately allows us to test most points of the code in one go. LLVM has other headers for other more restrictive architectures that we can pull in if needed.