### PR TITLE
Tokenizer: use labeled switch instead of a loop

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -1241,7 +1241,7 @@ pub fn generateBuiltinMacros(comp: *Compilation, system_defines_mode: SystemDefi
 
     if (allocating.written().len > std.math.maxInt(u32)) return error.FileTooBig;
 
-    const contents = try allocating.toOwnedSlice();
+    const contents = try allocating.toOwnedSliceSentinel(0);
     errdefer comp.gpa.free(contents);
     return comp.addSourceFromOwnedBuffer("<builtin>", contents, .user);
 }
@@ -1661,7 +1661,7 @@ pub fn getSource(comp: *const Compilation, id: Source.Id) Source {
     }
     if (id.index == .generated) return .{
         .path = "<scratch space>",
-        .buf = comp.generated_buf.items,
+        .buf = @ptrCast(comp.generated_buf.items),
         .id = .generated,
         .splice_locs = &.{},
         .kind = .user,
@@ -1675,7 +1675,7 @@ pub fn getSource(comp: *const Compilation, id: Source.Id) Source {
 /// or line-ending changes happen.
 /// caller retains ownership of `path`
 /// To add a file's contents given its path, see addSourceFromPath
-pub fn addSourceFromOwnedBuffer(comp: *Compilation, path: []const u8, buf: []u8, kind: Source.Kind) !Source {
+pub fn addSourceFromOwnedBuffer(comp: *Compilation, path: []const u8, buf: [:0]u8, kind: Source.Kind) !Source {
     assert(buf.len <= std.math.maxInt(u32));
     try comp.sources.ensureUnusedCapacity(comp.gpa, 1);
 
@@ -1798,9 +1798,9 @@ pub fn addSourceFromOwnedBuffer(comp: *Compilation, path: []const u8, buf: []u8,
     if (i != contents.len) {
         var list: std.ArrayList(u8) = .{
             .items = contents[0..i],
-            .capacity = contents.len,
+            .capacity = contents.len + 1, // +1 for sentinel
         };
-        contents = try list.toOwnedSlice(comp.gpa);
+        contents = try list.toOwnedSliceSentinel(comp.gpa, 0);
     }
     errdefer @compileError("errdefers in callers would possibly free the realloced slice using the original len");
 
@@ -1819,7 +1819,7 @@ pub fn addSourceFromOwnedBuffer(comp: *Compilation, path: []const u8, buf: []u8,
 fn addNewlineEscapeError(
     comp: *Compilation,
     path: []const u8,
-    buf: []const u8,
+    buf: [:0]const u8,
     splice_locs: []const u32,
     byte_offset: u32,
     line: u32,
@@ -1855,7 +1855,7 @@ pub fn addSourceFromBuffer(comp: *Compilation, path: []const u8, buf: []const u8
     if (comp.sources.get(path)) |some| return some;
     if (buf.len > std.math.maxInt(u32)) return error.FileTooBig;
 
-    const contents = try comp.gpa.dupe(u8, buf);
+    const contents = try comp.gpa.dupeSentinel(u8, buf, 0);
     errdefer comp.gpa.free(contents);
 
     return comp.addSourceFromOwnedBuffer(path, contents, .user);
@@ -2234,7 +2234,7 @@ pub const IncludeType = enum {
     cli,
 };
 
-fn getPathContents(comp: *Compilation, path: []const u8, limit: Io.Limit) ![]u8 {
+fn getPathContents(comp: *Compilation, path: []const u8, limit: Io.Limit) ![:0]u8 {
     if (mem.indexOfScalar(u8, path, 0) != null) {
         return error.FileNotFound;
     }
@@ -2244,7 +2244,7 @@ fn getPathContents(comp: *Compilation, path: []const u8, limit: Io.Limit) ![]u8 
     return comp.getFileContents(file, limit);
 }
 
-fn getFileContents(comp: *Compilation, file: std.Io.File, limit: Io.Limit) ![]u8 {
+fn getFileContents(comp: *Compilation, file: std.Io.File, limit: Io.Limit) ![:0]u8 {
     var file_buf: [4096]u8 = undefined;
     var file_reader = file.reader(comp.io, &file_buf);
 
@@ -2259,14 +2259,14 @@ fn getFileContents(comp: *Compilation, file: std.Io.File, limit: Io.Limit) ![]u8
     var remaining = limit.min(.limited(std.math.maxInt(u32)));
     while (remaining.nonzero()) {
         const n = file_reader.interface.stream(&allocating.writer, remaining) catch |err| switch (err) {
-            error.EndOfStream => return allocating.toOwnedSlice(),
+            error.EndOfStream => return allocating.toOwnedSliceSentinel(0),
             error.WriteFailed => return error.OutOfMemory,
             error.ReadFailed => return file_reader.err.?,
         };
         remaining = remaining.subtract(n).?;
     }
     if (limit == .unlimited) return error.FileTooBig;
-    return allocating.toOwnedSlice();
+    return allocating.toOwnedSliceSentinel(0);
 }
 
 fn normalizePath(comp: *Compilation, path: []u8) void {
@@ -2283,7 +2283,7 @@ pub fn findEmbed(
     include_type: IncludeType,
     limit: Io.Limit,
     opt_dep_file: ?*DepFile,
-) !?[]u8 {
+) !?[:0]u8 {
     if (std.fs.path.isAbsolute(filename)) {
         if (comp.getPathContents(filename, limit)) |some| {
             errdefer comp.gpa.free(some);

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -1249,7 +1249,7 @@ pub fn main(d: *Driver, tc: *Toolchain, args: []const []const u8, comptime fast_
         if (macro_buf.items.len > std.math.maxInt(u32)) {
             return d.fatal("user provided macro source exceeded max size", .{});
         }
-        const contents = try macro_buf.toOwnedSlice(d.comp.gpa);
+        const contents = try macro_buf.toOwnedSliceSentinel(d.comp.gpa, 0);
         errdefer d.comp.gpa.free(contents);
 
         break :macros try d.comp.addSourceFromOwnedBuffer("<command line>", contents, .user);

--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -1642,16 +1642,18 @@ fn pragmaOperator(pp: *Preprocessor, arg_tok: TokenWithExpansionLocs, buf: *Expa
     const gpa = pp.comp.gpa;
 
     pp.char_buf.clearRetainingCapacity();
-    const total_len = directive.len + content.len + 1; // destringify can never grow the string, + 1 for newline
+    const total_len = directive.len + content.len + 2; // destringify can never grow the string, +2 for newline and null terminator
     try pp.char_buf.ensureUnusedCapacity(gpa, total_len);
     pp.char_buf.appendSliceAssumeCapacity(directive);
     pp.destringify(content);
-    pp.char_buf.appendAssumeCapacity('\n');
+    pp.char_buf.appendSliceAssumeCapacity("\n\x00");
 
     const start = pp.comp.generated_buf.items.len;
     try pp.comp.generated_buf.appendSlice(gpa, pp.char_buf.items);
+    defer pp.comp.generated_buf.items.len -= 1; // remove redundant null terminator
+
     var tmp_tokenizer: Tokenizer = .{
-        .buf = pp.comp.generated_buf.items,
+        .buf = pp.comp.generated_buf.items[0 .. pp.comp.generated_buf.items.len - 1 :0],
         .langopts = pp.comp.langopts,
         .index = @intCast(start),
         .source = .generated,
@@ -1769,9 +1771,9 @@ fn stringify(pp: *Preprocessor, tokens: []const TokenWithExpansionLocs) !void {
         pp.char_buf.appendSliceAssumeCapacity("\"\n");
         return;
     }
-    pp.char_buf.appendAssumeCapacity('"');
+    pp.char_buf.appendSliceAssumeCapacity("\"\x00");
     var tokenizer: Tokenizer = .{
-        .buf = pp.char_buf.items,
+        .buf = pp.char_buf.items[0 .. pp.char_buf.items.len - 1 :0],
         .index = 0,
         .source = .generated,
         .langopts = pp.comp.langopts,
@@ -1782,7 +1784,7 @@ fn stringify(pp: *Preprocessor, tokens: []const TokenWithExpansionLocs) !void {
     if (item.id == .unterminated_string_literal) {
         const tok = tokens[tokens.len - 1];
         try pp.err(tok, .invalid_pp_stringify_escape, .{});
-        pp.char_buf.items.len -= 2; // erase unpaired backslash and appended end quote
+        pp.char_buf.items.len -= 3; // erase unpaired backslash and appended end quote
         pp.char_buf.appendAssumeCapacity('"');
     }
     pp.char_buf.appendAssumeCapacity('\n');
@@ -2975,15 +2977,16 @@ fn pasteTokens(pp: *Preprocessor, lhs_toks: *ExpandBuf, rhs_toks: []const TokenW
 
     const start = pp.comp.generated_buf.items.len;
     const end = start + pp.expandedSlice(lhs).len + pp.expandedSlice(rhs).len;
-    try pp.comp.generated_buf.ensureTotalCapacity(gpa, end + 1); // +1 for a newline
+    try pp.comp.generated_buf.ensureTotalCapacity(gpa, end + 2); // +2 for a newline and null terminator
     // We cannot use the same slices here since they might be invalidated by `ensureCapacity`
     pp.comp.generated_buf.appendSliceAssumeCapacity(pp.expandedSlice(lhs));
     pp.comp.generated_buf.appendSliceAssumeCapacity(pp.expandedSlice(rhs));
-    pp.comp.generated_buf.appendAssumeCapacity('\n');
+    pp.comp.generated_buf.appendSliceAssumeCapacity("\n\x00");
+    defer pp.comp.generated_buf.items.len -= 1; // remove redundant null terminator
 
     // Try to tokenize the result.
     var tmp_tokenizer: Tokenizer = .{
-        .buf = pp.comp.generated_buf.items,
+        .buf = pp.comp.generated_buf.items[0 .. pp.comp.generated_buf.items.len - 1 :0],
         .langopts = pp.comp.langopts,
         .index = @intCast(start),
         .source = .generated,

--- a/src/aro/Source.zig
+++ b/src/aro/Source.zig
@@ -50,7 +50,7 @@ pub const ExpandedLocation = struct {
 const Source = @This();
 
 path: []const u8,
-buf: []const u8,
+buf: [:0]const u8,
 id: Id,
 /// each entry represents a byte position within `buf` where a backslash+newline was deleted
 /// from the original raw buffer. The same position can appear multiple times if multiple

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -1150,7 +1150,7 @@ pub const Token = struct {
 
 const Tokenizer = @This();
 
-buf: []const u8,
+buf: [:0]const u8,
 index: u32 = 0,
 source: Source.Id,
 langopts: LangOpts,
@@ -1159,7 +1159,7 @@ splice_index: u32 = 0,
 splice_locs: []const u32,
 
 pub fn next(self: *Tokenizer) Token {
-    var state: enum {
+    const State = enum {
         start,
         whitespace,
         u,
@@ -1200,335 +1200,365 @@ pub fn next(self: *Tokenizer) Token {
         pp_num,
         pp_num_exponent,
         pp_num_digit_separator,
-    } = .start;
+    };
 
     var start = self.index;
     var id: Token.Id = .eof;
 
-    while (self.index < self.buf.len) : (self.index += 1) {
-        const c = self.buf[self.index];
-        switch (state) {
-            .start => switch (c) {
-                '\n' => {
-                    id = .nl;
-                    self.index += 1;
-                    self.line += 1;
-                    break;
-                },
-                '"' => {
-                    id = .string_literal;
-                    state = .string_literal;
-                },
-                '\'' => {
-                    id = .char_literal;
-                    state = .char_literal_start;
-                },
-                'u' => state = .u,
-                'U' => state = .U,
-                'L' => state = .L,
-                '\\' => {
-                    const ucn_kind = UCNKind.classify(self.buf[self.index..]);
-                    switch (ucn_kind) {
-                        .none => {
-                            self.index += 1;
-                            id = .invalid;
-                            break;
-                        },
-                        .incomplete => {
-                            self.index += 1;
-                            id = .incomplete_ucn;
-                            break;
-                        },
-                        .hex4, .hex8 => {
-                            self.index += @backingInt(ucn_kind);
-                            id = .extended_identifier;
-                            state = .extended_identifier;
-                        },
-                    }
-                },
-                'a'...'t', 'v'...'z', 'A'...'K', 'M'...'T', 'V'...'Z', '_' => state = .identifier,
-                '=' => state = .equal,
-                '!' => state = .bang,
-                '|' => state = .pipe,
-                '(' => {
-                    id = .l_paren;
-                    self.index += 1;
-                    break;
-                },
-                ')' => {
-                    id = .r_paren;
-                    self.index += 1;
-                    break;
-                },
-                '[' => {
-                    id = .l_bracket;
-                    self.index += 1;
-                    break;
-                },
-                ']' => {
-                    id = .r_bracket;
-                    self.index += 1;
-                    break;
-                },
-                ';' => {
-                    id = .semicolon;
-                    self.index += 1;
-                    break;
-                },
-                ',' => {
-                    id = .comma;
-                    self.index += 1;
-                    break;
-                },
-                '?' => {
-                    id = .question_mark;
-                    self.index += 1;
-                    break;
-                },
-                ':' => state = .colon,
-                '%' => state = .percent,
-                '*' => state = .asterisk,
-                '+' => state = .plus,
-                '<' => state = .angle_bracket_left,
-                '>' => state = .angle_bracket_right,
-                '^' => state = .caret,
-                '{' => {
-                    id = .l_brace;
-                    self.index += 1;
-                    break;
-                },
-                '}' => {
-                    id = .r_brace;
-                    self.index += 1;
-                    break;
-                },
-                '~' => {
-                    id = .tilde;
-                    self.index += 1;
-                    break;
-                },
-                '.' => state = .period,
-                '-' => state = .minus,
-                '/' => state = .slash,
-                '&' => state = .ampersand,
-                '#' => state = .hash,
-                '0'...'9' => state = .pp_num,
-                '\t', '\x0B', '\x0C', ' ' => state = .whitespace,
-                '$' => if (self.langopts.dollars_in_identifiers) {
-                    state = .extended_identifier;
-                } else {
+    loop: switch (State.start) {
+        .start => switch (self.buf[self.index]) {
+            0 => {
+                if (self.index != self.buf.len) {
                     id = .invalid;
                     self.index += 1;
-                    break;
-                },
-                0x1A => if (self.langopts.ms_extensions) {
-                    id = .eof;
-                    break;
-                } else {
-                    id = .invalid;
-                    self.index += 1;
-                    break;
-                },
-                0x80...0xFF => state = .extended_identifier,
-                else => {
-                    id = .invalid;
-                    self.index += 1;
-                    break;
-                },
+                }
             },
-            .whitespace => switch (c) {
-                '\t', '\x0B', '\x0C', ' ' => {},
-                else => {
-                    id = .whitespace;
-                    break;
-                },
+            '\n' => {
+                id = .nl;
+                self.index += 1;
+                self.line += 1;
             },
-            .u => switch (c) {
+            '"' => {
+                id = .string_literal;
+                continue :loop .string_literal;
+            },
+            '\'' => {
+                id = .char_literal;
+                continue :loop .char_literal_start;
+            },
+            'u' => continue :loop .u,
+            'U' => continue :loop .U,
+            'L' => continue :loop .L,
+            '\\' => {
+                const ucn_kind = UCNKind.classify(self.buf[self.index..]);
+                switch (ucn_kind) {
+                    .none => {
+                        self.index += 1;
+                        id = .invalid;
+                    },
+                    .incomplete => {
+                        self.index += 1;
+                        id = .incomplete_ucn;
+                    },
+                    .hex4, .hex8 => {
+                        self.index += @backingInt(ucn_kind);
+                        id = .extended_identifier;
+                        continue :loop .extended_identifier;
+                    },
+                }
+            },
+            'a'...'t', 'v'...'z', 'A'...'K', 'M'...'T', 'V'...'Z', '_' => continue :loop .identifier,
+            '=' => continue :loop .equal,
+            '!' => continue :loop .bang,
+            '|' => continue :loop .pipe,
+            '(' => {
+                id = .l_paren;
+                self.index += 1;
+            },
+            ')' => {
+                id = .r_paren;
+                self.index += 1;
+            },
+            '[' => {
+                id = .l_bracket;
+                self.index += 1;
+            },
+            ']' => {
+                id = .r_bracket;
+                self.index += 1;
+            },
+            ';' => {
+                id = .semicolon;
+                self.index += 1;
+            },
+            ',' => {
+                id = .comma;
+                self.index += 1;
+            },
+            '?' => {
+                id = .question_mark;
+                self.index += 1;
+            },
+            ':' => continue :loop .colon,
+            '%' => continue :loop .percent,
+            '*' => continue :loop .asterisk,
+            '+' => continue :loop .plus,
+            '<' => continue :loop .angle_bracket_left,
+            '>' => continue :loop .angle_bracket_right,
+            '^' => continue :loop .caret,
+            '{' => {
+                id = .l_brace;
+                self.index += 1;
+            },
+            '}' => {
+                id = .r_brace;
+                self.index += 1;
+            },
+            '~' => {
+                id = .tilde;
+                self.index += 1;
+            },
+            '.' => continue :loop .period,
+            '-' => continue :loop .minus,
+            '/' => continue :loop .slash,
+            '&' => continue :loop .ampersand,
+            '#' => continue :loop .hash,
+            '0'...'9' => continue :loop .pp_num,
+            '\t', '\x0B', '\x0C', ' ' => continue :loop .whitespace,
+            '$' => if (self.langopts.dollars_in_identifiers) {
+                continue :loop .extended_identifier;
+            } else {
+                id = .invalid;
+                self.index += 1;
+            },
+            0x1A => if (self.langopts.ms_extensions) {
+                id = .eof;
+            } else {
+                id = .invalid;
+                self.index += 1;
+            },
+            0x80...0xFF => continue :loop .extended_identifier,
+            else => {
+                id = .invalid;
+                self.index += 1;
+            },
+        },
+        .whitespace => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                '\t', '\x0B', '\x0C', ' ' => continue :loop .whitespace,
+                else => id = .whitespace,
+            }
+        },
+        .u => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '8' => {
-                    state = .u8;
+                    continue :loop .u8;
                 },
                 '\'' => {
                     id = .char_literal_utf_16;
-                    state = .char_literal_start;
+                    continue :loop .char_literal_start;
                 },
                 '\"' => {
                     id = .string_literal_utf_16;
-                    state = .string_literal;
+                    continue :loop .string_literal;
                 },
                 else => {
                     self.index -= 1;
-                    state = .identifier;
+                    continue :loop .identifier;
                 },
-            },
-            .u8 => switch (c) {
+            }
+        },
+        .u8 => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '\"' => {
                     id = .string_literal_utf_8;
-                    state = .string_literal;
+                    continue :loop .string_literal;
                 },
                 '\'' => {
                     id = .char_literal_utf_8;
-                    state = .char_literal_start;
+                    continue :loop .char_literal_start;
                 },
                 else => {
                     self.index -= 1;
-                    state = .identifier;
+                    continue :loop .identifier;
                 },
-            },
-            .U => switch (c) {
+            }
+        },
+        .U => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '\'' => {
                     id = .char_literal_utf_32;
-                    state = .char_literal_start;
+                    continue :loop .char_literal_start;
                 },
                 '\"' => {
                     id = .string_literal_utf_32;
-                    state = .string_literal;
+                    continue :loop .string_literal;
                 },
                 else => {
                     self.index -= 1;
-                    state = .identifier;
+                    continue :loop .identifier;
                 },
-            },
-            .L => switch (c) {
+            }
+        },
+        .L => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '\'' => {
                     id = .char_literal_wide;
-                    state = .char_literal_start;
+                    continue :loop .char_literal_start;
                 },
                 '\"' => {
                     id = .string_literal_wide;
-                    state = .string_literal;
+                    continue :loop .string_literal;
                 },
                 else => {
                     self.index -= 1;
-                    state = .identifier;
+                    continue :loop .identifier;
                 },
-            },
-            .string_literal => switch (c) {
+            }
+        },
+        .string_literal => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '\\' => {
-                    state = .string_escape_sequence;
+                    continue :loop .string_escape_sequence;
                 },
                 '"' => {
                     self.index += 1;
-                    break;
                 },
                 '\n' => {
                     id = .unterminated_string_literal;
-                    break;
                 },
                 '\r' => unreachable,
-                else => {},
-            },
-            .char_literal_start => switch (c) {
+                0 => {
+                    if (self.index == self.buf.len) {
+                        id = .unterminated_string_literal;
+                    } else {
+                        continue :loop .string_literal;
+                    }
+                },
+                else => continue :loop .string_literal,
+            }
+        },
+        .char_literal_start => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '\\' => {
-                    state = .char_escape_sequence;
+                    continue :loop .char_escape_sequence;
                 },
                 '\'' => {
                     id = .empty_char_literal;
                     self.index += 1;
-                    break;
                 },
                 '\n' => {
                     id = .unterminated_char_literal;
-                    break;
                 },
-                else => {
-                    state = .char_literal;
+                0 => {
+                    if (self.index == self.buf.len) {
+                        id = .unterminated_char_literal;
+                    } else {
+                        continue :loop .char_literal;
+                    }
                 },
-            },
-            .char_literal => switch (c) {
+                else => continue :loop .char_literal,
+            }
+        },
+        .char_literal => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '\\' => {
-                    state = .char_escape_sequence;
+                    continue :loop .char_escape_sequence;
                 },
                 '\'' => {
                     self.index += 1;
-                    break;
                 },
                 '\n' => {
                     id = .unterminated_char_literal;
-                    break;
                 },
-                else => {},
-            },
-            .char_escape_sequence => switch (c) {
+                0 => {
+                    if (self.index == self.buf.len) {
+                        id = .unterminated_char_literal;
+                    } else {
+                        continue :loop .char_literal;
+                    }
+                },
+                else => continue :loop .char_literal,
+            }
+        },
+        .char_escape_sequence => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '\r', '\n' => {
                     id = .unterminated_char_literal;
-                    break;
                 },
-                else => state = .char_literal,
-            },
-            .string_escape_sequence => switch (c) {
+                else => continue :loop .char_literal,
+            }
+        },
+        .string_escape_sequence => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '\r', '\n' => {
                     id = .unterminated_string_literal;
-                    break;
                 },
-                else => state = .string_literal,
-            },
-            .identifier, .extended_identifier => switch (c) {
-                'a'...'z', 'A'...'Z', '_', '0'...'9' => {},
+                else => continue :loop .string_literal,
+            }
+        },
+        inline .identifier, .extended_identifier => |state| {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                'a'...'z', 'A'...'Z', '_', '0'...'9' => {
+                    continue :loop state;
+                },
                 '$' => if (self.langopts.dollars_in_identifiers) {
-                    state = .extended_identifier;
+                    continue :loop .extended_identifier;
                 } else {
                     id = if (state == .identifier) Token.getTokenId(self.langopts, self.buf[start..self.index]) else .extended_identifier;
-                    break;
                 },
-                0x80...0xFF => state = .extended_identifier,
+                0x80...0xFF => continue :loop .extended_identifier,
                 '\\' => {
                     const ucn_kind = UCNKind.classify(self.buf[self.index..]);
                     switch (ucn_kind) {
                         .none, .incomplete => {
                             id = if (state == .identifier) Token.getTokenId(self.langopts, self.buf[start..self.index]) else .extended_identifier;
-                            break;
                         },
                         .hex4, .hex8 => {
-                            state = .extended_identifier;
                             self.index += @backingInt(ucn_kind);
+                            continue :loop .extended_identifier;
                         },
                     }
                 },
-
                 else => {
                     id = if (state == .identifier) Token.getTokenId(self.langopts, self.buf[start..self.index]) else .extended_identifier;
-                    break;
                 },
-            },
-            .equal => switch (c) {
+            }
+        },
+        .equal => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '=' => {
                     id = .equal_equal;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .equal;
-                    break;
                 },
-            },
-            .bang => switch (c) {
+            }
+        },
+        .bang => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '=' => {
                     id = .bang_equal;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .bang;
-                    break;
                 },
-            },
-            .pipe => switch (c) {
+            }
+        },
+        .pipe => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '=' => {
                     id = .pipe_equal;
                     self.index += 1;
-                    break;
                 },
                 '|' => {
                     id = .pipe_pipe;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .pipe;
-                    break;
                 },
-            },
-            .colon => switch (c) {
+            }
+        },
+        .colon => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '>' => {
                     if (self.langopts.hasDigraphs()) {
                         id = .r_bracket;
@@ -1536,23 +1566,22 @@ pub fn next(self: *Tokenizer) Token {
                     } else {
                         id = .colon;
                     }
-                    break;
                 },
                 ':' => {
                     id = .colon_colon;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .colon;
-                    break;
                 },
-            },
-            .percent => switch (c) {
+            }
+        },
+        .percent => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '=' => {
                     id = .percent_equal;
                     self.index += 1;
-                    break;
                 },
                 '>' => {
                     if (self.langopts.hasDigraphs()) {
@@ -1561,54 +1590,54 @@ pub fn next(self: *Tokenizer) Token {
                     } else {
                         id = .percent;
                     }
-                    break;
                 },
                 ':' => {
                     if (self.langopts.hasDigraphs()) {
-                        state = .hash_digraph;
+                        continue :loop .hash_digraph;
                     } else {
                         id = .percent;
-                        break;
                     }
                 },
                 else => {
                     id = .percent;
-                    break;
                 },
-            },
-            .asterisk => switch (c) {
+            }
+        },
+        .asterisk => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '=' => {
                     id = .asterisk_equal;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .asterisk;
-                    break;
                 },
-            },
-            .plus => switch (c) {
+            }
+        },
+        .plus => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '=' => {
                     id = .plus_equal;
                     self.index += 1;
-                    break;
                 },
                 '+' => {
                     id = .plus_plus;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .plus;
-                    break;
                 },
-            },
-            .angle_bracket_left => switch (c) {
-                '<' => state = .angle_bracket_angle_bracket_left,
+            }
+        },
+        .angle_bracket_left => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                '<' => continue :loop .angle_bracket_angle_bracket_left,
                 '=' => {
                     id = .angle_bracket_left_equal;
                     self.index += 1;
-                    break;
                 },
                 ':' => {
                     if (self.langopts.hasDigraphs()) {
@@ -1617,7 +1646,6 @@ pub fn next(self: *Tokenizer) Token {
                     } else {
                         id = .angle_bracket_left;
                     }
-                    break;
                 },
                 '%' => {
                     if (self.langopts.hasDigraphs()) {
@@ -1626,209 +1654,258 @@ pub fn next(self: *Tokenizer) Token {
                     } else {
                         id = .angle_bracket_left;
                     }
-                    break;
                 },
                 else => {
                     id = .angle_bracket_left;
-                    break;
                 },
-            },
-            .angle_bracket_angle_bracket_left => switch (c) {
+            }
+        },
+        .angle_bracket_angle_bracket_left => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '=' => {
                     id = .angle_bracket_angle_bracket_left_equal;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .angle_bracket_angle_bracket_left;
-                    break;
                 },
-            },
-            .angle_bracket_right => switch (c) {
-                '>' => state = .angle_bracket_angle_bracket_right,
+            }
+        },
+        .angle_bracket_right => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                '>' => continue :loop .angle_bracket_angle_bracket_right,
                 '=' => {
                     id = .angle_bracket_right_equal;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .angle_bracket_right;
-                    break;
                 },
-            },
-            .angle_bracket_angle_bracket_right => switch (c) {
+            }
+        },
+        .angle_bracket_angle_bracket_right => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '=' => {
                     id = .angle_bracket_angle_bracket_right_equal;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .angle_bracket_angle_bracket_right;
-                    break;
                 },
-            },
-            .caret => switch (c) {
+            }
+        },
+        .caret => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '=' => {
                     id = .caret_equal;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .caret;
-                    break;
                 },
-            },
-            .period => switch (c) {
-                '.' => state = .period2,
-                '0'...'9' => state = .pp_num,
+            }
+        },
+        .period => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                '.' => continue :loop .period2,
+                '0'...'9' => continue :loop .pp_num,
                 else => {
                     id = .period;
-                    break;
                 },
-            },
-            .period2 => switch (c) {
+            }
+        },
+        .period2 => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '.' => {
                     id = .ellipsis;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .period;
                     self.index -= 1;
-                    break;
                 },
-            },
-            .minus => switch (c) {
+            }
+        },
+        .minus => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '>' => {
                     id = .arrow;
                     self.index += 1;
-                    break;
                 },
                 '=' => {
                     id = .minus_equal;
                     self.index += 1;
-                    break;
                 },
                 '-' => {
                     id = .minus_minus;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .minus;
-                    break;
                 },
-            },
-            .ampersand => switch (c) {
+            }
+        },
+        .ampersand => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '&' => {
                     id = .ampersand_ampersand;
                     self.index += 1;
-                    break;
                 },
                 '=' => {
                     id = .ampersand_equal;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .ampersand;
-                    break;
                 },
-            },
-            .hash => switch (c) {
+            }
+        },
+        .hash => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '#' => {
                     id = .hash_hash;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .hash;
-                    break;
                 },
-            },
-            .hash_digraph => switch (c) {
-                '%' => state = .hash_hash_digraph_partial,
+            }
+        },
+        .hash_digraph => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                '%' => continue :loop .hash_hash_digraph_partial,
                 else => {
                     id = .hash;
-                    break;
                 },
-            },
-            .hash_hash_digraph_partial => switch (c) {
+            }
+        },
+        .hash_hash_digraph_partial => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 ':' => {
                     id = .hash_hash;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .hash;
                     self.index -= 1; // re-tokenize the percent
-                    break;
                 },
-            },
-            .slash => switch (c) {
-                '/' => state = .line_comment,
-                '*' => state = .multi_line_comment,
+            }
+        },
+        .slash => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                '/' => continue :loop .line_comment,
+                '*' => continue :loop .multi_line_comment,
                 '=' => {
                     id = .slash_equal;
                     self.index += 1;
-                    break;
                 },
                 else => {
                     id = .slash;
-                    break;
                 },
-            },
-            .line_comment => switch (c) {
+            }
+        },
+        .line_comment => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                0 => {
+                    if (self.index == self.buf.len) {
+                        if (self.langopts.preserve_comments) {
+                            id = .comment;
+                        } else {
+                            continue :loop .start;
+                        }
+                    } else {
+                        continue :loop .line_comment;
+                    }
+                },
                 '\n' => {
                     if (self.langopts.preserve_comments) {
                         id = .comment;
-                        break;
+                    } else {
+                        continue :loop .start;
                     }
-                    self.index -= 1;
-                    state = .start;
                 },
-                else => {},
-            },
-            .multi_line_comment => switch (c) {
-                '*' => state = .multi_line_comment_asterisk,
-                '\n' => self.line += 1,
-                else => {},
-            },
-            .multi_line_comment_asterisk => switch (c) {
+                else => continue :loop .line_comment,
+            }
+        },
+        .multi_line_comment => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                0 => {
+                    if (self.index == self.buf.len) {
+                        id = .unterminated_comment;
+                    } else {
+                        continue :loop .multi_line_comment;
+                    }
+                },
+                '*' => continue :loop .multi_line_comment_asterisk,
+                '\n' => {
+                    self.line += 1;
+                    continue :loop .multi_line_comment;
+                },
+                else => continue :loop .multi_line_comment,
+            }
+        },
+        .multi_line_comment_asterisk => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
+                0 => {
+                    if (self.index == self.buf.len) {
+                        id = .unterminated_comment;
+                    } else {
+                        continue :loop .multi_line_comment;
+                    }
+                },
                 '/' => {
                     if (self.langopts.preserve_comments) {
                         self.index += 1;
                         id = .comment;
-                        break;
+                    } else {
+                        continue :loop .multi_line_comment_done;
                     }
-                    state = .multi_line_comment_done;
                 },
                 '\n' => {
                     self.line += 1;
-                    state = .multi_line_comment;
+                    continue :loop .multi_line_comment;
                 },
-                '*' => {},
-                else => state = .multi_line_comment,
-            },
-            .multi_line_comment_done => switch (c) {
+                '*' => continue :loop .multi_line_comment_asterisk,
+                else => continue :loop .multi_line_comment,
+            }
+        },
+        .multi_line_comment_done => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 '\n' => {
                     start = self.index;
                     id = .nl;
                     self.index += 1;
                     self.line += 1;
-                    break;
                 },
                 '\r' => unreachable,
                 '\t', '\x0B', '\x0C', ' ' => {
                     start = self.index;
-                    state = .whitespace;
+                    continue :loop .whitespace;
                 },
                 else => {
                     id = .whitespace;
-                    break;
                 },
-            },
-            .pp_num => switch (c) {
+            }
+        },
+        .pp_num => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 'a'...'d',
                 'A'...'D',
                 'f'...'o',
@@ -1838,20 +1915,21 @@ pub fn next(self: *Tokenizer) Token {
                 '0'...'9',
                 '_',
                 '.',
-                => {},
-                'e', 'E', 'p', 'P' => state = .pp_num_exponent,
+                => continue :loop .pp_num,
+                'e', 'E', 'p', 'P' => continue :loop .pp_num_exponent,
                 '\'' => if (self.langopts.standard.atLeast(.c23)) {
-                    state = .pp_num_digit_separator;
+                    continue :loop .pp_num_digit_separator;
                 } else {
                     id = .pp_num;
-                    break;
                 },
                 else => {
                     id = .pp_num;
-                    break;
                 },
-            },
-            .pp_num_digit_separator => switch (c) {
+            }
+        },
+        .pp_num_digit_separator => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 'a'...'d',
                 'A'...'D',
                 'f'...'o',
@@ -1860,14 +1938,16 @@ pub fn next(self: *Tokenizer) Token {
                 'Q'...'Z',
                 '0'...'9',
                 '_',
-                => state = .pp_num,
+                => continue :loop .pp_num,
                 else => {
                     self.index -= 1;
                     id = .pp_num;
-                    break;
                 },
-            },
-            .pp_num_exponent => switch (c) {
+            }
+        },
+        .pp_num_exponent => {
+            self.index += 1;
+            switch (self.buf[self.index]) {
                 'a'...'o',
                 'q'...'z',
                 'A'...'O',
@@ -1877,62 +1957,13 @@ pub fn next(self: *Tokenizer) Token {
                 '.',
                 '+',
                 '-',
-                => state = .pp_num,
-                'p', 'P' => {},
+                => continue :loop .pp_num,
+                'p', 'P' => continue :loop .pp_num_exponent,
                 else => {
                     id = .pp_num;
-                    break;
                 },
-            },
-        }
-    } else if (self.index == self.buf.len) {
-        switch (state) {
-            .start => {},
-            .line_comment => if (self.langopts.preserve_comments) {
-                id = .comment;
-            },
-            .u, .u8, .U, .L, .identifier => id = Token.getTokenId(self.langopts, self.buf[start..self.index]),
-            .extended_identifier => id = .extended_identifier,
-
-            .period2 => {
-                self.index -= 1;
-                id = .period;
-            },
-
-            .multi_line_comment,
-            .multi_line_comment_asterisk,
-            => id = .unterminated_comment,
-
-            .char_escape_sequence, .char_literal, .char_literal_start => id = .unterminated_char_literal,
-            .string_escape_sequence, .string_literal => id = .unterminated_string_literal,
-
-            .whitespace => id = .whitespace,
-            .multi_line_comment_done => id = .whitespace,
-
-            .equal => id = .equal,
-            .bang => id = .bang,
-            .minus => id = .minus,
-            .slash => id = .slash,
-            .ampersand => id = .ampersand,
-            .hash => id = .hash,
-            .period => id = .period,
-            .pipe => id = .pipe,
-            .angle_bracket_angle_bracket_right => id = .angle_bracket_angle_bracket_right,
-            .angle_bracket_right => id = .angle_bracket_right,
-            .angle_bracket_angle_bracket_left => id = .angle_bracket_angle_bracket_left,
-            .angle_bracket_left => id = .angle_bracket_left,
-            .plus => id = .plus,
-            .colon => id = .colon,
-            .percent => id = .percent,
-            .caret => id = .caret,
-            .asterisk => id = .asterisk,
-            .hash_digraph => id = .hash,
-            .hash_hash_digraph_partial => {
-                id = .hash;
-                self.index -= 1; // re-tokenize the percent
-            },
-            .pp_num, .pp_num_exponent, .pp_num_digit_separator => id = .pp_num,
-        }
+            }
+        },
     }
 
     for (self.splice_locs[self.splice_index..]) |splice_offset| {


### PR DESCRIPTION
```sh-session
$ poop -d 10000 "arocc-master stb_image.h -E" "arocc-branch stb_image.h -E"
Benchmark 1 (2318 runs): arocc-master stb_image.h -E
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          4.29ms ±  243us    3.98ms … 6.33ms        248 (11%)        0%
  peak_rss           5.99MB ±  131KB    5.23MB … 6.12MB        459 (20%)        0%
  cpu_cycles         19.7M  ±  311K     19.2M  … 21.5M          82 ( 4%)        0%
  instructions       57.7M  ± 6.94      57.7M  … 57.7M          13 ( 1%)        0%
  cache_references    769K  ± 17.3K      732K  …  875K          81 ( 3%)        0%
  cache_misses       24.8K  ± 4.29K     20.1K  … 48.5K          30 ( 1%)        0%
  branch_misses       237K  ± 3.54K      228K  …  253K          63 ( 3%)        0%
Benchmark 2 (2455 runs): arocc-branch stb_image.h -E
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          4.06ms ±  187us    3.76ms … 5.32ms        212 ( 9%)        ⚡-  5.4% ±  0.3%
  peak_rss           5.99MB ±  129KB    5.20MB … 6.05MB        590 (24%)          +  0.1% ±  0.1%
  cpu_cycles         18.6M  ±  316K     18.1M  … 20.4M          91 ( 4%)        ⚡-  5.5% ±  0.1%
  instructions       52.9M  ± 7.89      52.9M  … 52.9M           0 ( 0%)        ⚡-  8.3% ±  0.0%
  cache_references    769K  ± 17.2K      730K  …  899K          94 ( 4%)          -  0.1% ±  0.1%
  cache_misses       24.3K  ± 4.30K     20.1K  … 50.0K          26 ( 1%)          -  1.7% ±  1.0%
  branch_misses       236K  ± 4.10K      222K  …  253K          39 ( 2%)          -  0.4% ±  0.1%
```