### PR TITLE
TypeStore: compute array alignment directly from element alignment

### DIFF
--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -706,7 +706,7 @@ pub const QualType = packed struct(u32) {
 
             .func => comp.target.defaultFunctionAlignment(),
 
-            .array => |array| continue :loop array.elem.base(comp).type,
+            .array => |array| return array.elem.alignof(comp),
             .vector => |vector| continue :loop vector.elem.base(comp).type,
 
             .@"struct", .@"union" => |record| {

--- a/test/cases/alignment.c
+++ b/test/cases/alignment.c
@@ -48,6 +48,15 @@ void array_fixed(void) {
     _Static_assert(_Alignof(__typeof(a)) == 32, "");
 }
 
+void array_element_typedef(void) {
+    typedef int pair[2];
+    typedef pair elem __attribute__((aligned(8)));
+    typedef elem arr[3];
+    arr a = {{1, 2}, {3, 4}, {5, 6}};
+    _Static_assert(_Alignof(arr) == 8, "");
+    _Static_assert(_Alignof(__typeof(a)) == 8, "");
+}
+
 /** manifest:
 syntax
 args = -Wno-implicit-int

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -8,16 +8,8 @@ const process = std.process;
 /// Skip entirely.
 /// To skip a test entirely just put the test name as a single-element tuple e.g. initComptime(.{.{"0044"}});
 const global_test_exclude = std.StaticStringMap(void).initComptime(.{
-    .{"0008"},
-    .{"0010"},
     .{"0011"},
     .{"0014"},
-    .{"0017"},
-    .{"0018"},
-    .{"0025"},
-    .{"0026"},
-    .{"0042"},
-    .{"0045"},
     .{"0046"},
 });
 


### PR DESCRIPTION
Previously we were losing element attributes.