### PR TITLE
Fix fuzzer

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -185,6 +185,16 @@ pub const InitOptions = struct {
         .environ_map = null,
         .add_default_pragma_handlers = false,
     };
+
+    var fuzzing_diagnostics: Diagnostics = .{ .output = .ignore };
+    pub const fuzzing: InitOptions = .{
+        .gpa = std.testing.allocator,
+        .arena = undefined,
+        .io = std.Io.failing,
+        .diagnostics = &fuzzing_diagnostics,
+        .environ_map = null,
+        .add_default_pragma_handlers = false,
+    };
 };
 
 /// Initialize Compilation with default environment,

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -2381,7 +2381,11 @@ test "Universal character names" {
 test "Tokenizer fuzz test" {
     const Context = struct {
         fn testOne(_: @This(), smith: *std.testing.Smith) anyerror!void {
-            var comp = try Compilation.init(.testing);
+            const Diagnostics = @import("Diagnostics.zig");
+            var diagnostics: Diagnostics = .{ .output = .ignore };
+            var options = Compilation.InitOptions.testing;
+            options.diagnostics = &diagnostics;
+            var comp = try Compilation.init(options);
             defer comp.deinit();
 
             var buf: [256]u8 = undefined;

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -2402,11 +2402,7 @@ test "Universal character names" {
 test "Tokenizer fuzz test" {
     const Context = struct {
         fn testOne(_: @This(), smith: *std.testing.Smith) anyerror!void {
-            const Diagnostics = @import("Diagnostics.zig");
-            var diagnostics: Diagnostics = .{ .output = .ignore };
-            var options = Compilation.InitOptions.testing;
-            options.diagnostics = &diagnostics;
-            var comp = try Compilation.init(options);
+            var comp = try Compilation.init(.fuzzing);
             defer comp.deinit();
 
             var buf: [256]u8 = undefined;

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -1473,6 +1473,13 @@ pub fn next(self: *Tokenizer) Token {
                 '\r', '\n' => {
                     id = .unterminated_char_literal;
                 },
+                0 => {
+                    if (self.index == self.buf.len) {
+                        id = .unterminated_char_literal;
+                    } else {
+                        continue :loop .char_literal;
+                    }
+                },
                 else => continue :loop .char_literal,
             }
         },
@@ -1481,6 +1488,13 @@ pub fn next(self: *Tokenizer) Token {
             switch (self.buf[self.index]) {
                 '\r', '\n' => {
                     id = .unterminated_string_literal;
+                },
+                0 => {
+                    if (self.index == self.buf.len) {
+                        id = .unterminated_string_literal;
+                    } else {
+                        continue :loop .string_literal;
+                    }
                 },
                 else => continue :loop .string_literal,
             }
@@ -1989,6 +2003,13 @@ pub fn nextNoWSComments(self: *Tokenizer) Token {
     var tok = self.next();
     while (tok.id == .whitespace) tok = self.next();
     return tok;
+}
+
+test "escaped literals at eof or with embedded NUL byte" {
+    try expectTokens("'\\", &.{.unterminated_char_literal});
+    try expectTokens("\"\\", &.{.unterminated_string_literal});
+    try expectTokens("'\\\x00", &.{.unterminated_char_literal});
+    try expectTokens("\"\\\x00", &.{.unterminated_string_literal});
 }
 
 test "operators" {


### PR DESCRIPTION
Fixing the fuzzer actually uncovered an error in the Tokenizer - if this change looks good I can go back and update the Preprocessor parser test and see if it finds anything.