### PR TITLE
Compilation: fix bug in `removeDuplicateSearchPaths`

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -2035,7 +2035,7 @@ fn removeDuplicateSearchPaths(comp: *Compilation, start: usize, verbose: bool) !
                 continue;
             }
         } else {
-            const gop = try seen_frameworks.getOrPut(allocator, include.path);
+            const gop = try seen_includes.getOrPut(allocator, include.path);
             if (!gop.found_existing) {
                 comp.search_path.items[i] = include;
                 i += 1;


### PR DESCRIPTION
I think this was a copy and paste error.