### PR TITLE
Preprocessor: skip over comments in expressions

### DIFF
--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -1167,6 +1167,10 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
             .nl, .eof => break tok,
             .whitespace => if (pp.top_expansion_buf.items.len == 0) continue,
             .comment => continue,
+            .unterminated_comment => {
+                try pp.err(tok, .unterminated_comment, .{});
+                continue;
+            },
             else => {},
         }
         try pp.top_expansion_buf.append(gpa, tokFromRaw(tok));
@@ -1400,9 +1404,6 @@ fn skip(
             line_start = false;
             tokenizer.index += 1;
         }
-    } else {
-        const eof = tokenizer.next();
-        return pp.err(eof, .unterminated_conditional_directive, .{});
     }
 }
 

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -1166,6 +1166,7 @@ fn expr(pp: *Preprocessor, tokenizer: *Tokenizer) MacroError!bool {
         switch (tok.id) {
             .nl, .eof => break tok,
             .whitespace => if (pp.top_expansion_buf.items.len == 0) continue,
+            .comment => continue,
             else => {},
         }
         try pp.top_expansion_buf.append(gpa, tokFromRaw(tok));

--- a/test/cases/expanded/preserve comments.c
+++ b/test/cases/expanded/preserve comments.c
@@ -3,6 +3,8 @@
 1
 1
 hello1
+2
+/*foo*/1
 /** manifest:
 expand_partial
 args = -C

--- a/test/cases/preserve comments in macros.c
+++ b/test/cases/preserve comments in macros.c
@@ -14,6 +14,18 @@ d
 
 e(hello/*foo*/)
 
+#if 1 // foo
+#endif /*bar*/
+
+#if 2 /*bar*/ == 2
+2
+#endif
+
+#define g(x) x
+#if /*foo*/g(/*foo*/1/*bar*/)
+/*foo*/g(/*foo*/1/*bar*/)
+#endif
+
 
 // MS EOF used to stop preprocessing before nested block comment
 

--- a/test/cases/preserve comments.c
+++ b/test/cases/preserve comments.c
@@ -14,6 +14,18 @@ d
 
 e(hello/*foo*/)
 
+#if 1 // foo
+#endif /*bar*/
+
+#if 2 /*bar*/ == 2
+2
+#endif
+
+#define g(x) x
+#if /*foo*/g(/*foo*/1/*bar*/)
+/*foo*/g(/*foo*/1/*bar*/)
+#endif
+
 /** manifest:
 expand_partial
 args = -C

--- a/test/cases/unterminated comment in preprocessor expression.c
+++ b/test/cases/unterminated comment in preprocessor expression.c
@@ -1,8 +1,8 @@
 /** manifest:
 syntax
 
-unterminated comment in preprocessor expression.c:11:5: error: invalid token at start of a preprocessor expression
-unterminated comment in preprocessor expression.c:11:1: error: unterminated conditional directive
+unterminated comment in preprocessor expression.c:11:5: error: unterminated comment
+unterminated comment in preprocessor expression.c:11:1: error: expected value in expression
 unterminated comment in preprocessor expression.c:11:1: error: unterminated conditional directive
 */
 


### PR DESCRIPTION
Fixes #1060, partially addresses #1065

---

Without this fix, the modified tests would fail with

```
========= new error ==========
preserve comments.c:17:7: error: token is not a valid binary operator in a preprocessor subexpression

=== not in expected errors ===
in case 'preserve comments'

========= new error ==========
preserve comments in macros.c:17:7: error: token is not a valid binary operator in a preprocessor subexpression

=== not in expected errors ===
in case 'preserve comments in macros'
```