### PR TITLE
Hideset: store precomputed identifier slices

### DIFF
--- a/src/aro/Hideset.zig
+++ b/src/aro/Hideset.zig
@@ -13,25 +13,12 @@ const Allocator = mem.Allocator;
 
 const Compilation = @import("Compilation.zig");
 const Source = @import("Source.zig");
-const Tokenizer = @import("Tokenizer.zig");
 
 pub const Hideset = @This();
 
 const Identifier = struct {
     id: Source.Id = .unused,
     byte_offset: u32 = 0,
-
-    fn slice(self: Identifier, comp: *const Compilation) []const u8 {
-        var tmp_tokenizer: Tokenizer = .{
-            .buf = comp.getSource(self.id).buf,
-            .langopts = comp.langopts,
-            .index = self.byte_offset,
-            .source = .generated,
-            .splice_locs = &.{},
-        };
-        const res = tmp_tokenizer.next();
-        return tmp_tokenizer.buf[res.start..res.end];
-    }
 
     fn fromLocation(loc: Source.Location) Identifier {
         return .{
@@ -43,6 +30,7 @@ const Identifier = struct {
 
 const Item = struct {
     identifier: Identifier = .{},
+    str: []const u8,
     next: Index = .none,
 
     const List = std.MultiArrayList(Item);
@@ -58,24 +46,32 @@ map: std.AutoHashMapUnmanaged(Identifier, Index) = .{},
 /// until hideset is deinit'ed
 tmp_map: std.AutoHashMapUnmanaged(Identifier, void) = .{},
 linked_list: Item.List = .{},
-comp: *const Compilation,
+gpa: Allocator,
+
+const Temp = struct { identifier: Identifier, str: []const u8 };
 
 /// Invalidated if the underlying MultiArrayList slice is reallocated due to resize
 const Iterator = struct {
     slice: Item.List.Slice,
     i: Index,
 
-    fn next(self: *Iterator) ?Identifier {
+    fn next(self: *Iterator) ?Item {
         if (self.i == .none) return null;
         defer self.i = self.slice.items(.next)[@intFromEnum(self.i)];
-        return self.slice.items(.identifier)[@intFromEnum(self.i)];
+        const identifier = self.slice.items(.identifier)[@intFromEnum(self.i)];
+        const str = self.slice.items(.str)[@intFromEnum(self.i)];
+
+        return .{
+            .identifier = identifier,
+            .str = str,
+        };
     }
 };
 
 pub fn deinit(self: *Hideset) void {
-    self.map.deinit(self.comp.gpa);
-    self.tmp_map.deinit(self.comp.gpa);
-    self.linked_list.deinit(self.comp.gpa);
+    self.map.deinit(self.gpa);
+    self.tmp_map.deinit(self.gpa);
+    self.linked_list.deinit(self.gpa);
 }
 
 pub fn clearRetainingCapacity(self: *Hideset) void {
@@ -84,9 +80,9 @@ pub fn clearRetainingCapacity(self: *Hideset) void {
 }
 
 pub fn clearAndFree(self: *Hideset) void {
-    self.map.clearAndFree(self.comp.gpa);
-    self.tmp_map.clearAndFree(self.comp.gpa);
-    self.linked_list.shrinkAndFree(self.comp.gpa, 0);
+    self.map.clearAndFree(self.gpa);
+    self.tmp_map.clearAndFree(self.gpa);
+    self.linked_list.shrinkAndFree(self.gpa, 0);
 }
 
 /// Iterator is invalidated if the underlying MultiArrayList slice is reallocated due to resize
@@ -102,29 +98,29 @@ pub fn get(self: *const Hideset, loc: Source.Location) Index {
 }
 
 pub fn put(self: *Hideset, loc: Source.Location, value: Index) !void {
-    try self.map.put(self.comp.gpa, Identifier.fromLocation(loc), value);
+    try self.map.put(self.gpa, Identifier.fromLocation(loc), value);
 }
 
 fn ensureUnusedCapacity(self: *Hideset, new_size: usize) !void {
-    try self.linked_list.ensureUnusedCapacity(self.comp.gpa, new_size);
+    try self.linked_list.ensureUnusedCapacity(self.gpa, new_size);
 }
 
 /// Creates a one-item list with contents `identifier`
-fn createNodeAssumeCapacity(self: *Hideset, identifier: Identifier) Index {
-    return self.createNodeAssumeCapacityExtra(identifier, .none);
+fn createNodeAssumeCapacity(self: *Hideset, identifier: Identifier, str: []const u8) Index {
+    return self.createNodeAssumeCapacityExtra(identifier, .none, str);
 }
 
 /// Creates a one-item list with contents `identifier`
-fn createNodeAssumeCapacityExtra(self: *Hideset, identifier: Identifier, next: Index) Index {
+fn createNodeAssumeCapacityExtra(self: *Hideset, identifier: Identifier, next: Index, str: []const u8) Index {
     const next_idx = self.linked_list.len;
-    self.linked_list.appendAssumeCapacity(.{ .identifier = identifier, .next = next });
+    self.linked_list.appendAssumeCapacity(.{ .identifier = identifier, .next = next, .str = str });
     return @enumFromInt(next_idx);
 }
 
 /// Create a new list with `identifier` at the front followed by `tail`
-pub fn prepend(self: *Hideset, loc: Source.Location, tail: Index) !Index {
+pub fn prepend(self: *Hideset, loc: Source.Location, str: []const u8, tail: Index) !Index {
     const new_idx = self.linked_list.len;
-    try self.linked_list.append(self.comp.gpa, .{ .identifier = Identifier.fromLocation(loc), .next = tail });
+    try self.linked_list.append(self.gpa, .{ .identifier = Identifier.fromLocation(loc), .next = tail, .str = str });
     return @enumFromInt(new_idx);
 }
 
@@ -135,16 +131,16 @@ pub fn @"union"(self: *Hideset, a: Index, b: Index) !Index {
     self.tmp_map.clearRetainingCapacity();
 
     var it = self.iterator(b);
-    while (it.next()) |identifier| {
-        try self.tmp_map.put(self.comp.gpa, identifier, {});
+    while (it.next()) |item| {
+        try self.tmp_map.put(self.gpa, item.identifier, {});
     }
 
     var head: Index = b;
     try self.ensureUnusedCapacity(self.len(a));
     it = self.iterator(a);
-    while (it.next()) |identifier| {
-        if (!self.tmp_map.contains(identifier)) {
-            head = self.createNodeAssumeCapacityExtra(identifier, head);
+    while (it.next()) |item| {
+        if (!self.tmp_map.contains(item.identifier)) {
+            head = self.createNodeAssumeCapacityExtra(item.identifier, head, item.str);
         }
     }
     return head;
@@ -152,8 +148,8 @@ pub fn @"union"(self: *Hideset, a: Index, b: Index) !Index {
 
 pub fn contains(self: *const Hideset, list: Index, str: []const u8) bool {
     var it = self.iterator(list);
-    while (it.next()) |identifier| {
-        if (mem.eql(u8, str, identifier.slice(self.comp))) return true;
+    while (it.next()) |item| {
+        if (mem.eql(u8, str, item.str)) return true;
     }
     return false;
 }
@@ -176,15 +172,15 @@ pub fn intersection(self: *Hideset, a: Index, b: Index) !Index {
     var head: Index = .none;
     var it = self.iterator(a);
     var a_len: usize = 0;
-    while (it.next()) |identifier| : (a_len += 1) {
-        try self.tmp_map.put(self.comp.gpa, identifier, {});
+    while (it.next()) |item| : (a_len += 1) {
+        try self.tmp_map.put(self.gpa, item.identifier, {});
     }
     try self.ensureUnusedCapacity(@min(a_len, self.len(b)));
 
     it = self.iterator(b);
-    while (it.next()) |identifier| {
-        if (self.tmp_map.contains(identifier)) {
-            const new_idx = self.createNodeAssumeCapacity(identifier);
+    while (it.next()) |item| {
+        if (self.tmp_map.contains(item.identifier)) {
+            const new_idx = self.createNodeAssumeCapacity(item.identifier, item.str);
             if (head == .none) {
                 head = new_idx;
             }

--- a/src/aro/Hideset.zig
+++ b/src/aro/Hideset.zig
@@ -11,7 +11,6 @@ const std = @import("std");
 const mem = std.mem;
 const Allocator = mem.Allocator;
 
-const Compilation = @import("Compilation.zig");
 const Source = @import("Source.zig");
 
 pub const Hideset = @This();
@@ -47,8 +46,6 @@ map: std.AutoHashMapUnmanaged(Identifier, Index) = .{},
 tmp_map: std.AutoHashMapUnmanaged(Identifier, void) = .{},
 linked_list: Item.List = .{},
 gpa: Allocator,
-
-const Temp = struct { identifier: Identifier, str: []const u8 };
 
 /// Invalidated if the underlying MultiArrayList slice is reallocated due to resize
 const Iterator = struct {

--- a/src/aro/Hideset.zig
+++ b/src/aro/Hideset.zig
@@ -11,6 +11,7 @@ const std = @import("std");
 const mem = std.mem;
 const Allocator = mem.Allocator;
 
+const Compilation = @import("Compilation.zig");
 const Source = @import("Source.zig");
 
 pub const Hideset = @This();
@@ -29,7 +30,7 @@ const Identifier = struct {
 
 const Item = struct {
     identifier: Identifier = .{},
-    str: []const u8,
+    len: u32 = 0,
     next: Index = .none,
 
     const List = std.MultiArrayList(Item);
@@ -45,7 +46,7 @@ map: std.AutoHashMapUnmanaged(Identifier, Index) = .{},
 /// until hideset is deinit'ed
 tmp_map: std.AutoHashMapUnmanaged(Identifier, void) = .{},
 linked_list: Item.List = .{},
-gpa: Allocator,
+comp: *const Compilation,
 
 /// Invalidated if the underlying MultiArrayList slice is reallocated due to resize
 const Iterator = struct {
@@ -56,19 +57,19 @@ const Iterator = struct {
         if (self.i == .none) return null;
         defer self.i = self.slice.items(.next)[@intFromEnum(self.i)];
         const identifier = self.slice.items(.identifier)[@intFromEnum(self.i)];
-        const str = self.slice.items(.str)[@intFromEnum(self.i)];
+        const length = self.slice.items(.len)[@intFromEnum(self.i)];
 
         return .{
             .identifier = identifier,
-            .str = str,
+            .len = length,
         };
     }
 };
 
 pub fn deinit(self: *Hideset) void {
-    self.map.deinit(self.gpa);
-    self.tmp_map.deinit(self.gpa);
-    self.linked_list.deinit(self.gpa);
+    self.map.deinit(self.comp.gpa);
+    self.tmp_map.deinit(self.comp.gpa);
+    self.linked_list.deinit(self.comp.gpa);
 }
 
 pub fn clearRetainingCapacity(self: *Hideset) void {
@@ -77,9 +78,9 @@ pub fn clearRetainingCapacity(self: *Hideset) void {
 }
 
 pub fn clearAndFree(self: *Hideset) void {
-    self.map.clearAndFree(self.gpa);
-    self.tmp_map.clearAndFree(self.gpa);
-    self.linked_list.shrinkAndFree(self.gpa, 0);
+    self.map.clearAndFree(self.comp.gpa);
+    self.tmp_map.clearAndFree(self.comp.gpa);
+    self.linked_list.shrinkAndFree(self.comp.gpa, 0);
 }
 
 /// Iterator is invalidated if the underlying MultiArrayList slice is reallocated due to resize
@@ -95,29 +96,29 @@ pub fn get(self: *const Hideset, loc: Source.Location) Index {
 }
 
 pub fn put(self: *Hideset, loc: Source.Location, value: Index) !void {
-    try self.map.put(self.gpa, Identifier.fromLocation(loc), value);
+    try self.map.put(self.comp.gpa, Identifier.fromLocation(loc), value);
 }
 
 fn ensureUnusedCapacity(self: *Hideset, new_size: usize) !void {
-    try self.linked_list.ensureUnusedCapacity(self.gpa, new_size);
+    try self.linked_list.ensureUnusedCapacity(self.comp.gpa, new_size);
 }
 
 /// Creates a one-item list with contents `identifier`
-fn createNodeAssumeCapacity(self: *Hideset, identifier: Identifier, str: []const u8) Index {
-    return self.createNodeAssumeCapacityExtra(identifier, .none, str);
+fn createNodeAssumeCapacity(self: *Hideset, identifier: Identifier, length: u32) Index {
+    return self.createNodeAssumeCapacityExtra(identifier, .none, length);
 }
 
 /// Creates a one-item list with contents `identifier`
-fn createNodeAssumeCapacityExtra(self: *Hideset, identifier: Identifier, next: Index, str: []const u8) Index {
+fn createNodeAssumeCapacityExtra(self: *Hideset, identifier: Identifier, next: Index, length: u32) Index {
     const next_idx = self.linked_list.len;
-    self.linked_list.appendAssumeCapacity(.{ .identifier = identifier, .next = next, .str = str });
+    self.linked_list.appendAssumeCapacity(.{ .identifier = identifier, .next = next, .len = length });
     return @enumFromInt(next_idx);
 }
 
 /// Create a new list with `identifier` at the front followed by `tail`
-pub fn prepend(self: *Hideset, loc: Source.Location, str: []const u8, tail: Index) !Index {
+pub fn prepend(self: *Hideset, loc: Source.Location, length: u32, tail: Index) !Index {
     const new_idx = self.linked_list.len;
-    try self.linked_list.append(self.gpa, .{ .identifier = Identifier.fromLocation(loc), .next = tail, .str = str });
+    try self.linked_list.append(self.comp.gpa, .{ .identifier = Identifier.fromLocation(loc), .next = tail, .len = length });
     return @enumFromInt(new_idx);
 }
 
@@ -129,7 +130,7 @@ pub fn @"union"(self: *Hideset, a: Index, b: Index) !Index {
 
     var it = self.iterator(b);
     while (it.next()) |item| {
-        try self.tmp_map.put(self.gpa, item.identifier, {});
+        try self.tmp_map.put(self.comp.gpa, item.identifier, {});
     }
 
     var head: Index = b;
@@ -137,7 +138,7 @@ pub fn @"union"(self: *Hideset, a: Index, b: Index) !Index {
     it = self.iterator(a);
     while (it.next()) |item| {
         if (!self.tmp_map.contains(item.identifier)) {
-            head = self.createNodeAssumeCapacityExtra(item.identifier, head, item.str);
+            head = self.createNodeAssumeCapacityExtra(item.identifier, head, item.len);
         }
     }
     return head;
@@ -146,7 +147,11 @@ pub fn @"union"(self: *Hideset, a: Index, b: Index) !Index {
 pub fn contains(self: *const Hideset, list: Index, str: []const u8) bool {
     var it = self.iterator(list);
     while (it.next()) |item| {
-        if (mem.eql(u8, str, item.str)) return true;
+        const start = item.identifier.byte_offset;
+        const end = start + item.len;
+        const slice = self.comp.getSource(item.identifier.id).buf[start..end];
+
+        if (mem.eql(u8, str, slice)) return true;
     }
     return false;
 }
@@ -170,14 +175,14 @@ pub fn intersection(self: *Hideset, a: Index, b: Index) !Index {
     var it = self.iterator(a);
     var a_len: usize = 0;
     while (it.next()) |item| : (a_len += 1) {
-        try self.tmp_map.put(self.gpa, item.identifier, {});
+        try self.tmp_map.put(self.comp.gpa, item.identifier, {});
     }
     try self.ensureUnusedCapacity(@min(a_len, self.len(b)));
 
     it = self.iterator(b);
     while (it.next()) |item| {
         if (self.tmp_map.contains(item.identifier)) {
-            const new_idx = self.createNodeAssumeCapacity(item.identifier, item.str);
+            const new_idx = self.createNodeAssumeCapacity(item.identifier, item.len);
             if (head == .none) {
                 head = new_idx;
             }

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -322,7 +322,7 @@ pub fn init(comp: *Compilation, options: InitOptions) !Preprocessor {
         .comp = comp,
         .diagnostics = comp.diagnostics,
         .arena = .init(comp.gpa),
-        .hideset = .{ .gpa = comp.gpa },
+        .hideset = .{ .comp = comp },
         .source_epoch = source_epoch,
         .base_file = options.base_file,
         .path_replacements = options.path_replacements,
@@ -2705,7 +2705,7 @@ fn expandMacroExhaustive(
                         .none
                     else
                         try pp.hideset.intersection(macro_hidelist, r_paren_hidelist);
-                    hs = try pp.hideset.prepend(macro_tok.loc, expanded, hs);
+                    hs = try pp.hideset.prepend(macro_tok.loc, @intCast(expanded.len), hs);
 
                     var args_count: u32 = @intCast(args.items.len);
                     // if the macro has zero arguments g() args_count is still 1
@@ -2769,7 +2769,7 @@ fn expandMacroExhaustive(
                     var res = try pp.expandObjMacro(macro);
                     defer res.deinit(gpa);
 
-                    const hs = try pp.hideset.prepend(macro_tok.loc, expanded, macro_hidelist);
+                    const hs = try pp.hideset.prepend(macro_tok.loc, @intCast(expanded.len), macro_hidelist);
 
                     const macro_expansion_locs = macro_tok.expansionSlice();
                     var increment_idx_by = res.items.len;

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -322,7 +322,7 @@ pub fn init(comp: *Compilation, options: InitOptions) !Preprocessor {
         .comp = comp,
         .diagnostics = comp.diagnostics,
         .arena = .init(comp.gpa),
-        .hideset = .{ .comp = comp },
+        .hideset = .{ .gpa = comp.gpa },
         .source_epoch = source_epoch,
         .base_file = options.base_file,
         .path_replacements = options.path_replacements,
@@ -2705,7 +2705,7 @@ fn expandMacroExhaustive(
                         .none
                     else
                         try pp.hideset.intersection(macro_hidelist, r_paren_hidelist);
-                    hs = try pp.hideset.prepend(macro_tok.loc, hs);
+                    hs = try pp.hideset.prepend(macro_tok.loc, expanded, hs);
 
                     var args_count: u32 = @intCast(args.items.len);
                     // if the macro has zero arguments g() args_count is still 1
@@ -2769,7 +2769,7 @@ fn expandMacroExhaustive(
                     var res = try pp.expandObjMacro(macro);
                     defer res.deinit(gpa);
 
-                    const hs = try pp.hideset.prepend(macro_tok.loc, macro_hidelist);
+                    const hs = try pp.hideset.prepend(macro_tok.loc, expanded, macro_hidelist);
 
                     const macro_expansion_locs = macro_tok.expansionSlice();
                     var increment_idx_by = res.items.len;


### PR DESCRIPTION
improves #1044 

Before:
- 7k long macro chain (I couldn't profile a larger input, Tracy OOMed and my pc crashed):
<img width="1748" height="180" alt="image" src="https://github.com/user-attachments/assets/d4317067-6cd6-4029-9e10-5a6dd8109d90" />

- 25k long macro chain:

```
$ time arocc -E macro-chain.c -nostdinc >/dev/null
real    0m7.643s
user    0m7.615s
sys     0m0.005s
```

After:
- 45k long chain:
<img width="1747" height="117" alt="image" src="https://github.com/user-attachments/assets/81dda018-55cb-4e9e-b1a6-bd1392cc4558" />

```
$ time ./zig-out/bin/arocc -nostdinc -E macro-chain.c > /dev/null
real    0m0.398s
user    0m0.391s
sys     0m0.006s
```

This doesn't fix the quadratic-time expansion, but it removes the largest overhead in the process, which is re-tokenizing all expansion locations stored in the hideset. I didn't try that hard to fix the quadratic-time issue because I am not very familiar with how hidesets work, but I would be glad to try to improve it more.