### PR TITLE
TypStore: Fix MSVC typedef alignment handling

### DIFF
--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -678,7 +678,10 @@ pub const QualType = packed struct(u32) {
                     break :request;
                 }
             } else if (comp.langopts.emulate == .msvc) {
-                const type_align = qt.base(comp).qt.alignof(comp);
+                const type_align = switch (qt.type(comp)) {
+                    .typedef => |typedef| typedef.base.alignof(comp),
+                    else => qt.base(comp).qt.alignof(comp),
+                };
                 return @max(requested, type_align);
             }
             return requested;

--- a/test/cases/alignment on typedef msvc.c
+++ b/test/cases/alignment on typedef msvc.c
@@ -12,6 +12,15 @@ _Static_assert(_Alignof(X) == 4, "");
 _Static_assert(sizeof(Y) == 4, "");
 _Static_assert(_Alignof(Y) == 4, "");
 
+__declspec(align(8)) typedef int I1;
+__declspec(align(1)) typedef I1 I2;
+
+_Static_assert(sizeof(I1) == 4, "");
+_Static_assert(_Alignof(I1) == 8, "");
+_Static_assert(sizeof(I2) == 4, "");
+_Static_assert(_Alignof(I2) == 8, "");
+
+
 /** manifest:
 syntax
 args = -target x86_64-windows-msvc

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -4,14 +4,8 @@ const mem = std.mem;
 const print = std.debug.print;
 const process = std.process;
 
-/// These tests don't work for any platform due to Aro bugs.
-/// Skip entirely.
 /// To skip a test entirely just put the test name as a single-element tuple e.g. initComptime(.{.{"0044"}});
-const global_test_exclude = std.StaticStringMap(void).initComptime(.{
-    .{"0011"},
-    .{"0014"},
-    .{"0046"},
-});
+const global_test_exclude = std.StaticStringMap(void).initComptime(.{});
 
 fn lessThan(_: void, lhs: []const u8, rhs: []const u8) bool {
     return mem.lessThan(u8, lhs, rhs);


### PR DESCRIPTION
Fixes #437