### PR TITLE
Compilation: add target OS macros

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -275,6 +275,11 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
             , .{ name, name });
         }
     }.defineStd;
+    const defineBool = struct {
+        fn defineBool(_w: *Io.Writer, name: []const u8, value: bool) !void {
+            try _w.print("#define {s} {d}\n", .{ name, @intFromBool(value) });
+        }
+    }.defineBool;
     const target = &comp.target;
     const ptr_width = target.ptrBitWidth();
     const is_gnu = comp.langopts.standard.isGNU();
@@ -335,6 +340,68 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
         .emscripten => try define(w, "__EMSCRIPTEN_PTHREADS__"),
         else => {},
     };
+
+    // Target OS macros, transcribed from LLVM TargetOSMacros.def
+    if (comp.langopts.hasTargetOsMacros()) {
+        // Windows
+        try defineBool(w, "TARGET_OS_WIN32", target.os.tag == .windows);
+        try defineBool(w, "TARGET_OS_WINDOWS", target.os.tag == .windows);
+
+        // Linux
+        try defineBool(w, "TARGET_OS_LINUX", target.os.tag == .linux);
+
+        // Unix
+        try defineBool(
+            w,
+            "TARGET_OS_UNIX",
+            switch (target.os.tag) {
+                .freebsd, .openbsd, .netbsd, .illumos => true,
+                else => false,
+            },
+        );
+
+        // Apple Targets
+        try defineBool(w, "TARGET_OS_MAC", target.os.tag.isDarwin());
+        // NOTE: LLVM checks the triple for "Triple::Darwin" as well, but this
+        // is different from "isOSDarwin()" and would be like if Zig had a
+        // ".darwin" OS tag, but it doesn't.
+        try defineBool(w, "TARGET_OS_OSX", target.os.tag == .macos);
+        try defineBool(
+            w,
+            "TARGET_OS_IPHONE",
+            switch (target.os.tag) {
+                .ios, .tvos, .watchos => true,
+                else => false,
+            },
+        );
+        try defineBool(w, "TARGET_OS_IOS", target.os.tag == .ios);
+        try defineBool(w, "TARGET_OS_TV", target.os.tag == .tvos);
+        try defineBool(w, "TARGET_OS_WATCH", target.os.tag == .watchos);
+        try defineBool(w, "TARGET_OS_VISION", target.os.tag == .visionos);
+        try defineBool(w, "TARGET_OS_DRIVERKIT", target.os.tag == .driverkit);
+        // Note that LLVM has this as an actual target environment (ABI). Zig
+        // doesn't, so just doing a best effort here and assuming that all
+        // catalyst apps will be tagged as such in the OS.
+        try defineBool(w, "TARGET_OS_MACCATALYST", target.os.tag == .maccatalyst);
+        // Note that there are no other guards for this macro in LLVM either -
+        // running under the assumption that the only things that uses the
+        // ".simulator" ABI are the appropriate Apple device simulators.
+        try defineBool(w, "TARGET_OS_SIMULATOR", target.abi == .simulator);
+        try defineBool(
+            w,
+            "TARGET_OS_EMBEDDED",
+            switch (target.os.tag) {
+                .ios, .tvos, .visionos, .watchos => true,
+                else => false,
+            } and target.abi != .simulator,
+        );
+        try defineBool(w, "TARGET_OS_NANO", target.os.tag == .watchos);
+        try defineBool(w, "TARGET_IPHONE_SIMULATOR", target.abi == .simulator);
+        try defineBool(w, "TARGET_OS_UIKITFORMAC", target.os.tag == .maccatalyst);
+
+        // UEFI
+        try defineBool(w, "TARGET_OS_UEFI", target.os.tag == .uefi);
+    }
 
     // os macros
     switch (target.os.tag) {
@@ -420,14 +487,23 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
             else
                 mem.print(&version_buf, "{d:0>2}{d:0>2}{d:0>2}", .{ version.major, @min(version.minor, 99), @min(version.patch, 99) }) catch unreachable;
 
-            try w.print("#define {s} {s}\n", .{ switch (target.os.tag) {
-                .tvos => "__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__",
-                .ios, .maccatalyst => "__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__",
-                .watchos => "__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__",
-                .driverkit => "__ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__",
-                .macos => "__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__",
-                else => unreachable,
-            }, version_str });
+            platform_os_version_define: {
+                try w.print("#define {s} {s}\n", .{
+                    switch (target.os.tag) {
+                        .tvos => "__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__",
+                        .ios, .maccatalyst => "__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__",
+                        .watchos => "__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__",
+                        .driverkit => "__ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__",
+                        .macos => "__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__",
+                        .visionos => {
+                            // No platform-specific OS version define for visionOS
+                            break :platform_os_version_define;
+                        },
+                        else => unreachable,
+                    },
+                    version_str,
+                });
+            }
 
             try w.print("#define __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__ {s}\n", .{version_str});
         },

--- a/src/aro/LangOpts.zig
+++ b/src/aro/LangOpts.zig
@@ -206,6 +206,10 @@ pub fn hasDigraphs(self: *const LangOpts) bool {
     return self.digraphs orelse self.standard.atLeast(.gnu89);
 }
 
+pub fn hasTargetOsMacros(self: *const LangOpts) bool {
+    return self.emulate == .no or self.emulate == .clang;
+}
+
 pub fn setEmulatedCompiler(self: *LangOpts, compiler: Compiler) void {
     self.emulate = compiler;
     self.setMSExtensions(compiler == .msvc);

--- a/src/aro/features.zig
+++ b/src/aro/features.zig
@@ -92,7 +92,7 @@ pub fn hasExtension(comp: *Compilation, ext_raw: []const u8) bool {
         .gnu_asm_goto_with_outputs = comp.langopts.gnu_asm,
         .matrix_types = false, // TODO
         .matrix_types_scalar_division = false, // TODO
-        .define_target_os_macros = comp.langopts.emulate == .no or comp.langopts.emulate == .clang,
+        .define_target_os_macros = comp.langopts.hasTargetOsMacros(),
     };
     inline for (@typeInfo(@TypeOf(list)).@"struct".field_names) |f_name| {
         if (std.mem.eql(u8, f_name, ext)) return @field(list, f_name);

--- a/src/aro/toolchains/Darwin.zig
+++ b/src/aro/toolchains/Darwin.zig
@@ -50,6 +50,7 @@ const Sdk = union(enum) {
             .maccatalyst => .{ .macosx = .{ .catalyst = true } },
             .macos => .{ .macosx = .{ .catalyst = false } },
             .tvos => if (target.abi == .simulator) .appletvsimulator else .appletvos,
+            .visionos => if (target.abi == .simulator) .xrsimulator else .xros,
             .watchos => if (target.abi == .simulator) .watchsimulator else .watchos,
             else => {
                 std.debug.assert(!target.os.tag.isDarwin());

--- a/test/cases/target_macros driverkit.c
+++ b/test/cases/target_macros driverkit.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 1
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 0
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 1
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 0
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target aarch64-driverkit --emulate=clang
+*/

--- a/test/cases/target_macros ios.c
+++ b/test/cases/target_macros ios.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 1
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 1
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 1
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 1
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target aarch64-ios --emulate=clang
+*/

--- a/test/cases/target_macros iphone.c
+++ b/test/cases/target_macros iphone.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 1
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 1
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 1
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 1
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target aarch64-ios --emulate=clang
+*/

--- a/test/cases/target_macros linux.c
+++ b/test/cases/target_macros linux.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 1
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 0
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 0
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 0
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target x86_64-linux --emulate=clang
+*/

--- a/test/cases/target_macros maccatalyst.c
+++ b/test/cases/target_macros maccatalyst.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 1
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 0
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 1
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 0
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 1
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target aarch64-maccatalyst --emulate=clang
+*/

--- a/test/cases/target_macros macos.c
+++ b/test/cases/target_macros macos.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 1
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 1
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 0
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 0
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target aarch64-macos --emulate=clang
+*/

--- a/test/cases/target_macros simulator.c
+++ b/test/cases/target_macros simulator.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 1
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 1
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 1
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 1
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 0
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 1
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target aarch64-ios-simulator --emulate=clang
+*/

--- a/test/cases/target_macros tvos.c
+++ b/test/cases/target_macros tvos.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 1
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 1
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 1
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 1
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target aarch64-tvos --emulate=clang
+*/

--- a/test/cases/target_macros uefi.c
+++ b/test/cases/target_macros uefi.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 0
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 0
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 0
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 1
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target x86_64-uefi --emulate=clang
+*/

--- a/test/cases/target_macros unix.c
+++ b/test/cases/target_macros unix.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 1
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 0
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 0
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 0
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target x86_64-freebsd --emulate=clang
+*/

--- a/test/cases/target_macros visionos.c
+++ b/test/cases/target_macros visionos.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 1
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 0
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 1
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 1
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target aarch64-visionos
+*/

--- a/test/cases/target_macros watchos.c
+++ b/test/cases/target_macros watchos.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 0
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 0
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 1
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 1
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 1
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 1
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 1
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target aarch64-watchos --emulate=clang
+*/

--- a/test/cases/target_macros windows.c
+++ b/test/cases/target_macros windows.c
@@ -1,0 +1,80 @@
+#if TARGET_OS_WIN32 != 1
+#error TARGET_OS_WIN32 is not the expected value
+#endif
+
+#if TARGET_OS_WINDOWS != 1
+#error TARGET_OS_WINDOWS is not the expected value
+#endif
+
+#if TARGET_OS_LINUX != 0
+#error TARGET_OS_LINUX is not the expected value
+#endif
+
+#if TARGET_OS_UNIX != 0
+#error TARGET_OS_UNIX is not the expected value
+#endif
+
+#if TARGET_OS_MAC != 0
+#error TARGET_OS_MAC is not the expected value
+#endif
+
+#if TARGET_OS_OSX != 0
+#error TARGET_OS_OSX is not the expected value
+#endif
+
+#if TARGET_OS_IPHONE != 0
+#error TARGET_OS_IPHONE is not the expected value
+#endif
+
+#if TARGET_OS_IOS != 0
+#error TARGET_OS_IOS is not the expected value
+#endif
+
+#if TARGET_OS_TV != 0
+#error TARGET_OS_TV is not the expected value
+#endif
+
+#if TARGET_OS_WATCH != 0
+#error TARGET_OS_WATCH is not the expected value
+#endif
+
+#if TARGET_OS_VISION != 0
+#error TARGET_OS_VISION is not the expected value
+#endif
+
+#if TARGET_OS_DRIVERKIT != 0
+#error TARGET_OS_DRIVERKIT is not the expected value
+#endif
+
+#if TARGET_OS_MACCATALYST != 0
+#error TARGET_OS_MACCATALYST is not the expected value
+#endif
+
+#if TARGET_OS_SIMULATOR != 0
+#error TARGET_OS_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_EMBEDDED != 0
+#error TARGET_OS_EMBEDDED is not the expected value
+#endif
+
+#if TARGET_OS_NANO != 0
+#error TARGET_OS_NANO is not the expected value
+#endif
+
+#if TARGET_IPHONE_SIMULATOR != 0
+#error TARGET_IPHONE_SIMULATOR is not the expected value
+#endif
+
+#if TARGET_OS_UIKITFORMAC != 0
+#error TARGET_OS_UIKITFORMAC is not the expected value
+#endif
+
+#if TARGET_OS_UEFI != 0
+#error TARGET_OS_UEFI is not the expected value
+#endif
+
+/** manifest:
+syntax
+args = -target x86_64-windows --emulate=clang
+*/


### PR DESCRIPTION
This commit adds the target OS macros as they currently exist in LLVM 22.

The logic around adding them is designed to mirror how `TargetOSMacros.def` defines them, e.g., checking the triple for each macro versus say handling it in a switch per OS/abi/etc.

This also 1) adds a helper to make defining boolean values for system defines, and 2) adds a few extra bits to ensure that targeting visionOS does not cause crashes due to unreachable code.