### PR TITLE
Attribute: ignore alignment on enums in MSVC

### DIFF
--- a/src/aro/Attribute/Diagnostic.zig
+++ b/src/aro/Attribute/Diagnostic.zig
@@ -149,6 +149,12 @@ pub const non_pow2_align: Diagnostic = .{
     .kind = .@"error",
 };
 
+pub const msvc_enum_align_ignored: Diagnostic = .{
+    .fmt = "alignment specifier is ignored on enum",
+    .kind = .warning,
+    .opt = .@"ignored-attributes",
+};
+
 // warn_unused_result
 pub const warn_unused_result_void: Diagnostic = .{
     .fmt = "attribute {at} cannot be applied to functions without return value",

--- a/src/aro/Attribute/Wip.zig
+++ b/src/aro/Attribute/Wip.zig
@@ -597,6 +597,15 @@ fn applyAlignment(wip: *Wip) !void {
         }
         casted = @intCast(requested);
     }
+    if (comp.langopts.emulate == .msvc) {
+        switch (wip.current.node()) {
+            .enum_forward_decl, .enum_decl => {
+                try wip.err(.msvc_enum_align_ignored, .{});
+                return;
+            },
+            else => {},
+        }
+    }
     try wip.addAlignmentToTypeMap(casted);
     try wip.add(.{ .alignment = casted });
 }

--- a/test/cases/alignment on typedef msvc.c
+++ b/test/cases/alignment on typedef msvc.c
@@ -20,8 +20,25 @@ _Static_assert(_Alignof(I1) == 8, "");
 _Static_assert(sizeof(I2) == 4, "");
 _Static_assert(_Alignof(I2) == 8, "");
 
+typedef enum {
+  A
+} NaturallyAlignedEnum;
+
+typedef enum __declspec(align(16)) {
+  B,
+} IgnoredAlignmentEnum;
+
+_Static_assert(_Alignof(IgnoredAlignmentEnum) == _Alignof(NaturallyAlignedEnum), "");
+
+__declspec(align(16)) typedef enum {
+  C,
+} AlignedEnum;
+
+_Static_assert(_Alignof(AlignedEnum) == 16, "");
 
 /** manifest:
 syntax
 args = -target x86_64-windows-msvc
+
+alignment on typedef msvc.c:27:25: warning: alignment specifier is ignored on enum [-Wignored-attributes]
 */


### PR DESCRIPTION
Enum alignment must be done via a typedef.

See https://godbolt.org/z/q14xjs9qn