### PR TITLE
Compilation: define __BLOCKS__ when blocks are enabled

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -1189,6 +1189,11 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
             }
         },
     }
+
+    // Blocks
+    if (comp.langopts.blocks) {
+        try define(w, "__BLOCKS__");
+    }
 }
 
 const RiscvFloatAbi = enum { soft, single, double };

--- a/test/cases/block types.c
+++ b/test/cases/block types.c
@@ -58,6 +58,11 @@ void my_func_accepting_block(double (*afunc)(int), double (^ablock)(int)) {
 // blocks can be nullable
 typedef int (^_Nullable NullableBlock)(void);
 
+// Block predefines
+#if !defined(__BLOCKS__)
+#error "expected __BLOCKS__ to be defined"
+#endif
+
 /** manifest:
 syntax
 args = -fblocks -Wpedantic -Wno-gnu-auto-type --target=aarch64-macos


### PR DESCRIPTION
This gets defined when blocks are enabled in clang: https://github.com/llvm/llvm-project/blob/9e22a5950e51ace7f50729d7f556ca99d06fa8bb/clang/lib/Frontend/InitPreprocessor.cpp#L1010

Found while trying to translate `#include <CoreVideo/CoreVideo.h>` on MacOS.

PS: Not too sure if this should be implicit or not somewhere, but `-fblocks` specifically needs to be enabled when doing C translation for the MacOS frameworks that employ blocks. I don't recall if this is necessary or not in Zig right now currently (it might just be in our flags somewhere that I haven't seen yet).