### PR TITLE
Diagnostics: treat extra tokens at end of macro directive as warning

### DIFF
--- a/src/aro/Diagnostics.zig
+++ b/src/aro/Diagnostics.zig
@@ -204,6 +204,7 @@ pub const Option = enum {
     @"base-file-extension",
     @"include-level-extension",
     @"blocks-extension",
+    @"extra-tokens",
 
     /// GNU extensions
     pub const gnu = [_]Option{

--- a/src/aro/Preprocessor/Diagnostic.zig
+++ b/src/aro/Preprocessor/Diagnostic.zig
@@ -112,7 +112,8 @@ pub const macro_name_missing: Diagnostic = .{
 
 pub const extra_tokens_directive_end: Diagnostic = .{
     .fmt = "extra tokens at end of macro directive",
-    .kind = .@"error",
+    .kind = .warning,
+    .opt = .@"extra-tokens",
 };
 
 pub const expected_value_in_expr: Diagnostic = .{


### PR DESCRIPTION
Fixes #1049 