### PR TITLE
Parser: array element size must be a multiple of alignment

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -3661,6 +3661,13 @@ const Declarator = struct {
                     try p.err(source_tok, .array_func_elem, .{});
                     return .nested_invalid;
                 }
+                if (elem_qt.sizeofOrNull(p.comp)) |elem_size| {
+                    const elem_align = elem_qt.alignof(p.comp);
+                    if (elem_size % elem_align != 0) {
+                        try p.err(source_tok, .array_elem_size_not_multiple, .{ elem_qt, elem_size, elem_align });
+                        return .nested_invalid;
+                    }
+                }
                 if (elem_qt.get(p.comp, .array)) |elem_array_ty| {
                     if (elem_array_ty.len == .static) {
                         try p.err(source_tok, .static_non_outermost_array, .{});

--- a/src/aro/Parser/Diagnostic.zig
+++ b/src/aro/Parser/Diagnostic.zig
@@ -434,6 +434,11 @@ pub const array_incomplete_elem: Diagnostic = .{
     .kind = .@"error",
 };
 
+pub const array_elem_size_not_multiple: Diagnostic = .{
+    .fmt = "size of array element of type {qt} ({d} bytes) isn't a multiple of its alignment ({d} bytes)",
+    .kind = .@"error",
+};
+
 pub const array_func_elem: Diagnostic = .{
     .fmt = "arrays cannot have functions as their element type",
     .kind = .@"error",

--- a/test/cases/alignment.c
+++ b/test/cases/alignment.c
@@ -57,6 +57,11 @@ void array_element_typedef(void) {
     _Static_assert(_Alignof(__typeof(a)) == 8, "");
 }
 
+void array_size_align_typedef(void) {
+    typedef int elem __attribute__((aligned(8)));
+    typedef elem arr[4];
+}
+
 /** manifest:
 syntax
 args = -Wno-implicit-int
@@ -72,5 +77,6 @@ alignment.c:13:10: error: requested negative alignment of -2 is invalid
 alignment.c:15:10: error: '_Alignas' attribute requires integer constant expression
 alignment.c:35:24: error: '_Alignas' attribute requires integer constant expression
 alignment.c:36:10: error: expression is not an integer constant expression
+alignment.c:62:21: error: size of array element of type 'elem' (aka 'int') (4 bytes) isn't a multiple of its alignment (8 bytes)
 */
 


### PR DESCRIPTION
Fixes #1046