### PR TITLE
Ensure __has_extension treats features as extensions

### DIFF
--- a/src/aro/features.zig
+++ b/src/aro/features.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Compilation = @import("Compilation.zig");
+const Diagnostics = @import("Diagnostics.zig");
 const Target = @import("Target.zig");
 
 /// Used to implement the __has_feature macro.
@@ -54,6 +55,19 @@ pub fn hasFeature(comp: *Compilation, ext: []const u8) bool {
 
 /// Used to implement the __has_extension macro.
 pub fn hasExtension(comp: *Compilation, ext: []const u8) bool {
+    // Extensions are a superset of features, so check all features first.
+    if (hasFeature(comp, ext)) {
+        return true;
+    }
+
+    // "-pedantic-errors" effectively disables extensions by erroring out on
+    // them, so we just return early. This makes "__has_extension" the same as
+    // "__has_feature" when this is set.
+    switch (comp.diagnostics.state.extensions) {
+        .@"error", .@"fatal error" => return false,
+        else => {},
+    }
+
     const list = .{
         // C11 features
         .c_alignas = true,

--- a/test/cases/feature as extension pedantic.c
+++ b/test/cases/feature as extension pedantic.c
@@ -1,0 +1,15 @@
+// has_extension pedantic test (c_alignas is a C11 feature, so this should
+// return unsupported on C99).
+
+#if __has_extension(c_alignas)
+#error expected c_alignas to be unavailable as an extension
+#endif
+
+int main(void) {
+  return 0;
+}
+
+/** manifest:
+syntax
+args = -pedantic-errors -std=c99
+*/

--- a/test/cases/feature as extension.c
+++ b/test/cases/feature as extension.c
@@ -1,0 +1,15 @@
+// Tests to make sure that __has_extension can be used on features as well
+// (extensions are a superset of features).
+
+#if !__has_feature(attribute_deprecated_with_message)
+#error expected attribute_deprecated_with_message to be available as a feature
+#endif
+
+#if !__has_extension(attribute_deprecated_with_message)
+#error expected attribute_deprecated_with_message to be available as an extension
+#endif
+
+/** manifest:
+syntax
+
+*/


### PR DESCRIPTION
Confirmed that this was the behavior in clang for prior art, both as documented, and also as implemented (in [`PPMacroExpansion.cpp`](https://github.com/llvm/llvm-project/blob/da4bbda3dcefbaf88c2f336afd03c4a6ebb41a27/clang/lib/Lex/PPMacroExpansion.cpp#L1145-L1146)).

Additionally, as documented in clang and implemented in the aforementioned, we always return the result from `hasFeature` if `-pedantic-errors` is used.