### PR TITLE
Preprocessor: preserve is_macro_arg in generated tokens

### DIFF
--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -2995,7 +2995,7 @@ fn pasteTokens(pp: *Preprocessor, lhs_toks: *ExpandBuf, rhs_toks: []const TokenW
         pasted_token.id;
 
     const hideset = try pp.hideset.intersection(pp.hideset.get(lhs.loc), pp.hideset.get(rhs.loc));
-    const generated_token = try pp.makeGeneratedTokenExtra(start, pasted_id, lhs, hideset);
+    const generated_token = try pp.makeGeneratedTokenExtra(start, pasted_id, lhs, hideset, lhs.flags.is_macro_arg or rhs.flags.is_macro_arg);
     try lhs_toks.append(gpa, generated_token);
 
     if (next.id != .nl and next.id != .eof) {
@@ -3006,13 +3006,13 @@ fn pasteTokens(pp: *Preprocessor, lhs_toks: *ExpandBuf, rhs_toks: []const TokenW
     try bufCopyTokens(gpa, lhs_toks, rhs_toks[rhs_rest..], &.{});
 }
 
-fn makeGeneratedTokenExtra(pp: *Preprocessor, start: usize, id: Token.Id, source: TokenWithExpansionLocs, hideset: Hideset.Index) !TokenWithExpansionLocs {
+fn makeGeneratedTokenExtra(pp: *Preprocessor, start: usize, id: Token.Id, source: TokenWithExpansionLocs, hideset: Hideset.Index, is_macro_arg: bool) !TokenWithExpansionLocs {
     const gpa = pp.comp.gpa;
     var pasted_token = TokenWithExpansionLocs{ .id = id, .loc = .{
         .id = .generated,
         .byte_offset = @intCast(start),
         .line = pp.generated_line,
-    } };
+    }, .flags = .{ .is_macro_arg = is_macro_arg } };
     pp.generated_line += 1;
     try pasted_token.addExpansionLocation(gpa, &.{source.loc});
     try pasted_token.addExpansionLocation(gpa, source.expansionSlice());
@@ -3022,7 +3022,7 @@ fn makeGeneratedTokenExtra(pp: *Preprocessor, start: usize, id: Token.Id, source
 }
 
 fn makeGeneratedToken(pp: *Preprocessor, start: usize, id: Token.Id, source: TokenWithExpansionLocs) !TokenWithExpansionLocs {
-    return pp.makeGeneratedTokenExtra(start, id, source, pp.hideset.get(source.loc));
+    return pp.makeGeneratedTokenExtra(start, id, source, pp.hideset.get(source.loc), false);
 }
 
 /// Defines a new macro and warns if it is a duplicate

--- a/test/cases/apply pasted macro name.c
+++ b/test/cases/apply pasted macro name.c
@@ -1,0 +1,11 @@
+#define CONCAT_(a, b) a##b
+#define CONCAT(a, b)  CONCAT_(a, b)
+#define APPLY(macro, args) macro args
+
+#define OVERLOAD1(x) x
+
+int call_via_apply = APPLY(CONCAT(OVERLOAD, 1), (7));
+
+/** manifest:
+expand
+*/

--- a/test/cases/expanded/apply pasted macro name.c
+++ b/test/cases/expanded/apply pasted macro name.c
@@ -1,0 +1,1 @@
+int call_via_apply = 7;


### PR DESCRIPTION
If either side of a `##` paste was a macro arg, set that flag in the generated token. This will allow the token to expand if it is a function-like macro.

Fixes #1063