### PR TITLE
Preprocessor: reject invalid extended identifier as macro name

### DIFF
--- a/src/aro/Preprocessor.zig
+++ b/src/aro/Preprocessor.zig
@@ -6,6 +6,7 @@ const assert = std.debug.assert;
 
 const Attribute = @import("Attribute.zig");
 const Builtins = @import("Builtins.zig");
+const char_info = @import("char_info.zig");
 const Compilation = @import("Compilation.zig");
 const Error = Compilation.Error;
 const Diagnostics = @import("Diagnostics.zig");
@@ -2902,6 +2903,21 @@ fn defineMacro(pp: *Preprocessor, define_tok: RawToken, name_tok: TokenWithExpan
     gop.value_ptr.* = macro;
 }
 
+/// Return true if an extended-identifier macro name consists only of codepoints
+/// allowed in an identifier for the active language standard.
+fn validExtendedMacroName(pp: *Preprocessor, tok: RawToken) bool {
+    const slice = pp.comp.getSource(tok.source).buf[tok.start..tok.end];
+    const view = std.unicode.Utf8View.init(slice) catch return false;
+    var it = view.iterator();
+    const standard = pp.comp.langopts.standard;
+    var first = true;
+    while (it.nextCodepoint()) |codepoint| : (first = false) {
+        if (codepoint <= 0x7F) continue;
+        if (!standard.codepointAllowedInIdentifier(codepoint, first)) return false;
+    }
+    return true;
+}
+
 /// Handle a #define directive.
 fn define(pp: *Preprocessor, tokenizer: *Tokenizer, define_tok: RawToken) Error!void {
     // Get macro name and validate it.
@@ -2911,6 +2927,10 @@ fn define(pp: *Preprocessor, tokenizer: *Tokenizer, define_tok: RawToken) Error!
         return skipToNl(tokenizer);
     }
     if (!escaped_macro_name.id.isMacroIdentifier()) {
+        try pp.err(escaped_macro_name, .macro_name_must_be_identifier, .{});
+        return skipToNl(tokenizer);
+    }
+    if (escaped_macro_name.id == .extended_identifier and !pp.validExtendedMacroName(escaped_macro_name)) {
         try pp.err(escaped_macro_name, .macro_name_must_be_identifier, .{});
         return skipToNl(tokenizer);
     }

--- a/test/cases/macro name must be an identifier.c
+++ b/test/cases/macro name must be an identifier.c
@@ -1,0 +1,8 @@
+#define ™ 42
+
+/** manifest:
+expand_error
+args = -std=c23
+
+macro name must be an identifier.c:1:9: error: macro name must be an identifier
+*/


### PR DESCRIPTION
## What

Closes #593. `#define ™ 42` (macro name `U+2122 TRADE MARK SIGN`) was silently accepted, even though `™` is not a valid identifier character and the parser correctly rejects it in a declaration (`int ™;` → `error: unexpected character <U+2122>`).

## Fix

`define()` already rejects a macro name whose token isn't a macro identifier, but any byte in `0x80..0xFF` tokenizes as `.extended_identifier`, which passes that check without the codepoints ever being validated. Added a check that walks the extended-identifier name and confirms every codepoint is allowed in an identifier for the active language standard (reusing `Standard.codepointAllowedInIdentifier`, the same predicate the parser uses). On failure it emits the existing `macro_name_must_be_identifier` diagnostic, matching the message requested in the issue.

This is standard-dependent and now matches the declaration path exactly: valid extended identifiers (e.g. Greek `α`) are still accepted; `™` is rejected wherever `int ™;` would be rejected.

```
$ arocc -std=c23 -fsyntax-only tm.c
tm.c:1:9: error: macro name must be an identifier
#define ™ 42
        ^
```

## Tests

- Added `test/cases/macro name must be an identifier.c`.
- `zig build test` → `478 passed; 33 skipped` and `9007 passed; 2 skipped`.
- `zig build test-fmt` clean.
- Verified genuine RED→GREEN: reverting the new check makes the added case fail (`477 passed; 1 failed`), restoring it passes.
- Confirmed valid extended-identifier macro names (`#define α 42`) still work, and that the `#define` result now matches the declaration path across `-std=c99/c11/c17/c23`.

Happy to adjust.
