### PR TITLE
Parser: improve _Static_assert message

### DIFF
--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -92,6 +92,15 @@ const InitContext = enum {
     static,
 };
 
+const StaticAssertEvalNote = struct {
+    tok: TokenIndex,
+    lhs_val: Value,
+    lhs_qt: QualType,
+    op: std.math.CompareOperator,
+    rhs_val: Value,
+    rhs_qt: QualType,
+};
+
 /// How the parser handles const int decl references when it is expecting an integer
 /// constant expression.
 const ConstDeclFoldingMode = enum {
@@ -152,6 +161,8 @@ extension_suppressed: bool = false,
 contains_address_of_label: bool = false,
 label_count: u32 = 0,
 const_decl_folding: ConstDeclFoldingMode = .fold_const_decls,
+record_static_assert_eval_note: bool = false,
+static_assert_eval_note: ?StaticAssertEvalNote = null,
 /// location of first computed goto in function currently being parsed
 /// if a computed goto is used, the function must contain an
 /// address-of-label expression (tracked with contains_address_of_label)
@@ -1771,11 +1782,19 @@ fn writeStaticAssertRequirement(p: *Parser, cond_node: Node.Index, start: TokenI
     }
 }
 
-fn staticAssertMessage(p: *Parser, cond_node: Node.Index, cond_start: TokenIndex, cond_end: TokenIndex, maybe_message: ?Result, allocating: *std.Io.Writer.Allocating) ![]const u8 {
+const StaticAsssertMessage = struct {
+    full: []const u8,
+    req_start: u32,
+    req_end: u32,
+};
+
+fn staticAssertMessage(p: *Parser, cond_node: Node.Index, cond_start: TokenIndex, cond_end: TokenIndex, maybe_message: ?Result, allocating: *std.Io.Writer.Allocating) !StaticAsssertMessage {
     const w = &allocating.writer;
 
     try w.writeAll("due to requirement '");
+    const start = allocating.written().len;
     try p.writeStaticAssertRequirement(cond_node, cond_start, cond_end, w);
+    const end = allocating.written().len;
     try w.writeAll("':");
 
     if (maybe_message) |message| {
@@ -1786,7 +1805,64 @@ fn staticAssertMessage(p: *Parser, cond_node: Node.Index, cond_start: TokenIndex
             try Value.printString(bytes, message.qt, p.comp, w, .bare);
         }
     }
+    const written = allocating.written();
+    return .{
+        .full = written,
+        .req_start = @intCast(start),
+        .req_end = @intCast(end),
+    };
+}
+
+fn staticAssertComparisonOperator(op: std.math.CompareOperator) []const u8 {
+    return switch (op) {
+        .lt => "<",
+        .lte => "<=",
+        .eq => "==",
+        .gte => ">=",
+        .gt => ">",
+        .neq => "!=",
+    };
+}
+
+fn staticAssertRecordEvaluationNote(p: *Parser, tok: TokenIndex, op: std.math.CompareOperator, lhs: Result, rhs: Result) void {
+    if (lhs.val.opt_ref == .none or rhs.val.opt_ref == .none) return;
+    if (lhs.val.is(.pointer, p.comp) or rhs.val.is(.pointer, p.comp)) return;
+
+    p.static_assert_eval_note = .{
+        .tok = tok,
+        .lhs_val = lhs.val,
+        .lhs_qt = lhs.qt,
+        .op = op,
+        .rhs_val = rhs.val,
+        .rhs_qt = rhs.qt,
+    };
+}
+
+fn writeStaticAssertEvalValue(p: *Parser, w: *std.Io.Writer, val: Value, qt: QualType) !bool {
+    if (try val.print(qt, p.comp, w)) |_| return false;
+    return true;
+}
+
+fn writeStaticAssertEvalNote(p: *Parser, note: *const StaticAssertEvalNote, allocating: *std.Io.Writer.Allocating) !?[]const u8 {
+    const w = &allocating.writer;
+
+    if (!try p.writeStaticAssertEvalValue(w, note.lhs_val, note.lhs_qt)) return null;
+    try w.print(" {s} ", .{staticAssertComparisonOperator(note.op)});
+    if (!try p.writeStaticAssertEvalValue(w, note.rhs_val, note.rhs_qt)) return null;
     return allocating.written();
+}
+
+fn staticAssertEvaluationNote(p: *Parser, note: *const StaticAssertEvalNote, requirement: []const u8) Error!void {
+    var note_bfa_buf: [1024]u8 = undefined;
+    var note_bfa: std.heap.BufferFirstAllocator = .init(&note_bfa_buf, p.comp.gpa);
+    var note_allocating: std.Io.Writer.Allocating = .init(note_bfa.allocator());
+    defer note_allocating.deinit();
+
+    const eval_text = (p.writeStaticAssertEvalNote(note, &note_allocating) catch return error.OutOfMemory) orelse return;
+
+    if (std.mem.eql(u8, eval_text, requirement)) return;
+
+    try p.err(note.tok, .static_assert_expression_evaluates_to, .{eval_text});
 }
 
 /// staticAssert
@@ -1797,6 +1873,14 @@ fn staticAssert(p: *Parser) Error!bool {
     const static_assert = p.eatToken(.keyword_static_assert) orelse p.eatToken(.keyword_c23_static_assert) orelse return false;
     const l_paren = try p.expectToken(.l_paren);
     const res_token = p.tok_i;
+    const old_record_static_assert_eval_note = p.record_static_assert_eval_note;
+    const old_static_assert_eval_note = p.static_assert_eval_note;
+    p.record_static_assert_eval_note = true;
+    p.static_assert_eval_note = null;
+    defer {
+        p.record_static_assert_eval_note = old_record_static_assert_eval_note;
+        p.static_assert_eval_note = old_static_assert_eval_note;
+    }
     var res = try p.constExpr(.gnu_folding_extension);
     const res_node = res.node;
     const res_end = p.tok_i - 1;
@@ -1840,7 +1924,10 @@ fn staticAssert(p: *Parser) Error!bool {
             defer allocating.deinit();
 
             const message = p.staticAssertMessage(res_node, res_token, res_end, str, &allocating) catch return error.OutOfMemory;
-            try p.err(res_token, .static_assert_failure_message, .{message});
+            try p.err(res_token, .static_assert_failure_message, .{message.full});
+            if (p.static_assert_eval_note) |*note| {
+                try p.staticAssertEvaluationNote(note, message.full[message.req_start..message.req_end]);
+            }
         }
     }
 
@@ -8446,6 +8533,9 @@ fn eqExpr(p: *Parser) Error!?Result {
             else
                 lhs.val.compare(op, rhs.val, p.comp);
 
+            if (p.record_static_assert_eval_note and res == false) {
+                p.staticAssertRecordEvaluationNote(tok, op, lhs, rhs);
+            }
             lhs.val = if (res) |val| Value.fromBool(val) else .{};
         } else {
             lhs.val.boolCast(p.comp);
@@ -8479,6 +8569,9 @@ fn compExpr(p: *Parser) Error!?Result {
                 lhs.val.comparePointers(op, rhs.val, p.comp)
             else
                 lhs.val.compare(op, rhs.val, p.comp);
+            if (p.record_static_assert_eval_note and res == false) {
+                p.staticAssertRecordEvaluationNote(tok, op, lhs, rhs);
+            }
             lhs.val = if (res) |val| Value.fromBool(val) else .{};
         } else {
             lhs.val.boolCast(p.comp);

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1741,22 +1741,7 @@ fn decl(p: *Parser) Error!bool {
     return true;
 }
 
-fn writeStaticAssertRequirement(p: *Parser, cond_node: Node.Index, start: TokenIndex, end: TokenIndex, w: *std.Io.Writer) !void {
-    const cond = cond_node.get(&p.tree);
-    if (cond == .builtin_types_compatible_p) {
-        try w.writeAll("__builtin_types_compatible_p(");
-
-        const lhs_ty = cond.builtin_types_compatible_p.lhs;
-        try lhs_ty.print(p.comp, w);
-        try w.writeAll(", ");
-
-        const rhs_ty = cond.builtin_types_compatible_p.rhs;
-        try rhs_ty.print(p.comp, w);
-
-        try w.writeByte(')');
-        return;
-    }
-
+fn writeStaticAssertRequirement(p: *Parser, start: TokenIndex, end: TokenIndex, w: *std.Io.Writer) !void {
     const start_loc = p.pp.tokens.items(.loc)[start];
     const end_loc = p.pp.tokens.items(.loc)[end];
     const end_offset = end_loc.byte_offset + @as(u32, @intCast(p.tokSlice(end).len));
@@ -1788,12 +1773,12 @@ const StaticAsssertMessage = struct {
     req_end: u32,
 };
 
-fn staticAssertMessage(p: *Parser, cond_node: Node.Index, cond_start: TokenIndex, cond_end: TokenIndex, maybe_message: ?Result, allocating: *std.Io.Writer.Allocating) !StaticAsssertMessage {
+fn staticAssertMessage(p: *Parser, cond_start: TokenIndex, cond_end: TokenIndex, maybe_message: ?Result, allocating: *std.Io.Writer.Allocating) !StaticAsssertMessage {
     const w = &allocating.writer;
 
     try w.writeAll("due to requirement '");
     const start = allocating.written().len;
-    try p.writeStaticAssertRequirement(cond_node, cond_start, cond_end, w);
+    try p.writeStaticAssertRequirement(cond_start, cond_end, w);
     const end = allocating.written().len;
     try w.writeAll("':");
 
@@ -1882,7 +1867,6 @@ fn staticAssert(p: *Parser) Error!bool {
         p.static_assert_eval_note = old_static_assert_eval_note;
     }
     var res = try p.constExpr(.gnu_folding_extension);
-    const res_node = res.node;
     const res_end = p.tok_i - 1;
     const str = if (p.eatToken(.comma) != null)
         switch (p.tok_ids[p.tok_i]) {
@@ -1923,7 +1907,7 @@ fn staticAssert(p: *Parser) Error!bool {
             var allocating: std.Io.Writer.Allocating = .init(bfa.allocator());
             defer allocating.deinit();
 
-            const message = p.staticAssertMessage(res_node, res_token, res_end, str, &allocating) catch return error.OutOfMemory;
+            const message = p.staticAssertMessage(res_token, res_end, str, &allocating) catch return error.OutOfMemory;
             try p.err(res_token, .static_assert_failure_message, .{message.full});
             if (p.static_assert_eval_note) |*note| {
                 try p.staticAssertEvaluationNote(note, message.full[message.req_start..message.req_end]);

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -96,7 +96,6 @@ const StaticAssertEvalNote = struct {
     tok: TokenIndex,
     lhs_val: Value,
     lhs_qt: QualType,
-    op: std.math.CompareOperator,
     rhs_val: Value,
     rhs_qt: QualType,
 };
@@ -1798,18 +1797,7 @@ fn staticAssertMessage(p: *Parser, cond_start: TokenIndex, cond_end: TokenIndex,
     };
 }
 
-fn staticAssertComparisonOperator(op: std.math.CompareOperator) []const u8 {
-    return switch (op) {
-        .lt => "<",
-        .lte => "<=",
-        .eq => "==",
-        .gte => ">=",
-        .gt => ">",
-        .neq => "!=",
-    };
-}
-
-fn staticAssertRecordEvaluationNote(p: *Parser, tok: TokenIndex, op: std.math.CompareOperator, lhs: Result, rhs: Result) void {
+fn staticAssertRecordEvaluationNote(p: *Parser, tok: TokenIndex, lhs: Result, rhs: Result) void {
     if (lhs.val.opt_ref == .none or rhs.val.opt_ref == .none) return;
     if (lhs.val.is(.pointer, p.comp) or rhs.val.is(.pointer, p.comp)) return;
 
@@ -1817,7 +1805,6 @@ fn staticAssertRecordEvaluationNote(p: *Parser, tok: TokenIndex, op: std.math.Co
         .tok = tok,
         .lhs_val = lhs.val,
         .lhs_qt = lhs.qt,
-        .op = op,
         .rhs_val = rhs.val,
         .rhs_qt = rhs.qt,
     };
@@ -1832,7 +1819,7 @@ fn writeStaticAssertEvalNote(p: *Parser, note: *const StaticAssertEvalNote, allo
     const w = &allocating.writer;
 
     if (!try p.writeStaticAssertEvalValue(w, note.lhs_val, note.lhs_qt)) return null;
-    try w.print(" {s} ", .{staticAssertComparisonOperator(note.op)});
+    try w.print(" {s} ", .{p.tokSlice(note.tok)});
     if (!try p.writeStaticAssertEvalValue(w, note.rhs_val, note.rhs_qt)) return null;
     return allocating.written();
 }
@@ -8518,7 +8505,7 @@ fn eqExpr(p: *Parser) Error!?Result {
                 lhs.val.compare(op, rhs.val, p.comp);
 
             if (p.record_static_assert_eval_note and res == false) {
-                p.staticAssertRecordEvaluationNote(tok, op, lhs, rhs);
+                p.staticAssertRecordEvaluationNote(tok, lhs, rhs);
             }
             lhs.val = if (res) |val| Value.fromBool(val) else .{};
         } else {
@@ -8554,7 +8541,7 @@ fn compExpr(p: *Parser) Error!?Result {
             else
                 lhs.val.compare(op, rhs.val, p.comp);
             if (p.record_static_assert_eval_note and res == false) {
-                p.staticAssertRecordEvaluationNote(tok, op, lhs, rhs);
+                p.staticAssertRecordEvaluationNote(tok, lhs, rhs);
             }
             lhs.val = if (res) |val| Value.fromBool(val) else .{};
         } else {

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1730,12 +1730,10 @@ fn decl(p: *Parser) Error!bool {
     return true;
 }
 
-fn staticAssertMessage(p: *Parser, cond_node: Node.Index, maybe_message: ?Result, allocating: *std.Io.Writer.Allocating) !?[]const u8 {
-    const w = &allocating.writer;
-
+fn writeStaticAssertRequirement(p: *Parser, cond_node: Node.Index, start: TokenIndex, end: TokenIndex, w: *std.Io.Writer) !void {
     const cond = cond_node.get(&p.tree);
     if (cond == .builtin_types_compatible_p) {
-        try w.writeAll("'__builtin_types_compatible_p(");
+        try w.writeAll("__builtin_types_compatible_p(");
 
         const lhs_ty = cond.builtin_types_compatible_p.lhs;
         try lhs_ty.print(p.comp, w);
@@ -1744,16 +1742,49 @@ fn staticAssertMessage(p: *Parser, cond_node: Node.Index, maybe_message: ?Result
         const rhs_ty = cond.builtin_types_compatible_p.rhs;
         try rhs_ty.print(p.comp, w);
 
-        try w.writeAll(")'");
-    } else if (maybe_message == null) return null;
+        try w.writeByte(')');
+        return;
+    }
+
+    const start_loc = p.pp.tokens.items(.loc)[start];
+    const end_loc = p.pp.tokens.items(.loc)[end];
+    const end_offset = end_loc.byte_offset + @as(u32, @intCast(p.tokSlice(end).len));
+    if (start <= end and
+        start_loc.id == end_loc.id and
+        start_loc.id != Source.Id.generated and
+        start_loc.byte_offset <= end_loc.byte_offset)
+    {
+        const source = p.comp.getSource(start_loc.id);
+        if (end_offset <= source.buf.len) {
+            const requirement = source.buf[start_loc.byte_offset..end_offset];
+            if (std.mem.indexOfScalar(u8, requirement, '\n') == null) {
+                try w.writeAll(requirement);
+                return;
+            }
+        }
+    }
+
+    var tok = start;
+    while (tok <= end) : (tok += 1) {
+        if (tok != start) try w.writeByte(' ');
+        try w.writeAll(p.tokSlice(tok));
+    }
+}
+
+fn staticAssertMessage(p: *Parser, cond_node: Node.Index, cond_start: TokenIndex, cond_end: TokenIndex, maybe_message: ?Result, allocating: *std.Io.Writer.Allocating) ![]const u8 {
+    const w = &allocating.writer;
+
+    try w.writeAll("due to requirement '");
+    try p.writeStaticAssertRequirement(cond_node, cond_start, cond_end, w);
+    try w.writeAll("':");
 
     if (maybe_message) |message| {
-        assert(message.node.get(&p.tree) == .string_literal_expr);
-        if (allocating.written().len > 0) {
-            try w.writeByte(' ');
-        }
         const bytes = p.comp.interner.get(message.val.ref()).bytes;
-        try Value.printString(bytes, message.qt, p.comp, w);
+        const size: Compilation.CharUnitSize = @enumFromInt(message.qt.childType(p.comp).sizeof(p.comp));
+        if (bytes.len > @intFromEnum(size)) {
+            try w.writeByte(' ');
+            try Value.printString(bytes, message.qt, p.comp, w, .bare);
+        }
     }
     return allocating.written();
 }
@@ -1768,6 +1799,7 @@ fn staticAssert(p: *Parser) Error!bool {
     const res_token = p.tok_i;
     var res = try p.constExpr(.gnu_folding_extension);
     const res_node = res.node;
+    const res_end = p.tok_i - 1;
     const str = if (p.eatToken(.comma) != null)
         switch (p.tok_ids[p.tok_i]) {
             .string_literal,
@@ -1807,11 +1839,8 @@ fn staticAssert(p: *Parser) Error!bool {
             var allocating: std.Io.Writer.Allocating = .init(bfa.allocator());
             defer allocating.deinit();
 
-            if (p.staticAssertMessage(res_node, str, &allocating) catch return error.OutOfMemory) |message| {
-                try p.err(static_assert, .static_assert_failure_message, .{message});
-            } else {
-                try p.err(static_assert, .static_assert_failure, .{});
-            }
+            const message = p.staticAssertMessage(res_node, res_token, res_end, str, &allocating) catch return error.OutOfMemory;
+            try p.err(res_token, .static_assert_failure_message, .{message});
         }
     }
 

--- a/src/aro/Parser/Diagnostic.zig
+++ b/src/aro/Parser/Diagnostic.zig
@@ -113,6 +113,11 @@ pub const static_assert_failure_message: Diagnostic = .{
     .kind = .@"error",
 };
 
+pub const static_assert_expression_evaluates_to: Diagnostic = .{
+    .fmt = "expression evaluates to '{s}'",
+    .kind = .note,
+};
+
 pub const expected_type: Diagnostic = .{
     .fmt = "expected a type",
     .kind = .@"error",

--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -1099,7 +1099,7 @@ pub fn print(v: Value, qt: QualType, comp: *const Compilation, w: *std.Io.Writer
             .f32 => |x| try w.print("{d}", .{@round(@as(f64, @floatCast(x)) * 1000000) / 1000000}),
             inline else => |x| try w.print("{d}", .{@as(f64, @floatCast(x))}),
         },
-        .bytes => |b| try printString(b, qt, comp, w),
+        .bytes => |b| try printString(b, qt, comp, w, .quoted),
         .complex => |repr| switch (repr) {
             .cf32 => |components| try w.print("{d} + {d}i", .{ @round(@as(f64, @floatCast(components[0])) * 1000000) / 1000000, @round(@as(f64, @floatCast(components[1])) * 1000000) / 1000000 }),
             inline else => |components| try w.print("{d} + {d}i", .{ @as(f64, @floatCast(components[0])), @as(f64, @floatCast(components[1])) }),
@@ -1110,10 +1110,13 @@ pub fn print(v: Value, qt: QualType, comp: *const Compilation, w: *std.Io.Writer
     return null;
 }
 
-pub fn printString(bytes: []const u8, qt: QualType, comp: *const Compilation, w: *std.Io.Writer) std.Io.Writer.Error!void {
+pub fn printString(bytes: []const u8, qt: QualType, comp: *const Compilation, w: *std.Io.Writer, style: enum { quoted, bare }) std.Io.Writer.Error!void {
+    if (style == .quoted) {
+        try w.writeByte('"');
+    }
+
     const size: Compilation.CharUnitSize = @enumFromInt(qt.childType(comp).sizeof(comp));
     const without_null = bytes[0 .. bytes.len - @intFromEnum(size)];
-    try w.writeByte('"');
     switch (size) {
         .@"1" => try std.zig.stringEscape(without_null, w),
         .@"2" => {
@@ -1152,5 +1155,8 @@ pub fn printString(bytes: []const u8, qt: QualType, comp: *const Compilation, w:
             }
         },
     }
-    try w.writeByte('"');
+
+    if (style == .quoted) {
+        try w.writeByte('"');
+    }
 }

--- a/src/assembly_backend/x86_64.zig
+++ b/src/assembly_backend/x86_64.zig
@@ -118,7 +118,7 @@ fn emitSingleValue(c: *AsmCodeGen, qt: QualType, node: Node.Index) !void {
         const bytes = value.toBytes(c.comp);
         const directive = if (bytes.len > bit_size / 8) "ascii" else "string";
         try c.data.print("  .{s} ", .{directive});
-        try Value.printString(bytes, qt, c.comp, c.data);
+        try Value.printString(bytes, qt, c.comp, c.data, .quoted);
 
         try c.data.writeByte('\n');
     } else unreachable;

--- a/test/cases/__builtin_types_compatible_p.c
+++ b/test/cases/__builtin_types_compatible_p.c
@@ -35,5 +35,5 @@ syntax
 args = -std=c23
 
 __builtin_types_compatible_p.c:30:16: error: static assertion failed due to requirement '__builtin_types_compatible_p(int, long)':
-__builtin_types_compatible_p.c:31:16: error: static assertion failed due to requirement '__builtin_types_compatible_p(typeof(const int) *, int *)': Types do not match
+__builtin_types_compatible_p.c:31:16: error: static assertion failed due to requirement '__builtin_types_compatible_p(__typeof__(const int) *, int *)': Types do not match
 */

--- a/test/cases/__builtin_types_compatible_p.c
+++ b/test/cases/__builtin_types_compatible_p.c
@@ -34,6 +34,6 @@ _Static_assert(__builtin_types_compatible_p(__typeof__(const int) *, int *), "Ty
 syntax
 args = -std=c23
 
-__builtin_types_compatible_p.c:30:1: error: static assertion failed '__builtin_types_compatible_p(int, long)'
-__builtin_types_compatible_p.c:31:1: error: static assertion failed '__builtin_types_compatible_p(typeof(const int) *, int *)' "Types do not match"
+__builtin_types_compatible_p.c:30:16: error: static assertion failed due to requirement '__builtin_types_compatible_p(int, long)':
+__builtin_types_compatible_p.c:31:16: error: static assertion failed due to requirement '__builtin_types_compatible_p(typeof(const int) *, int *)': Types do not match
 */

--- a/test/cases/const decl folding.c
+++ b/test/cases/const decl folding.c
@@ -70,12 +70,12 @@ const decl folding.c:34:27: error: '__builtin_choose_expr' requires a constant e
 const decl folding.c:38:15: warning: variable length array folded to constant array as an extension [-Wgnu-folding-constant]
 const decl folding.c:43:16: warning: implicit conversion turns string literal into bool: 'char [1]' to '_Bool' [-Wstring-conversion]
 const decl folding.c:43:16: error: static assertion expression is not an integral constant expression
-const decl folding.c:44:1: error: static assertion failed ""
+const decl folding.c:44:16: error: static assertion failed due to requirement '!""':
 const decl folding.c:46:16: error: static assertion expression is not an integral constant expression
 const decl folding.c:47:16: error: static assertion expression is not an integral constant expression
 const decl folding.c:50:16: warning: address of array 'arr' will always evaluate to 'true' [-Wpointer-bool-conversion]
 const decl folding.c:50:16: error: static assertion expression is not an integral constant expression
-const decl folding.c:51:1: error: static assertion failed ""
+const decl folding.c:51:16: error: static assertion failed due to requirement '!arr':
 const decl folding.c:53:16: warning: implicit conversion from 'double' to '_Bool' changes value from 4.2 to true [-Wfloat-conversion]
 const decl folding.c:53:16: error: static assertion expression is not an integral constant expression
 */

--- a/test/cases/msvc pointer keywords.c
+++ b/test/cases/msvc pointer keywords.c
@@ -22,8 +22,8 @@ skip = TODO: reimplement msvc pointer attribute keywords
 
 msvc pointer keywords.c:3:15: warning: TODO: implement 'ptr64' attribute
 msvc pointer keywords.c:7:15: warning: TODO: implement 'ptr32' attribute
-msvc pointer keywords.c:8:1: error: static assertion failed ""
-msvc pointer keywords.c:9:1: error: static assertion failed ""
+msvc pointer keywords.c:8:16: error: static assertion failed due to requirement 'sizeof(HANDLE32) == 4':
+msvc pointer keywords.c:9:16: error: static assertion failed due to requirement '_Alignof(HANDLE32) == 4':
 msvc pointer keywords.c:11:6: warning: TODO: implement 'ptr64' attribute
 msvc pointer keywords.c:11:14: warning: TODO: implement 'ptr32' attribute
 msvc pointer keywords.c:12:6: warning: TODO: implement 'sptr' attribute

--- a/test/cases/msvc pointer keywords.c
+++ b/test/cases/msvc pointer keywords.c
@@ -23,7 +23,9 @@ skip = TODO: reimplement msvc pointer attribute keywords
 msvc pointer keywords.c:3:15: warning: TODO: implement 'ptr64' attribute
 msvc pointer keywords.c:7:15: warning: TODO: implement 'ptr32' attribute
 msvc pointer keywords.c:8:16: error: static assertion failed due to requirement 'sizeof(HANDLE32) == 4':
+msvc pointer keywords.c:8:33: note: expression evaluates to '8 == 4'
 msvc pointer keywords.c:9:16: error: static assertion failed due to requirement '_Alignof(HANDLE32) == 4':
+msvc pointer keywords.c:9:35: note: expression evaluates to '8 == 4'
 msvc pointer keywords.c:11:6: warning: TODO: implement 'ptr64' attribute
 msvc pointer keywords.c:11:14: warning: TODO: implement 'ptr32' attribute
 msvc pointer keywords.c:12:6: warning: TODO: implement 'sptr' attribute

--- a/test/cases/relocations.c
+++ b/test/cases/relocations.c
@@ -72,7 +72,7 @@ _Static_assert(&((int *)casted)[1] == &casted[1], "");
 syntax
 args = --target=x86_64-linux -std=c23
 
-relocations.c:22:1: error: static assertion failed
+relocations.c:22:16: error: static assertion failed due to requirement '&x + 1 == &y + 1':
 relocations.c:27:16: error: static assertion expression is not an integral constant expression
 relocations.c:28:16: error: static assertion expression is not an integral constant expression
 relocations.c:37:16: warning: taking address of packed member 'x' of class or structure 'Packed' may result in an unaligned pointer value [-Waddress-of-packed-member]

--- a/test/cases/static assert messages.c
+++ b/test/cases/static assert messages.c
@@ -9,6 +9,7 @@ void bar(void) {
 }
 
 _Static_assert(1 == 0, "They are not equal!");
+_Static_assert(sizeof(int) == 3, "");
 
 /** manifest:
 syntax
@@ -20,4 +21,6 @@ static assert messages.c:4:20: error: static assertion failed due to requirement
 static assert messages.c:8:27: error: expected ')', found ','
 static assert messages.c:8:19: note: to match this '('
 static assert messages.c:11:16: error: static assertion failed due to requirement '1 == 0': They are not equal!
+static assert messages.c:12:16: error: static assertion failed due to requirement 'sizeof(int) == 3':
+static assert messages.c:12:28: note: expression evaluates to '4 == 3'
 */

--- a/test/cases/static assert messages.c
+++ b/test/cases/static assert messages.c
@@ -16,8 +16,8 @@ syntax
 static assert messages.c:2:20: error: static assertion expression is not an integral constant expression
 static assert messages.c:3:5: warning: '_Static_assert' with no message is a C23 extension [-Wc23-extensions]
 static assert messages.c:4:5: warning: '_Static_assert' with no message is a C23 extension [-Wc23-extensions]
-static assert messages.c:4:5: error: static assertion failed
+static assert messages.c:4:20: error: static assertion failed due to requirement '0':
 static assert messages.c:8:27: error: expected ')', found ','
 static assert messages.c:8:19: note: to match this '('
-static assert messages.c:11:1: error: static assertion failed "They are not equal!"
+static assert messages.c:11:16: error: static assertion failed due to requirement '1 == 0': They are not equal!
 */

--- a/test/cases/wide strings.c
+++ b/test/cases/wide strings.c
@@ -74,8 +74,8 @@ args = -std=c23
 wide strings.c:24:21: error: unsupported string literal concatenation
 wide strings.c:47:18: error: escape sequence out of range
 wide strings.c:49:18: error: escape sequence out of range
-wide strings.c:51:1: error: static assertion failed "😬😬"
-wide strings.c:52:1: error: static assertion failed "😬😬"
+wide strings.c:51:16: error: static assertion failed due to requirement '1 == 2': 😬😬
+wide strings.c:52:16: error: static assertion failed due to requirement '1 == 2': 😬😬
 wide strings.c:54:39: error: escape sequence out of range
 wide strings.c:66:21: error: expected ';', found 'a character literal'
 wide strings.c:67:16: error: array initializer must be an initializer list or wide string literal


### PR DESCRIPTION
While looking into closing out the last record layout tests I noticed that some of our MSVC tests seem to be wrong compared to what Godbolt is saying. Which led me on this sidequest of improving our static assert messages - `note: expression evaluates to '<EXPR>'` is really helpful for knowing what values are showing up in the static assert without having to dump the AST.