### PR TITLE
Typestore: preserve alignment through typedefs in MSVC

### DIFF
--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -1274,12 +1274,19 @@ pub const QualType = packed struct(u32) {
 
     pub fn requestedAlignment(qt: QualType, comp: *const Compilation) ?u32 {
         if (qt.isInvalid()) return null;
-        if (comp.type_store.requested_aligns.get(qt)) |alignment| return alignment;
-        loop: switch (qt.type(comp)) {
-            .typeof => |typeof| continue :loop typeof.base.type(comp),
-            .typedef => |typedef| return typedef.base.requestedAlignment(comp),
-            else => return null,
-        }
+        const own_alignment = comp.type_store.requested_aligns.get(qt);
+        const base_alignment = switch (qt.type(comp)) {
+            .typeof => |typeof| typeof.base.requestedAlignment(comp),
+            .typedef => |typedef| typedef.base.requestedAlignment(comp),
+            else => null,
+        };
+        return if (own_alignment) |own|
+            if (comp.langopts.emulate == .msvc and base_alignment != null)
+                @max(own, base_alignment.?)
+            else
+                own
+        else
+            base_alignment;
     }
 
     pub fn shouldDesugar(qt: QualType, comp: *const Compilation) bool {

--- a/test/cases/msvc typedef alignment inheritance clang.c
+++ b/test/cases/msvc typedef alignment inheritance clang.c
@@ -1,0 +1,15 @@
+__declspec(align(16)) typedef char OverAligned;
+__declspec(align(4)) typedef OverAligned UnderAligned;
+
+struct S {
+    char x;
+    UnderAligned y;
+};
+
+_Static_assert(_Alignof(struct S) == 4, "");
+_Static_assert(sizeof(struct S) == 8, "");
+
+/** manifest:
+syntax
+args = -target aarch64-windows-msvc --emulate=clang -fms-extensions
+*/

--- a/test/cases/msvc typedef alignment inheritance.c
+++ b/test/cases/msvc typedef alignment inheritance.c
@@ -1,0 +1,15 @@
+__declspec(align(16)) typedef char OverAligned;
+__declspec(align(4)) typedef OverAligned UnderAligned;
+
+struct S {
+    char x;
+    UnderAligned y;
+};
+
+_Static_assert(_Alignof(struct S) == 16, "");
+_Static_assert(sizeof(struct S) == 32, "");
+
+/** manifest:
+syntax
+args = -target aarch64-windows-msvc
+*/

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -430,14 +430,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
-            "aarch64-generic-windows-msvc:Msvc|0046",
-            .{ .parse = false, .layout = false, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0046",
-            .{ .parse = false, .layout = false, .extra = true, .offset = false },
-        },
-        .{
             "avr-avr2-other-eabi:Gcc|0062",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },


### PR DESCRIPTION
Preserve the maximum requested alignment across typedef layers

This matches MSVC: https://godbolt.org/z/4zsEbEEaM
Clang does not get this right: https://godbolt.org/z/6M43M19zM