### PR TITLE
Attribute: allow vectorcall on x86_64-windows targets

### DIFF
--- a/src/aro/Attribute/Wip.zig
+++ b/src/aro/Attribute/Wip.zig
@@ -1199,7 +1199,7 @@ fn applyCallingConvention(wip: *Wip) !void {
         .ms_abi => if (ms_abi) continue :check .cdecl else (comp.target.cpu.arch == .x86_64 or comp.target.cpu.arch.isAARCH64()),
         .sysv_abi => if (ms_abi) comp.target.cpu.arch == .x86_64 else continue :check .cdecl,
         .fastcall, .regcall, .stdcall, .thiscall => comp.target.cpu.arch == .x86,
-        .vectorcall => comp.target.cpu.arch == .x86 or comp.target.cpu.arch.isAARCH64(),
+        .vectorcall => comp.target.cpu.arch == .x86 or comp.target.cpu.arch == .x86_64 or comp.target.cpu.arch.isAARCH64(),
     };
     if (!supported) {
         try wip.err(.callconv_not_supported, .{attr});

--- a/test/cases/vectorcall.c
+++ b/test/cases/vectorcall.c
@@ -1,0 +1,7 @@
+void __attribute__((vectorcall)) gnu_vectorcall(void);
+void __vectorcall keyword_vectorcall(void);
+
+/** manifest:
+syntax
+args = --target=x86_64-windows-msvc
+*/


### PR DESCRIPTION
support translate-c `callconv(.{ .x86_64_vectorcall = .{} })` on msvc target