### PR TITLE
Value: don't report float-to-unsigned in (-1, 0) as out of range

### DIFF
--- a/src/aro/Value.zig
+++ b/src/aro/Value.zig
@@ -152,7 +152,11 @@ pub fn floatToInt(v: *Value, dest_ty: QualType, comp: *Compilation) !FloatToIntC
         v.* = fromBool(!was_zero);
         if (was_zero or was_one) return .none;
         return .value_changed;
-    } else if (dest_ty.signedness(comp) == .unsigned and float_val < 0) {
+    } else if (dest_ty.signedness(comp) == .unsigned and float_val <= -1) {
+        // A negative float is only out of range for an unsigned type once its
+        // truncated-toward-zero value is <= -1. Values in (-1, 0) truncate to 0,
+        // which is representable, so they fall through to the general path and are
+        // reported as a nonzero-to-zero conversion (matching signed destinations).
         v.* = zero;
         return .out_of_range;
     } else if (!std.math.isFinite(float_val)) {

--- a/test/cases/float to int.c
+++ b/test/cases/float to int.c
@@ -16,6 +16,7 @@ void foo(void) {
     _Bool j = 0.0;
     _Bool k = 1.0f;
     _Bool l = 1.5f;
+    unsigned m = -0.5;
 }
 
 /** manifest:
@@ -33,4 +34,5 @@ float to int.c:15:18: warning: implicit conversion of out of range value from 'd
 float to int.c:16:15: warning: implicit conversion turns floating-point number into integer: 'double' to '_Bool' [-Wliteral-conversion]
 float to int.c:17:15: warning: implicit conversion turns floating-point number into integer: 'float' to '_Bool' [-Wliteral-conversion]
 float to int.c:18:15: warning: implicit conversion from 'float' to '_Bool' changes value from 1.5 to true [-Wfloat-conversion]
+float to int.c:19:18: warning: implicit conversion from 'double' to 'unsigned int' changes non-zero value from -0.5 to 0 [-Wfloat-zero-conversion]
 */


### PR DESCRIPTION
`floatToInt` classifies any negative float to an unsigned type as `out_of_range`, which emits "implicit conversion of out of range value ... is undefined" under `-Wliteral-conversion`. But per C23 6.3.1.4, a finite float is truncated toward zero and the conversion is only undefined when the truncated integral part is not representable. A value in (-1, 0) truncates to 0, which is representable, so the conversion is defined and the result is 0.

arocc is already inconsistent about this:

```c
unsigned a = -0.5;  // warns "out of range ... is undefined"
int      d = -0.5;  // warns "changes non-zero value from -0.5 to 0"
```

Same value and same truncation to 0, but the unsigned case is reported as out-of-range/undefined while the signed case is correctly reported as a zero-conversion. GCC only warns (`-Woverflow`) for values `<= -1`, not for `-0.5`.

The fix changes the guard from `float_val < 0` to `float_val <= -1` so that negatives in (-1, 0) fall through to the general path, which truncates to 0 and returns `nonzero_to_zero`. Values `<= -1`, `-inf`, and `NaN` are unchanged. Adds a case to `test/cases/float to int.c` for the (-1, 0) interval.
