### PR TITLE
Attribute: avoid dangling function params in applyCallingConvention

### DIFF
--- a/src/aro/Attribute/Wip.zig
+++ b/src/aro/Attribute/Wip.zig
@@ -1214,12 +1214,11 @@ fn applyCallingConvention(wip: *Wip) !void {
 
     // We cannot pass the function type directly here because the pointer to
     // type_store.extra might get invalidated while setting the updated type.
-    var owned_params: ?[]Type.Func.Param = null;
-    defer if (owned_params) |some| comp.gpa.free(some);
-    if (func.params.len != 0) {
-        owned_params = try comp.gpa.dupe(Type.Func.Param, func.params);
-        func.params = owned_params.?;
-    }
+    const lb = &wip.current.parser.list_buf;
+    const list_buf_top = lb.items.len;
+    defer lb.items.len = list_buf_top;
+    try lb.appendSlice(comp.gpa, @ptrCast(func.params));
+    func.params = @ptrCast(lb.items[list_buf_top..]);
 
     // TODO this can overwrite a typedef
     // typedef void (*fn_ptr)(void);

--- a/src/aro/Attribute/Wip.zig
+++ b/src/aro/Attribute/Wip.zig
@@ -1212,6 +1212,15 @@ fn applyCallingConvention(wip: *Wip) !void {
     }
     func.cc = cc;
 
+    // We cannot pass the function type directly here because the pointer to
+    // type_store.extra might get invalidated while setting the updated type.
+    var owned_params: ?[]Type.Func.Param = null;
+    defer if (owned_params) |some| comp.gpa.free(some);
+    if (func.params.len != 0) {
+        owned_params = try comp.gpa.dupe(Type.Func.Param, func.params);
+        func.params = owned_params.?;
+    }
+
     // TODO this can overwrite a typedef
     // typedef void (*fn_ptr)(void);
     // __cdecl fn_ptr a;


### PR DESCRIPTION
`applyCallingConvention` updates a function type by changing func.cc and writing the full type back through `TypeStore.set`.

`func.params` may be a borrowed slice into type_store.extra.

https://github.com/Vexu/arocc/blob/8f4df188ac8256fc4cd9bc069a3b8dd68fd62b68/src/aro/Attribute/Wip.zig#L1117-L1119

During `TypeStore.set`, type_store.extra may reallocate, causing `func.params` to become a dangling reference to invalid memory.

https://github.com/Vexu/arocc/blob/8f4df188ac8256fc4cd9bc069a3b8dd68fd62b68/src/aro/TypeStore.zig#L2147

https://github.com/Vexu/arocc/blob/8f4df188ac8256fc4cd9bc069a3b8dd68fd62b68/src/aro/TypeStore.zig#L2153
