### PR TITLE
WIP: block nullability

### DIFF
--- a/src/aro/Attribute/Wip.zig
+++ b/src/aro/Attribute/Wip.zig
@@ -1310,17 +1310,6 @@ fn applyNullability(wip: *Wip) !void {
     const qt = wip.current.qt;
     if (qt.isInvalid()) return;
 
-    const comp = wip.current.parser.comp;
-    var pointer: Type.Pointer = qt.get(comp, .pointer) orelse {
-        if (wip.current.target == null and qt.is(comp, .array)) {
-            attr.used_as_type_attr = false;
-            return;
-        }
-
-        try wip.err(.invalid_nullability, .{qt});
-        return;
-    };
-
     const new_nullability: Type.Pointer.Nullability = switch (attr.name.keyword) {
         .nonnull => .nonnull,
         .null_unspecified => .unspecified,
@@ -1328,13 +1317,32 @@ fn applyNullability(wip: *Wip) !void {
         .nullable => .nullable,
         else => unreachable,
     };
-    if (pointer.nullability != .default and pointer.nullability != new_nullability) {
-        try wip.err(.conflicting_nullability, .{ new_nullability.str(), pointer.nullability.str() });
-        return;
-    }
 
-    pointer.nullability = new_nullability;
-    wip.current.qt = try comp.type_store.put(comp.gpa, .{ .pointer = pointer });
+    const comp = wip.current.parser.comp;
+    var base_type = qt.base(comp).type;
+    switch (base_type) {
+        inline .pointer, .block => |*bt, tag| {
+            if (bt.nullability != .default and bt.nullability != new_nullability) {
+                try wip.err(.conflicting_nullability, .{ new_nullability.str(), bt.nullability.str() });
+                return;
+            }
+
+            bt.nullability = new_nullability;
+            wip.current.qt = try comp.type_store.put(
+                comp.gpa,
+                @unionInit(TypeStore.Type, @tagName(tag), bt.*),
+            );
+        },
+        else => {
+            if (wip.current.target == null and qt.is(comp, .array)) {
+                attr.used_as_type_attr = false;
+                return;
+            }
+
+            try wip.err(.invalid_nullability, .{qt});
+            return;
+        },
+    }
 }
 
 pub fn applyStmtAttrs(wip: *Wip, p: *Parser, stmt: Tree.Node.Index) !void {

--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -1793,6 +1793,7 @@ pub const Type = union(enum) {
 
     pub const Block = struct {
         func: QualType,
+        nullability: Pointer.Nullability = .default,
     };
 
     pub const Func = struct {

--- a/test/cases/ast/block types.c
+++ b/test/cases/ast/block types.c
@@ -326,3 +326,6 @@ function: 'fn (afunc: *fn (int) double, ablock: block (int) double) void'
 
     implicit return_stmt: 'void'
 
+typedef: 'block () int'
+ name: NullableBlock
+

--- a/test/cases/block types.c
+++ b/test/cases/block types.c
@@ -55,6 +55,9 @@ void my_func_accepting_block(double (*afunc)(int), double (^ablock)(int)) {
   __auto_type ^a;
 }
 
+// blocks can be nullable
+typedef int (^_Nullable NullableBlock)(void);
+
 /** manifest:
 syntax
 args = -fblocks -Wpedantic -Wno-gnu-auto-type --target=aarch64-macos


### PR DESCRIPTION
This adds block nullability for the simple reduction case as described in #1052.

Currently WIP, not too sure if anything else needs to be added, also not too sure if `Pointer.Nullability` should be promoted - not too sure if it's worth it and/or what else could otherwise be nullable/nullability checks would need to be done.