### PR TITLE
Compilation: define __BLOCKS__ when blocks are enabled

### DIFF
--- a/src/aro/Compilation.zig
+++ b/src/aro/Compilation.zig
@@ -1334,6 +1334,11 @@ fn generateSystemDefines(comp: *Compilation, w: *Io.Writer) !void {
             }
         },
     }
+
+    // Blocks
+    if (comp.langopts.blocks) {
+        try define(w, "__BLOCKS__");
+    }
 }
 
 const RiscvFloatAbi = enum { soft, single, double };

--- a/test/cases/block types.c
+++ b/test/cases/block types.c
@@ -60,6 +60,11 @@ typedef int (^_Nullable NullableBlock)(void);
 
 int *^*mixed;
 
+// Block predefines
+#if !defined(__BLOCKS__)
+#error "expected __BLOCKS__ to be defined"
+#endif
+
 /** manifest:
 syntax
 args = -fblocks -Wpedantic -Wno-gnu-auto-type --target=aarch64-macos


### PR DESCRIPTION
This is a re-submission of #1074.

@Vexu can this be merged ahead of #971? Just to make sure we don't get regressions over in Ghostty when backporting (and working on future fixes on master as well).