### PR TITLE
Add AVR int24 support

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -1235,6 +1235,13 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
     try comp.generateIntMaxAndWidth(w, "INT", .int);
     try comp.generateIntMaxAndWidth(w, "LONG", .long);
     try comp.generateIntMaxAndWidth(w, "LONG_LONG", .long_long);
+    if (comp.langopts.has_int24) {
+        const suffix = if (Type.Int.int.bits(comp) == 8) "LL" else "L";
+        const unsigned_suffix = if (Type.Int.int.bits(comp) == 8) "ULL" else "UL";
+        try w.print("#define __INT24_MAX__ 8388607{s}\n", .{suffix});
+        try w.writeAll("#define __INT24_MIN__ (-__INT24_MAX__-1)\n");
+        try w.print("#define __UINT24_MAX__ 16777215{s}\n", .{unsigned_suffix});
+    }
     try comp.generateIntMaxAndWidth(w, "WCHAR", comp.type_store.wchar);
     try comp.generateIntMaxAndWidth(w, "WINT", comp.type_store.wint);
     try comp.generateIntMaxAndWidth(w, "INTMAX", comp.type_store.intmax);
@@ -1505,6 +1512,9 @@ pub fn smallestNBitIntTargetIndependent(comp: *const Compilation, bits: usize, s
 
 /// Lowest-rank integer type with at least N bits; subject to platform idiosyncrasies
 pub fn intLeastN(comp: *const Compilation, bits: usize, signedness: std.builtin.Signedness) QualType {
+    if (bits <= 24 and bits > Type.Int.int.bits(comp) and comp.langopts.has_int24) {
+        return if (signedness == .signed) .int24 else .uint24;
+    }
     if (bits == 64 and (comp.target.os.tag.isDarwin() or comp.target.cpu.arch.isWasm())) {
         // WebAssembly and Darwin use `long long` for `int_least64_t` and `int_fast64_t`.
         return if (signedness == .signed) .long_long else .ulong_long;
@@ -1726,10 +1736,12 @@ fn generateSizeofType(comp: *Compilation, w: *Io.Writer, name: []const u8, qt: Q
 
 pub fn nextLargestIntSameSign(comp: *const Compilation, qt: QualType) ?QualType {
     assert(qt.isInt(comp));
-    const candidates: [4]QualType = if (qt.signedness(comp) == .signed)
-        .{ .short, .int, .long, .long_long }
+    const candidates: []const QualType = if (qt.signedness(comp) == .signed)
+        if (comp.langopts.has_int24) &.{ .short, .int, .int24, .long, .long_long } else &.{ .short, .int, .long, .long_long }
+    else if (comp.langopts.has_int24)
+        &.{ .ushort, .uint, .uint24, .ulong, .ulong_long }
     else
-        .{ .ushort, .uint, .ulong, .ulong_long };
+        &.{ .ushort, .uint, .ulong, .ulong_long };
 
     const size = qt.sizeof(comp);
     for (candidates) |candidate| {

--- a/src/aro/LangOpts.zig
+++ b/src/aro/LangOpts.zig
@@ -184,6 +184,8 @@ blocks: bool = false,
 
 /// If non-null, contains ARM LDREX/STREX mask. Only populated on ARM targets.
 arm_ldrex: ?ArmLdrex = null,
+/// Whether the target supports AVR's non-standard 24-bit integer types.
+has_int24: bool = false,
 
 pthread: bool = false,
 
@@ -227,6 +229,7 @@ pub fn allowFixedSizedIntSuffixes(self: *const LangOpts) bool {
 
 pub fn setTargetOptions(self: *LangOpts, target: Target) void {
     // TODO: Move more stuff here :)
+    self.has_int24 = target.cpu.arch == .avr;
     switch (target.cpu.arch) {
         .arm, .armeb, .thumb, .thumbeb => {
             {

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1135,8 +1135,8 @@ pub fn parse(pp: *Preprocessor) Compilation.Error!Tree {
         try p.addImplicitTypedef("__int128_t", .int128);
         try p.addImplicitTypedef("__uint128_t", .uint128);
         if (p.comp.langopts.has_int24) {
-            try p.addImplicitTypedef("__int24_t", .int24);
-            try p.addImplicitTypedef("__uint24_t", .uint24);
+            try p.addImplicitTypedef("__int24", .int24);
+            try p.addImplicitTypedef("__uint24", .uint24);
         }
 
         try p.addImplicitTypedef("__builtin_ms_va_list", .char_pointer);

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1134,6 +1134,10 @@ pub fn parse(pp: *Preprocessor) Compilation.Error!Tree {
         }
         try p.addImplicitTypedef("__int128_t", .int128);
         try p.addImplicitTypedef("__uint128_t", .uint128);
+        if (p.comp.langopts.has_int24) {
+            try p.addImplicitTypedef("__int24_t", .int24);
+            try p.addImplicitTypedef("__uint24_t", .uint24);
+        }
 
         try p.addImplicitTypedef("__builtin_ms_va_list", .char_pointer);
 
@@ -2604,6 +2608,8 @@ fn typeSpec(p: *Parser, builder: *TypeStore.Builder) Error!bool {
             => |tok_id| try builder.combine(exactTypeKeywordToSpecMSVC(tok_id), p.tok_i),
 
             .keyword_int128 => try builder.combine(.int128, p.tok_i),
+            .keyword_int24 => try builder.combine(.int24, p.tok_i),
+            .keyword_uint24 => try builder.combine(.uint24, p.tok_i),
             .keyword_signed, .keyword_signed1, .keyword_signed2 => try builder.combine(.signed, p.tok_i),
             .keyword_unsigned => try builder.combine(.unsigned, p.tok_i),
             .keyword_fp16 => try builder.combine(.fp16, p.tok_i),
@@ -3613,6 +3619,9 @@ const Enumerator = struct {
                 return .int;
             }
             const long_width = Type.Int.long.bits(p.comp);
+            if (e.num_negative_bits == 24 and e.num_positive_bits < 24 and p.comp.langopts.has_int24) {
+                return .int24;
+            }
             if (e.num_negative_bits <= long_width and e.num_positive_bits < long_width) {
                 return .long;
             }
@@ -3628,6 +3637,8 @@ const Enumerator = struct {
             return .ushort;
         } else if (e.num_positive_bits <= int_width) {
             return .uint;
+        } else if (e.num_positive_bits == 24 and p.comp.langopts.has_int24) {
+            return .uint24;
         } else if (e.num_positive_bits <= Type.Int.long.bits(p.comp)) {
             return .ulong;
         }

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -1135,7 +1135,7 @@ pub fn parse(pp: *Preprocessor) Compilation.Error!Tree {
         try p.addImplicitTypedef("__int128_t", .int128);
         try p.addImplicitTypedef("__uint128_t", .uint128);
         if (p.comp.langopts.has_int24) {
-            try p.addImplicitTypedef("__int24", .int24);
+            try p.addImplicitTypedef("__int24__", .int24);
             try p.addImplicitTypedef("__uint24", .uint24);
         }
 

--- a/src/aro/Parser.zig
+++ b/src/aro/Parser.zig
@@ -2609,7 +2609,6 @@ fn typeSpec(p: *Parser, builder: *TypeStore.Builder) Error!bool {
 
             .keyword_int128 => try builder.combine(.int128, p.tok_i),
             .keyword_int24 => try builder.combine(.int24, p.tok_i),
-            .keyword_uint24 => try builder.combine(.uint24, p.tok_i),
             .keyword_signed, .keyword_signed1, .keyword_signed2 => try builder.combine(.signed, p.tok_i),
             .keyword_unsigned => try builder.combine(.unsigned, p.tok_i),
             .keyword_fp16 => try builder.combine(.fp16, p.tok_i),

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -285,6 +285,8 @@ pub const Token = struct {
         keyword_thread,
         /// __float128
         keyword_float128_1,
+        keyword_int24,
+        keyword_uint24,
         keyword_int128,
         keyword_imag1,
         keyword_imag2,
@@ -459,6 +461,8 @@ pub const Token = struct {
                 .keyword_asm1,
                 .keyword_asm2,
                 .keyword_float128_1,
+                .keyword_int24,
+                .keyword_uint24,
                 .keyword_int128,
                 .keyword_imag1,
                 .keyword_imag2,
@@ -766,6 +770,8 @@ pub const Token = struct {
                 .keyword_asm1 => "__asm",
                 .keyword_asm2 => "__asm__",
                 .keyword_float128_1 => "__float128",
+                .keyword_int24 => "__int24",
+                .keyword_uint24 => "__uint24",
                 .keyword_int128 => "__int128",
                 .keyword_imag1 => "__imag",
                 .keyword_imag2 => "__imag__",
@@ -921,6 +927,8 @@ pub const Token = struct {
             .keyword_typeof => if (standard.isGNU() or standard.atLeast(.c23)) kw else .identifier,
             .keyword_asm => if (standard.isGNU()) kw else .identifier,
             .keyword_declspec => if (langopts.declspec_attrs) kw else .identifier,
+
+            .keyword_int24, .keyword_uint24 => if (langopts.has_int24) kw else .identifier,
 
             .keyword_c23_alignas,
             .keyword_c23_alignof,
@@ -1093,6 +1101,8 @@ pub const Token = struct {
         .{ "__asm", .keyword_asm1 },
         .{ "__asm__", .keyword_asm2 },
         .{ "__float128", .keyword_float128_1 },
+        .{ "__int24", .keyword_int24 },
+        .{ "__uint24", .keyword_uint24 },
         .{ "__int128", .keyword_int128 },
         .{ "__imag", .keyword_imag1 },
         .{ "__imag__", .keyword_imag2 },
@@ -2359,6 +2369,11 @@ test "C23 keywords" {
         .keyword_nullptr,
         .keyword_typeof_unqual,
     }, .{ .standard = .c23 });
+}
+
+test "GCC integer keywords" {
+    try expectTokens("__int24 __uint24", &.{ .identifier, .identifier });
+    try expectTokensExtra("__int24 __uint24", &.{ .keyword_int24, .keyword_uint24 }, .{ .has_int24 = true });
 }
 
 test "Universal character names" {

--- a/src/aro/Tokenizer.zig
+++ b/src/aro/Tokenizer.zig
@@ -286,7 +286,6 @@ pub const Token = struct {
         /// __float128
         keyword_float128_1,
         keyword_int24,
-        keyword_uint24,
         keyword_int128,
         keyword_imag1,
         keyword_imag2,
@@ -462,7 +461,6 @@ pub const Token = struct {
                 .keyword_asm2,
                 .keyword_float128_1,
                 .keyword_int24,
-                .keyword_uint24,
                 .keyword_int128,
                 .keyword_imag1,
                 .keyword_imag2,
@@ -771,7 +769,6 @@ pub const Token = struct {
                 .keyword_asm2 => "__asm__",
                 .keyword_float128_1 => "__float128",
                 .keyword_int24 => "__int24",
-                .keyword_uint24 => "__uint24",
                 .keyword_int128 => "__int128",
                 .keyword_imag1 => "__imag",
                 .keyword_imag2 => "__imag__",
@@ -928,7 +925,7 @@ pub const Token = struct {
             .keyword_asm => if (standard.isGNU()) kw else .identifier,
             .keyword_declspec => if (langopts.declspec_attrs) kw else .identifier,
 
-            .keyword_int24, .keyword_uint24 => if (langopts.has_int24) kw else .identifier,
+            .keyword_int24 => if (langopts.has_int24) kw else .identifier,
 
             .keyword_c23_alignas,
             .keyword_c23_alignof,
@@ -1102,7 +1099,6 @@ pub const Token = struct {
         .{ "__asm__", .keyword_asm2 },
         .{ "__float128", .keyword_float128_1 },
         .{ "__int24", .keyword_int24 },
-        .{ "__uint24", .keyword_uint24 },
         .{ "__int128", .keyword_int128 },
         .{ "__imag", .keyword_imag1 },
         .{ "__imag__", .keyword_imag2 },
@@ -2372,8 +2368,8 @@ test "C23 keywords" {
 }
 
 test "GCC integer keywords" {
-    try expectTokens("__int24 __uint24", &.{ .identifier, .identifier });
-    try expectTokensExtra("__int24 __uint24", &.{ .keyword_int24, .keyword_uint24 }, .{ .has_int24 = true });
+    try expectTokens("__int24", &.{.identifier});
+    try expectTokensExtra("__int24", &.{.keyword_int24}, .{ .has_int24 = true });
 }
 
 test "Universal character names" {

--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -119,6 +119,8 @@ const Index = enum(u29) {
     float_dfloat128 = std.math.maxInt(u29) - 37,
     float_dfloat64x = std.math.maxInt(u29) - 38,
     mfp8 = std.math.maxInt(u29) - 39,
+    int_int24 = std.math.maxInt(u29) - 40,
+    int_uint24 = std.math.maxInt(u29) - 41,
     _,
 };
 
@@ -150,6 +152,8 @@ pub const QualType = packed struct(u32) {
     pub const ulong_long: QualType = .{ ._index = .int_ulong_long };
     pub const int128: QualType = .{ ._index = .int_int128 };
     pub const uint128: QualType = .{ ._index = .int_uint128 };
+    pub const int24: QualType = .{ ._index = .int_int24 };
+    pub const uint24: QualType = .{ ._index = .int_uint24 };
     pub const bf16: QualType = .{ ._index = .float_bf16 };
     pub const fp16: QualType = .{ ._index = .float_fp16 };
     pub const float16: QualType = .{ ._index = .float_float16 };
@@ -226,6 +230,8 @@ pub const QualType = packed struct(u32) {
             .int_ulong_long => return .{ .int = .ulong_long },
             .int_int128 => return .{ .int = .int128 },
             .int_uint128 => return .{ .int = .uint128 },
+            .int_int24 => return .{ .int = .int24 },
+            .int_uint24 => return .{ .int = .uint24 },
             .float_bf16 => return .{ .float = .bf16 },
             .float_fp16 => return .{ .float = .fp16 },
             .float_float16 => return .{ .float = .float16 },
@@ -684,8 +690,8 @@ pub const QualType = packed struct(u32) {
             .bit_int => |bit_int| bit_int.signedness,
             .int => |int_ty| switch (int_ty) {
                 .char => comp.getCharSignedness(),
-                .schar, .short, .int, .long, .long_long, .int128 => .signed,
-                .uchar, .ushort, .uint, .ulong, .ulong_long, .uint128 => .unsigned,
+                .schar, .short, .int, .int24, .long, .long_long, .int128 => .signed,
+                .uchar, .ushort, .uint, .uint24, .ulong, .ulong_long, .uint128 => .unsigned,
             },
             // Pointer values are signed.
             .pointer, .nullptr_t, .block => .signed,
@@ -731,6 +737,7 @@ pub const QualType = packed struct(u32) {
                 .ulong => comp.target.cTypeAlignment(.ulong),
                 .long_long => comp.target.cTypeAlignment(.longlong),
                 .ulong_long => comp.target.cTypeAlignment(.ulonglong),
+                .int24, .uint24 => 1,
                 .int128, .uint128 => if (comp.target.cpu.arch == .s390x and comp.target.os.tag == .linux and comp.target.abi.isGnu()) 8 else 16,
             },
             .float => |float_ty| switch (float_ty) {
@@ -839,6 +846,8 @@ pub const QualType = packed struct(u32) {
                 .ulong_long => return .ulong_long,
                 .int128 => return .uint128,
                 .uint128 => return .uint128,
+                .int24 => return .uint24,
+                .uint24 => return .uint24,
             },
             .bit_int => |bit_int| {
                 return try comp.type_store.put(comp.gpa, .{ .bit_int = .{
@@ -946,9 +955,10 @@ pub const QualType = packed struct(u32) {
                 .char, .schar, .uchar => 2 + (int_ty.bits(comp) * 8),
                 .short, .ushort => 3 + (int_ty.bits(comp) * 8),
                 .int, .uint => 4 + (int_ty.bits(comp) * 8),
-                .long, .ulong => 5 + (int_ty.bits(comp) * 8),
-                .long_long, .ulong_long => 6 + (int_ty.bits(comp) * 8),
-                .int128, .uint128 => 7 + (int_ty.bits(comp) * 8),
+                .int24, .uint24 => 5 + (int_ty.bits(comp) * 8),
+                .long, .ulong => 6 + (int_ty.bits(comp) * 8),
+                .long_long, .ulong_long => 7 + (int_ty.bits(comp) * 8),
+                .int128, .uint128 => 8 + (int_ty.bits(comp) * 8),
             },
             .complex => |complex| continue :loop complex.base(comp).type,
             .atomic => |atomic| continue :loop atomic.base(comp).type,
@@ -1456,6 +1466,8 @@ pub const QualType = packed struct(u32) {
                 .ulong_long => try w.writeAll("unsigned long long"),
                 .int128 => try w.writeAll("__int128"),
                 .uint128 => try w.writeAll("unsigned __int128"),
+                .int24 => try w.writeAll("__int24"),
+                .uint24 => try w.writeAll("__uint24"),
             },
             .bit_int => |bit_int| try w.print("{t} _BitInt({d})", .{ bit_int.signedness, bit_int.bits }),
             .float => |float_ty| switch (float_ty) {
@@ -1713,6 +1725,8 @@ pub const Type = union(enum) {
         ulong_long,
         int128,
         uint128,
+        int24,
+        uint24,
 
         pub fn bits(int: Int, comp: *const Compilation) u16 {
             return switch (int) {
@@ -1729,6 +1743,7 @@ pub const Type = union(enum) {
                 .ulong_long => comp.target.cTypeBitSize(.ulonglong),
                 .int128 => 128,
                 .uint128 => 128,
+                .int24, .uint24 => 24,
             };
         }
     };
@@ -2109,6 +2124,8 @@ pub fn putExtra(ts: *TypeStore, gpa: std.mem.Allocator, ty: Type) !Index {
             .ulong_long => return .int_ulong_long,
             .int128 => return .int_int128,
             .uint128 => return .int_uint128,
+            .int24 => return .int_int24,
+            .uint24 => return .int_uint24,
         },
         .float => |float| switch (float) {
             .bf16 => return .float_bf16,
@@ -2738,6 +2755,9 @@ pub const Builder = struct {
         int128,
         sint128,
         uint128,
+        int24,
+        sint24,
+        uint24,
         complex_unsigned,
         complex_signed,
         complex_short,
@@ -2764,6 +2784,9 @@ pub const Builder = struct {
         complex_int128,
         complex_sint128,
         complex_uint128,
+        complex_int24,
+        complex_sint24,
+        complex_uint24,
         bit_int: u64,
         sbit_int: u64,
         ubit_int: u64,
@@ -2840,6 +2863,9 @@ pub const Builder = struct {
                 .int128 => "__int128",
                 .sint128 => "signed __int128",
                 .uint128 => "unsigned __int128",
+                .int24 => "__int24",
+                .sint24 => "signed __int24",
+                .uint24 => "__uint24",
                 .complex_char => "_Complex char",
                 .complex_schar => "_Complex signed char",
                 .complex_uchar => "_Complex unsigned char",
@@ -2869,6 +2895,9 @@ pub const Builder = struct {
                 .complex_int128 => "_Complex __int128",
                 .complex_sint128 => "_Complex signed __int128",
                 .complex_uint128 => "_Complex unsigned __int128",
+                .complex_int24 => "_Complex __int24",
+                .complex_sint24 => "_Complex signed __int24",
+                .complex_uint24 => "_Complex __uint24",
 
                 .bf16 => "__bf16",
                 .fp16 => "__fp16",
@@ -2921,6 +2950,8 @@ pub const Builder = struct {
             .ulong_long, .ulong_long_int => .ulong_long,
             .int128, .sint128 => .int128,
             .uint128 => .uint128,
+            .int24, .sint24 => .int24,
+            .uint24 => .uint24,
 
             .complex_char,
             .complex_schar,
@@ -2951,6 +2982,9 @@ pub const Builder = struct {
             .complex_int128,
             .complex_sint128,
             .complex_uint128,
+            .complex_int24,
+            .complex_sint24,
+            .complex_uint24,
             => blk: {
                 const base_qt: QualType = switch (b.type) {
                     .complex_char => .char,
@@ -2968,6 +3002,8 @@ pub const Builder = struct {
                     .complex_ulong_long, .complex_ulong_long_int => .ulong_long,
                     .complex_int128, .complex_sint128 => .int128,
                     .complex_uint128 => .uint128,
+                    .complex_int24, .complex_sint24 => .int24,
+                    .complex_uint24 => .uint24,
                     else => unreachable,
                 };
                 if (b.complex_tok) |tok| try b.parser.err(tok, .complex_int, .{});
@@ -3211,6 +3247,7 @@ pub const Builder = struct {
                 .long_long => .slong_long,
                 .long_long_int => .slong_long_int,
                 .int128 => .sint128,
+                .int24 => .sint24,
                 .bit_int => |bits| .{ .sbit_int = bits },
                 .complex => .complex_signed,
                 .complex_char => .complex_schar,
@@ -3222,6 +3259,7 @@ pub const Builder = struct {
                 .complex_long_long => .complex_slong_long,
                 .complex_long_long_int => .complex_slong_long_int,
                 .complex_int128 => .sint128,
+                .complex_int24 => .complex_sint24,
                 .complex_bit_int => |bits| .{ .complex_sbit_int = bits },
                 .signed,
                 .sshort,
@@ -3232,6 +3270,7 @@ pub const Builder = struct {
                 .slong_long,
                 .slong_long_int,
                 .sint128,
+                .sint24,
                 .sbit_int,
                 .complex_schar,
                 .complex_signed,
@@ -3243,6 +3282,7 @@ pub const Builder = struct {
                 .complex_slong_long,
                 .complex_slong_long_int,
                 .complex_sint128,
+                .complex_sint24,
                 .complex_sbit_int,
                 => return b.duplicateSpec(source_tok, "signed"),
                 else => return b.cannotCombine(source_tok),
@@ -3258,6 +3298,7 @@ pub const Builder = struct {
                 .long_long => .ulong_long,
                 .long_long_int => .ulong_long_int,
                 .int128 => .uint128,
+                .int24 => .uint24,
                 .bit_int => |bits| .{ .ubit_int = bits },
                 .complex => .complex_unsigned,
                 .complex_char => .complex_uchar,
@@ -3269,6 +3310,7 @@ pub const Builder = struct {
                 .complex_long_long => .complex_ulong_long,
                 .complex_long_long_int => .complex_ulong_long_int,
                 .complex_int128 => .complex_uint128,
+                .complex_int24 => .complex_uint24,
                 .complex_bit_int => |bits| .{ .complex_ubit_int = bits },
                 .unsigned,
                 .ushort,
@@ -3279,6 +3321,7 @@ pub const Builder = struct {
                 .ulong_long,
                 .ulong_long_int,
                 .uint128,
+                .uint24,
                 .ubit_int,
                 .complex_uchar,
                 .complex_unsigned,
@@ -3290,6 +3333,7 @@ pub const Builder = struct {
                 .complex_ulong_long,
                 .complex_ulong_long_int,
                 .complex_uint128,
+                .complex_uint24,
                 .complex_ubit_int,
                 => return b.duplicateSpec(source_tok, "unsigned"),
                 else => return b.cannotCombine(source_tok),
@@ -3396,6 +3440,15 @@ pub const Builder = struct {
                 .complex => .complex_int128,
                 .complex_signed => .complex_sint128,
                 .complex_unsigned => .complex_uint128,
+                else => return b.cannotCombine(source_tok),
+            },
+            .int24 => switch (b.type) {
+                .none => .int24,
+                .unsigned => .uint24,
+                .signed => .sint24,
+                .complex => .complex_int24,
+                .complex_signed => .complex_sint24,
+                .complex_unsigned => .complex_uint24,
                 else => return b.cannotCombine(source_tok),
             },
             .bit_int => switch (b.type) {
@@ -3527,6 +3580,9 @@ pub const Builder = struct {
                 .int128 => .complex_int128,
                 .sint128 => .complex_sint128,
                 .uint128 => .complex_uint128,
+                .int24 => .complex_int24,
+                .sint24 => .complex_sint24,
+                .uint24 => .complex_uint24,
                 .bit_int => |bits| .{ .complex_bit_int = bits },
                 .sbit_int => |bits| .{ .complex_sbit_int = bits },
                 .ubit_int => |bits| .{ .complex_ubit_int = bits },
@@ -3564,6 +3620,9 @@ pub const Builder = struct {
                 .complex_int128,
                 .complex_sint128,
                 .complex_uint128,
+                .complex_int24,
+                .complex_sint24,
+                .complex_uint24,
                 .complex_bit_int,
                 .complex_sbit_int,
                 .complex_ubit_int,
@@ -3597,6 +3656,8 @@ pub const Builder = struct {
                 .ulong_long => .ulong_long,
                 .int128 => .int128,
                 .uint128 => .uint128,
+                .int24 => .int24,
+                .uint24 => .uint24,
             },
             .bit_int => |bit_int| if (bit_int.signedness == .unsigned) {
                 return .{ .ubit_int = bit_int.bits };
@@ -3639,6 +3700,8 @@ pub const Builder = struct {
                     .ulong_long => .complex_ulong_long,
                     .int128 => .complex_int128,
                     .uint128 => .complex_uint128,
+                    .int24 => .complex_int24,
+                    .uint24 => .complex_uint24,
                 },
                 .bit_int => |bit_int| if (bit_int.signedness == .unsigned) {
                     return .{ .complex_ubit_int = bit_int.bits };

--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -587,7 +587,7 @@ pub const QualType = packed struct(u32) {
             .storage_float => |storage_float| storage_float.bits() / 8,
             .int => |int_ty| int_ty.bits(comp) / 8,
             .float => |float_ty| float_ty.bits(comp) / 8,
-            .complex => |complex| complex.sizeofOrNull(comp),
+            .complex => |complex| (complex.sizeofOrNull(comp) orelse return null) * 2,
             .bit_int => |bit_int| {
                 const base_qt = qt.base(comp).qt;
                 return std.mem.alignForward(u64, (@as(u32, bit_int.bits) + 7) / 8, base_qt.alignof(comp));

--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -1467,7 +1467,7 @@ pub const QualType = packed struct(u32) {
                 .int128 => try w.writeAll("__int128"),
                 .uint128 => try w.writeAll("unsigned __int128"),
                 .int24 => try w.writeAll("__int24"),
-                .uint24 => try w.writeAll("__uint24"),
+                .uint24 => try w.writeAll("unsigned __int24"),
             },
             .bit_int => |bit_int| try w.print("{t} _BitInt({d})", .{ bit_int.signedness, bit_int.bits }),
             .float => |float_ty| switch (float_ty) {
@@ -2865,7 +2865,7 @@ pub const Builder = struct {
                 .uint128 => "unsigned __int128",
                 .int24 => "__int24",
                 .sint24 => "signed __int24",
-                .uint24 => "__uint24",
+                .uint24 => "unsigned __int24",
                 .complex_char => "_Complex char",
                 .complex_schar => "_Complex signed char",
                 .complex_uchar => "_Complex unsigned char",
@@ -2897,7 +2897,7 @@ pub const Builder = struct {
                 .complex_uint128 => "_Complex unsigned __int128",
                 .complex_int24 => "_Complex __int24",
                 .complex_sint24 => "_Complex signed __int24",
-                .complex_uint24 => "_Complex __uint24",
+                .complex_uint24 => "_Complex unsigned __int24",
 
                 .bf16 => "__bf16",
                 .fp16 => "__fp16",

--- a/test/cases/avr 24-bit int.c
+++ b/test/cases/avr 24-bit int.c
@@ -1,0 +1,20 @@
+_Static_assert(sizeof(__int24) == 3, "");
+_Static_assert(sizeof(__uint24) == 3, "");
+_Static_assert(_Generic((__int24)0 + 0, __int24: 1, default: 0), "");
+_Static_assert(_Generic((__uint24)0 + 0, __uint24: 1, default: 0), "");
+_Static_assert(_Generic((signed __int24)0, __int24: 1, default: 0), "");
+_Static_assert(_Generic((unsigned __int24)0, __uint24: 1, default: 0), "");
+
+_Static_assert(__INT24_MAX__ == 8388607L, "");
+_Static_assert(__INT24_MIN__ == -8388608L, "");
+_Static_assert(__UINT24_MAX__ == 16777215UL, "");
+
+typedef enum {
+    F121 = 8388608,
+} __attribute__((packed)) A028;
+_Static_assert(sizeof(A028) == 3, "");
+
+/** manifest:
+syntax
+args = --target=avr-freestanding-none
+*/

--- a/test/cases/avr 24-bit int.c
+++ b/test/cases/avr 24-bit int.c
@@ -14,6 +14,8 @@ typedef enum {
 } __attribute__((packed)) A028;
 _Static_assert(sizeof(A028) == 3, "");
 
+_Static_assert(sizeof(_Complex __int24) == 6, "");
+
 /** manifest:
 syntax
 args = --target=avr-freestanding-none

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -338,10 +338,6 @@ const compErr = blk: {
     @setEvalBranchQuota(100_000);
     break :blk std.StaticStringMap(ExpectedFailure).initComptime(&[_]struct { []const u8, ExpectedFailure }{
         .{
-            "avr-avr2-other-eabi:Gcc|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86_64-x86_64-windows-gnu:Gcc|0068",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },


### PR DESCRIPTION
When adding a _Complex __int24 test I noticed that our `sizeof` for `_Complex` types was wrong!

Fixes #1089