### PR TITLE
Compilation: Refactor to improve MIPS and ARM defines

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -717,7 +717,7 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
                     try w.writeAll("#define _MIPS_ISA _MIPS_ISA_MIPS64\n");
                 },
             }
-            if (target.mipsCpuName()) |name| {
+            if (target.cpu.model.llvm_name) |name| {
                 try w.print("#define _MIPS_ARCH \"{s}\"\n", .{name});
                 var buf: [16]u8 = undefined;
                 const upper = std.ascii.upperString(&buf, name);
@@ -821,6 +821,11 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
             try define(w, "__arm__");
             try define(w, "__arm");
             try define(w, "__ARM_32BIT_STATE");
+            try define(w, "__APCS_32__");
+            try define(w, "__VFP_FP__");
+            try define(w, "__ARM_FP16_ARGS");
+            try define(w, "__ARM_FP16_FORMAT_IEEE");
+
             try w.writeAll("#define __ARM_ACLE 200\n");
 
             // see https://clang.llvm.org/doxygen/Basic_2Targets_2ARM_8cpp_source.html
@@ -862,7 +867,7 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
                 try define(w, "__ARM_FEATURE_CLZ");
             }
 
-            if (target.cpu.has(.arm, .dsp)) {
+            if (target.armHasDsp()) {
                 try define(w, "__ARM_FEATURE_DSP");
             }
 
@@ -879,7 +884,7 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
                 sat = true;
             }
 
-            if (target.cpu.has(.arm, .dsp) or sat) {
+            if (target.armHasDsp() or sat) {
                 try define(w, "__ARM_FEATURE_QBIT");
             }
 

--- a/src/aro/Driver.zig
+++ b/src/aro/Driver.zig
@@ -1138,10 +1138,16 @@ fn parseTarget(
                 return d.fatal("unknown CPU feature: '{s}'", .{feature_name});
             }
         }
-    } else if (opt_sub_arch) |sub_arch| {
-        if (sub_arch.toFeature(arch)) |feature| {
-            query.cpu_model = .{ .explicit = &.{ .name = "empty", .llvm_name = null, .features = .empty } };
-            query.cpu_features_add.addFeature(feature);
+    } else if (!arch_is_native) {
+        if (Target.cpuModelForTargetQuadruple(arch, query.os_tag, query.abi, vendor, opt_sub_arch)) |model| {
+            query.cpu_model = .{ .explicit = model };
+        } else if (opt_sub_arch) |sub_arch| {
+            if (sub_arch.toCpuModel(arch)) |model| {
+                query.cpu_model = .{ .explicit = model };
+            } else if (sub_arch.toFeature(arch)) |feature| {
+                query.cpu_model = .{ .explicit = &.{ .name = "empty", .llvm_name = null, .features = .empty } };
+                query.cpu_features_add.addFeature(feature);
+            }
         }
     }
 

--- a/src/aro/Target.zig
+++ b/src/aro/Target.zig
@@ -196,6 +196,36 @@ pub const SubArch = enum {
         }
         return null;
     }
+
+    pub fn toCpuModel(sub: SubArch, arch: Cpu.Arch) ?*const Cpu.Model {
+        if (arch.isArm()) {
+            const cpu = std.Target.arm.cpu;
+            return switch (sub) {
+                .arm_v4t => &cpu.arm7tdmi,
+                .arm_v5 => &cpu.arm10tdmi,
+                .arm_v5te => &cpu.arm1022e,
+                .arm_v6 => &cpu.arm1136jf_s,
+                .arm_v6k => &cpu.mpcore,
+                .arm_v6t2 => &cpu.arm1156t2_s,
+                .arm_v6m => &cpu.cortex_m0,
+                .arm_v7r => &cpu.cortex_r4,
+                .arm_v7m => &cpu.cortex_m3,
+                .arm_v7em => &cpu.cortex_m4,
+                else => null,
+            };
+        } else if (arch.isMIPS32()) {
+            return switch (sub) {
+                .mips_r6 => &std.Target.mips.cpu.mips32r6,
+                else => null,
+            };
+        } else if (arch.isMIPS64()) {
+            return switch (sub) {
+                .mips_r6 => &std.Target.mips.cpu.mips64r6,
+                else => null,
+            };
+        }
+        return null;
+    }
 };
 
 const Target = @This();
@@ -1946,42 +1976,125 @@ pub fn mipsAbi(target: *const Target) MipsAbi {
 
 pub const MipsFpMode = enum { fp32, fp64, fpxx };
 
-/// Returns the CPU name for a MIPS target, if known. For some sub-architectures,
-/// the CPU name is inferred if it is not available from the target's model.
-pub fn mipsCpuName(target: *const Target) ?[]const u8 {
-    // Clang overwrites the CPU name for BSD. See `mips::getMipsCPUAndABI`.
-    switch (target.os.tag) {
-        .freebsd => return if (target.cpu.arch.isMIPS32()) "mips2" else "mips3",
-        .openbsd => if (target.cpu.arch.isMIPS64()) return "mips3",
-        else => {},
-    }
-    if (target.cpu.model.llvm_name) |name| return name;
-    if (target.cpu.arch.isMIPS64() and target.cpu.has(.mips, .mips64r6)) return "mips64r6";
-    if (target.cpu.arch.isMIPS32() and target.cpu.has(.mips, .mips32r6)) return "mips32r6";
-    return null;
-}
-
 /// Returns the default MIPS floating-point mode for the target.
 pub fn defaultMipsFpMode(target: *const Target) MipsFpMode {
-    const cpu = mipsCpuName(target) orelse "";
-    if (std.mem.eql(u8, cpu, "mips32r6") or
+    const cpu = std.Target.mips.cpu;
+    if (target.cpu.model == &cpu.mips32r6 or
         target.mipsAbi() == .n32 or target.mipsAbi() == .n64) return .fp64;
-    if (std.mem.eql(u8, cpu, "mips1")) return .fp32;
+    if (target.cpu.model == &cpu.mips1) return .fp32;
     return .fpxx;
 }
 
-const mips_isa_revs = std.StaticStringMap(u8).initComptime(.{
-    .{ "mips32", 1 },   .{ "mips64", 1 },
-    .{ "mips32r2", 2 }, .{ "mips64r2", 2 },
-    .{ "octeon", 2 },   .{ "octeon+", 2 },
-    .{ "mips32r3", 3 }, .{ "mips64r3", 3 },
-    .{ "mips32r5", 5 }, .{ "mips64r5", 5 },
-    .{ "p5600", 5 },    .{ "mips32r6", 6 },
-    .{ "mips64r6", 6 }, .{ "i6400", 6 },
-    .{ "i6500", 6 },
-});
-
 pub fn mipsIsaRev(target: *const Target) u8 {
-    const cpu = mipsCpuName(target) orelse return 0;
-    return mips_isa_revs.get(cpu) orelse 0;
+    const cpu = std.Target.mips.cpu;
+    const model = target.cpu.model;
+    // clang: MipsTargetInfo::getISARev, clang/lib/Basic/Targets/Mips.cpp
+    if (model == &cpu.mips32 or model == &cpu.mips64) return 1;
+    if (model == &cpu.mips32r2 or model == &cpu.mips64r2 or
+        model == &cpu.octeon or model == &cpu.@"octeon+") return 2;
+    if (model == &cpu.mips32r3 or model == &cpu.mips64r3) return 3;
+    if (model == &cpu.mips32r5 or model == &cpu.mips64r5 or model == &cpu.p5600) return 5;
+    if (model == &cpu.mips32r6 or model == &cpu.mips64r6 or
+        model == &cpu.i6400 or model == &cpu.i6500) return 6;
+    return 0;
+}
+
+/// Returns the CPU model based on arch, os, abi and vendor
+pub fn cpuModelForTargetQuadruple(
+    arch: Cpu.Arch,
+    opt_os_tag: ?Os.Tag,
+    opt_abi: ?Abi,
+    vendor: Vendor,
+    sub_arch: ?SubArch,
+) ?*const Cpu.Model {
+    const os_tag = opt_os_tag orelse builtin.os.tag;
+    const abi = opt_abi orelse builtin.abi;
+
+    switch (arch) {
+        .arm, .armeb, .thumb, .thumbeb => {
+            const cpu = std.Target.arm.cpu;
+
+            if (sub_arch) |sub| {
+                switch (os_tag) {
+                    .freebsd, .netbsd, .openbsd, .haiku => switch (sub) {
+                        .arm_v6 => return &cpu.arm1176jzf_s,
+                        .arm_v7 => return &cpu.cortex_a8,
+                        else => {},
+                    },
+                    // clang: `parseArchVersion(MArch) <= 7`
+                    .windows => switch (sub) {
+                        .arm_v4t,
+                        .arm_v5,
+                        .arm_v5te,
+                        .arm_v6,
+                        .arm_v6k,
+                        .arm_v6m,
+                        .arm_v6t2,
+                        .arm_v7,
+                        .arm_v7a,
+                        .arm_v7r,
+                        .arm_v7em,
+                        .arm_v7k,
+                        .arm_v7m,
+                        .arm_v7s,
+                        .arm_v7ve,
+                        => return &cpu.cortex_a9,
+                        else => {},
+                    },
+                    .ios, .macos, .tvos, .watchos, .driverkit, .visionos => switch (sub) {
+                        .arm_v7k => return &cpu.cortex_a7,
+                        else => {},
+                    },
+                    else => {},
+                }
+                return null;
+            }
+
+            return switch (os_tag) {
+                .windows => &cpu.cortex_a9,
+                .haiku => &cpu.arm1176jzf_s,
+                .netbsd => switch (abi) {
+                    .eabi, .eabihf, .gnueabi, .gnueabihf => &cpu.arm926ej_s,
+                    else => &cpu.strongarm,
+                },
+                .openbsd => &cpu.cortex_a8,
+                .fuchsia => &cpu.cortex_a53,
+                else => switch (abi) {
+                    .eabihf, .gnueabihf, .musleabihf => &cpu.arm1176jzf_s,
+                    else => &cpu.arm7tdmi,
+                },
+            };
+        },
+        .mips, .mipsel, .mips64, .mips64el => {
+            const cpu = std.Target.mips.cpu;
+            const is_64 = arch.isMIPS64();
+
+            // see clang: `mips::getMipsCPUAndABI`,
+            var model: *const Cpu.Model = if (is_64) &cpu.mips64r2 else &cpu.mips32r2;
+
+            if (vendor == .imagination_technologies and abi.isGnu())
+                model = if (is_64) &cpu.mips64r6 else &cpu.mips32r6;
+
+            if (sub_arch == .mips_r6)
+                model = if (is_64) &cpu.mips64r6 else &cpu.mips32r6;
+
+            if (os_tag == .openbsd and is_64)
+                model = &cpu.mips3;
+
+            if (os_tag == .freebsd)
+                model = if (is_64) &cpu.mips3 else &cpu.mips2;
+
+            return model;
+        },
+        else => return null,
+    }
+}
+
+pub fn armHasDsp(target: *const Target) bool {
+    assert(target.cpu.arch.isArm());
+
+    if (target.cpu.has(.arm, .mclass)) return target.cpu.has(.arm, .dsp);
+
+    const v = target.armVersion() orelse return false;
+    return v.version >= 6 or mem.startsWith(u8, v.string, "5TE");
 }


### PR DESCRIPTION
Clang sets the CPU model based on the target triplet/quadruple in some cases. This is true for at least MIPS and ARM. I've added the same behavior to `Driver.zig`, so `Compilation.zig` does not have to find out the right CPU model itself. I also added some more ARM definitions that were missing. And fixed `__ARM_FEATURE_DSP`, which only worked correctly for `.mclass` before. 

This is mostly a BSD and freestanding issue - at least that is where I came across it. I've got a suite of nushell scripts that I use for comparing clang with Aro, and this is what I get if I compare some BSD and freestanding targets:

| group | arch | targets | status | before | after | delta |
| --- | --- | --- | --- | --- | --- | --- |
| bsd | arm | 10 | missing | 110 | 60 | -50 |
| bsd | arm | 10 | differs | 8 | 0 | -8 |
| bsd | mips | 8 | missing | 3 | 3 | 0 |
| bsd | mips | 8 | differs | 0 | 0 | 0 |
| freestanding | arm | 11 | missing | 153 | 108 | -45 |
| freestanding | arm | 11 | differs | 6 | 2 | -4 |
| freestanding | mips | 4 | missing | 0 | 0 | 0 |
| freestanding | mips | 4 | differs | 0 | 0 | 0 |
| TOTAL |  | 33 |  | 280 | 173 | -107 |

This is the list of targets:

* arm-freebsd
* armv6-freebsd
* armv7-freebsd
* armeb-freebsd
* arm-netbsd
* armv6-netbsd
* armv7-netbsd
* arm-openbsd
* armv6-openbsd
* armv7-openbsd
* mips-freebsd
* mipsel-freebsd
* mips64-freebsd
* mips-netbsd
* mipsel-netbsd
* mips64-netbsd
* mips-openbsd
* mips64-openbsd
* arm-freestanding-eabi
* armv6-freestanding-eabi
* armv7-freestanding-eabi
* armv8a-freestanding-eabi
* armeb-freestanding-eabi
* armv6m-freestanding-eabi
* armv7m-freestanding-eabi
* armv7em-freestanding-eabi
* armv8m.base-freestanding-eabi
* armv8m.main-freestanding-eabi
* armv8r-freestanding-eabi
* mips-freestanding-none
* mipsel-freestanding-none
* mips64-freestanding-none
* mips64el-freestanding-none
 